### PR TITLE
[YUNIKORN-881] Fix e2e tests after K8S 1.20 upgrade.

### DIFF
--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -42,7 +42,7 @@ function kubectl_installation() {
 # Install Kind
 function kind_installation() {
     os_type=$1
-    curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.10.0/kind-${os_type}-amd64" \
+    curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.11.1/kind-${os_type}-amd64" \
                 && chmod +x ./kind && mv ./kind $(go env GOPATH)/bin
     exit_on_error "install KIND failed"
     check_cmd "kind"
@@ -216,7 +216,9 @@ Usage: $(basename "$0") -a <action> -n <kind-cluster-name> -v <kind-node-image-v
   <kind-node-image-version>    the kind node image used to provision the K8s cluster.
 
 Examples:
-  $(basename "$0") -n "yk8s" -v "kindest/node:v1.15.11"
+  $(basename "$0") -a test -n "yk8s" -v "kindest/node:v1.19.11"
+  $(basename "$0") -a test -n "yk8s" -v "kindest/node:v1.20.7"
+  $(basename "$0") -a test -n "yk8s" -v "kindest/node:v1.21.2"
 EOF
 }
 


### PR DESCRIPTION
### What is this PR for?
After the upgrade to kubernetes 1.20, some e2e tests no longer function. These tests have been updated to pass, and verified on multiple kubernetes versions.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-881

### How should this be tested?
Full e2e test runs have been completed successfully on local Kind clusters on 1.18.19, 1.19.11, 1.20.7, and 1.21.1.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
