### PR TITLE
[YUNIKORN-802] Supports to assign nodes to non-default partition

### DIFF
--- a/pkg/cache/node_test.go
+++ b/pkg/cache/node_test.go
@@ -19,6 +19,7 @@
 package cache
 
 import (
+	"reflect"
 	"testing"
 
 	"gotest.tools/assert"
@@ -62,11 +63,30 @@ func TestSetOccupiedResource(t *testing.T) {
 }
 
 func NewTestSchedulerNode() *SchedulerNode {
+	return NewTestSchedulerNodeWithLabels(nil)
+}
+
+func NewTestSchedulerNodeWithLabels(label map[string]string) *SchedulerNode {
 	api := test.NewSchedulerAPIMock()
 	r1 := common.NewResourceBuilder().
 		AddResource(constants.Memory, 1).
 		AddResource(constants.CPU, 1).
 		Build()
-	node := newSchedulerNode("host001", "UID001", r1, api, false)
+	node := newSchedulerNode("host001", "UID001", r1, api, false, label)
 	return node
+}
+
+func TestAttributes(t *testing.T) {
+	labels := map[string]string{
+		"a": "b",
+		"k": "v",
+	}
+	node := NewTestSchedulerNodeWithLabels(labels)
+
+	assert.Assert(t, reflect.DeepEqual(labels, node.labels))
+
+	attributes := node.toAttributes()
+	for k, v := range labels {
+		assert.Equal(t, v, attributes[k])
+	}
 }

--- a/pkg/cache/nodes_test.go
+++ b/pkg/cache/nodes_test.go
@@ -116,6 +116,9 @@ func TestUpdateNode(t *testing.T) {
 			Name:      "host0001",
 			Namespace: "default",
 			UID:       "uid_0001",
+			Labels: map[string]string{
+				"si/node-partition": "default",
+			},
 		},
 		Status: v1.NodeStatus{
 			Allocatable: resourceList,
@@ -127,6 +130,9 @@ func TestUpdateNode(t *testing.T) {
 			Name:      "host0001",
 			Namespace: "default",
 			UID:       "uid_0001",
+			Labels: map[string]string{
+				"si/node-partition": "default",
+			},
 		},
 		Status: v1.NodeStatus{
 			Allocatable: resourceList,
@@ -191,6 +197,9 @@ func TestUpdateNode(t *testing.T) {
 			Name:      "host0001",
 			Namespace: "default",
 			UID:       "uid_0001",
+			Labels: map[string]string{
+				"si/node-partition": "default",
+			},
 		},
 		Status: v1.NodeStatus{
 			Allocatable: newResourceList,
@@ -220,6 +229,25 @@ func TestUpdateNode(t *testing.T) {
 
 	api.UpdateFunction(checkFn)
 
+	nodes.updateNode(&oldNode, &newNode)
+	assert.Equal(t, api.GetRegisterCount(), int32(0))
+	assert.Equal(t, api.GetUpdateCount(), int32(1))
+
+	// change both resources and partition.
+	// the request should be skipped as changing partition is not supported
+	newNode = v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      "host0001",
+			Namespace: "default",
+			UID:       "uid_0001",
+			Labels: map[string]string{
+				"si/node-partition": "default2",
+			},
+		},
+		Status: v1.NodeStatus{
+			Allocatable: resourceList,
+		},
+	}
 	nodes.updateNode(&oldNode, &newNode)
 	assert.Equal(t, api.GetRegisterCount(), int32(0))
 	assert.Equal(t, api.GetUpdateCount(), int32(1))

--- a/pkg/common/node.go
+++ b/pkg/common/node.go
@@ -30,10 +30,15 @@ type Node struct {
 	uid      string
 	capacity *si.Resource
 	occupied *si.Resource
+	labels   map[string]string
 }
 
-func NewNode(name, uid string, capacity *si.Resource, occupied *si.Resource) Node {
-	return Node{name, uid, capacity, occupied}
+func NewNode(name, uid string, capacity *si.Resource, occupied *si.Resource, labels map[string]string) Node {
+	copyLabels := make(map[string]string, len(labels))
+	for k, v := range labels {
+		copyLabels[k] = v
+	}
+	return Node{name, uid, capacity, occupied, copyLabels}
 }
 
 func CreateFrom(node *v1.Node) Node {
@@ -41,6 +46,7 @@ func CreateFrom(node *v1.Node) Node {
 		name:     node.Name,
 		uid:      string(node.UID),
 		capacity: GetNodeResource(&node.Status),
+		labels:   make(map[string]string),
 	}
 }
 
@@ -49,5 +55,6 @@ func CreateFromNodeSpec(nodeName string, nodeUID string, nodeResource *si.Resour
 		name:     nodeName,
 		uid:      nodeUID,
 		capacity: nodeResource,
+		labels:   make(map[string]string),
 	}
 }

--- a/pkg/common/node_test.go
+++ b/pkg/common/node_test.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"reflect"
 	"testing"
 
 	"gotest.tools/assert"
@@ -88,4 +89,14 @@ func TestCreateNodeWithCustomResource(t *testing.T) {
 	assert.Equal(t, node.capacity.Resources[constants.Memory].Value, int64(999))
 	assert.Equal(t, node.capacity.Resources[constants.CPU].Value, int64(9000))
 	assert.Equal(t, node.capacity.Resources["nvidia.com/gpu"].Value, int64(3))
+}
+
+func TestLabelsOfNewNode(t *testing.T) {
+	labels := map[string]string{
+		"a": "b",
+		"k": "v",
+	}
+
+	node := NewNode("name", "id", nil, nil, labels)
+	assert.Assert(t, reflect.DeepEqual(labels, node.labels))
 }

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -128,11 +128,7 @@ func CreateUpdateRequestForNewNode(node Node) si.UpdateRequest {
 	nodeInfo := &si.NewNodeInfo{
 		NodeID:              node.name,
 		SchedulableResource: node.capacity,
-		// TODO is this required?
-		Attributes: map[string]string{
-			constants.DefaultNodeAttributeHostNameKey: node.name,
-			constants.DefaultNodeAttributeRackNameKey: constants.DefaultRackName,
-		},
+		Attributes:          node.labels,
 	}
 
 	nodes := make([]*si.NewNodeInfo, 1)
@@ -148,7 +144,7 @@ func CreateUpdateRequestForUpdatedNode(node Node) si.UpdateRequest {
 	// Currently only includes resource in the update request
 	nodeInfo := &si.UpdateNodeInfo{
 		NodeID:              node.name,
-		Attributes:          make(map[string]string),
+		Attributes:          node.labels,
 		SchedulableResource: node.capacity,
 		OccupiedResource:    node.occupied,
 		Action:              si.UpdateNodeInfo_UPDATE,
@@ -169,7 +165,7 @@ func CreateUpdateRequestForDeleteNode(node Node) si.UpdateRequest {
 		NodeID:              node.name,
 		SchedulableResource: node.capacity,
 		OccupiedResource:    node.occupied,
-		Attributes:          make(map[string]string),
+		Attributes:          node.labels,
 		Action:              si.UpdateNodeInfo_DECOMISSION,
 	}
 


### PR DESCRIPTION
### What is this PR for?
see comment (https://issues.apache.org/jira/browse/YUNIKORN-22?focusedCommentId=17398860&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17398860)

Currently, all nodes are hardcode to be assigned to "default" partition. That brings two disadvantages.
1. we can't select specify nodes, which are used to execute spark job only, from a cluster
1. multi-partitions does not work since non-default partition can't get nodes

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
1. support to change partition assignment of existent node (in this PR, the update request will be skipped)
1. support to remove existent node which had been reassigned (in this PR, removing such node cause error message "Failed to update non existing node ...")

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-802

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
