### PR TITLE
Changes to docker files for zap logging

### DIFF
--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:latest
 ADD k8s_yunikorn_scheduler /k8s_yunikorn_scheduler
 ENTRYPOINT ["/k8s_yunikorn_scheduler"]
-CMD ["-logtostderr=true", "-v=5", "-clusterid=mycluster", "-clusterversion=0.1"]
+CMD ["-logEncoding=console", "-logLevel=-1", "-clusterId=mycluster", "-clusterVersion=0.1"]

--- a/deployments/image/file/Dockerfile
+++ b/deployments/image/file/Dockerfile
@@ -2,4 +2,4 @@ FROM scratch
 ADD k8s_yunikorn_scheduler /k8s_yunikorn_scheduler
 ADD queues.yaml /queues.yaml
 ENTRYPOINT ["/k8s_yunikorn_scheduler"]
-CMD ["-logtostderr=true", "-v=5"]
+CMD ["-logEncoding=console", "-logLevel=-1"]


### PR DESCRIPTION
The logging options in the docker files have not been updated to reflect the changes introduced by zap logging use. Fix the CMD line in the docker files