### PR TITLE
[YUNIKORN-887] Automate generation of k8shim FSM state transition diagrams.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,13 @@ test: clean
 	go test ./pkg/... -cover -race -tags deadlock -coverprofile=coverage.txt -covermode=atomic
 	go vet $(REPO)...
 
+# Generate FSM graphs (dot/png)
+.PHONY: fsm_graph
+fsm_graph: clean
+	@echo "generating FSM graphs"
+	go test -tags graphviz -run 'Test.*FsmGraph' ./pkg/shim ./pkg/cache
+	scripts/generate-fsm-graph-images.sh
+
 # Simple clean of generated files only (no local cleanup).
 .PHONY: clean
 clean:

--- a/pkg/cache/application_graphviz_test.go
+++ b/pkg/cache/application_graphviz_test.go
@@ -1,0 +1,40 @@
+// +build graphviz
+
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/looplab/fsm"
+	"gotest.tools/assert"
+)
+
+func TestApplicationFsmGraph(t *testing.T) {
+	app := NewApplication("app00001", "root.queue", "testuser", map[string]string{}, newMockSchedulerAPI())
+	graph := fsm.Visualize(app.sm)
+
+	err := os.MkdirAll("../../_output/fsm", 0755)
+	assert.NilError(t, err, "Creating output dir failed")
+	ioutil.WriteFile("../../_output/fsm/k8shim-application-state.dot", []byte(graph), 0644)
+	assert.NilError(t, err, "Writing graph failed")
+}

--- a/pkg/cache/node_graphviz_test.go
+++ b/pkg/cache/node_graphviz_test.go
@@ -1,0 +1,49 @@
+// +build graphviz
+
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/looplab/fsm"
+	"gotest.tools/assert"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/test"
+)
+
+func TestNodeFsmGraph(t *testing.T) {
+	api := test.NewSchedulerAPIMock()
+	r1 := common.NewResourceBuilder().
+		AddResource(constants.Memory, 1).
+		AddResource(constants.CPU, 1).
+		Build()
+	node := newSchedulerNode("host001", "UID001", "{}", r1, api, false)
+	graph := fsm.Visualize(node.fsm)
+
+	err := os.MkdirAll("../../_output/fsm", 0755)
+	assert.NilError(t, err, "Creating output dir failed")
+	ioutil.WriteFile("../../_output/fsm/k8shim-node-state.dot", []byte(graph), 0644)
+	assert.NilError(t, err, "Writing graph failed")
+}

--- a/pkg/cache/task_graphviz_test.go
+++ b/pkg/cache/task_graphviz_test.go
@@ -1,0 +1,59 @@
+// +build graphviz
+
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/looplab/fsm"
+	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
+	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTaskFsmGraph(t *testing.T) {
+	mockedContext := initContextForTest()
+	mockedSchedulerAPI := newMockSchedulerAPI()
+	app := NewApplication("app01", "root.default",
+		"bob", map[string]string{}, mockedSchedulerAPI)
+
+	// pod has timestamp defined
+	pod := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name: "pod-00",
+			UID:  "UID-00",
+		},
+	}
+
+	task := NewTask("task00", app, mockedContext, pod)
+	graph := fsm.Visualize(task.sm)
+
+	err := os.MkdirAll("../../_output/fsm", 0755)
+	assert.NilError(t, err, "Creating output dir failed")
+	ioutil.WriteFile("../../_output/fsm/k8shim-task-state.dot", []byte(graph), 0644)
+	assert.NilError(t, err, "Writing graph failed")
+}

--- a/pkg/shim/scheduler_graphviz_test.go
+++ b/pkg/shim/scheduler_graphviz_test.go
@@ -1,0 +1,62 @@
+// +build graphviz
+
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/looplab/fsm"
+	"gotest.tools/assert"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/cache"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/test"
+	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/api"
+	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
+)
+
+func TestSchedulerFsmGraph(t *testing.T) {
+	var callback api.ResourceManagerCallback
+
+	mockedAMProtocol := cache.NewMockedAMProtocol()
+	mockedAPIProvider := client.NewMockedAPIProvider()
+	mockedAPIProvider.GetAPIs().SchedulerAPI = test.NewSchedulerAPIMock().RegisterFunction(
+		func(request *si.RegisterResourceManagerRequest,
+			callback api.ResourceManagerCallback) (response *si.RegisterResourceManagerResponse, e error) {
+			return nil, fmt.Errorf("some error")
+		})
+
+	ctx := cache.NewContext(mockedAPIProvider)
+	shim := newShimSchedulerInternal(ctx, mockedAPIProvider,
+		appmgmt.NewAMService(mockedAMProtocol, mockedAPIProvider), callback)
+
+	graph := fsm.Visualize(shim.stateMachine)
+
+	err := os.MkdirAll("../../_output/fsm", 0755)
+	assert.NilError(t, err, "Creating output dir failed")
+	ioutil.WriteFile("../../_output/fsm/k8shim-scheduler-state.dot", []byte(graph), 0644)
+	assert.NilError(t, err, "Writing graph failed")
+}
+

--- a/scripts/generate-fsm-graph-images.sh
+++ b/scripts/generate-fsm-graph-images.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+WORKDIR=$(pwd)/_output/fsm
+
+output_fsm() {
+  # print digraph header
+   head -n +1 "$1.dot"
+  # add options
+  echo "concentrate=true"
+  # print rest of file, eliminating transitions from same state to same state
+  # and cleaning up some verbose labels
+  tail -n +2 "$1.dot" | \
+	grep -E -v '"(\w+)" -> "\1"' | \
+	grep -v AppAllocationAsk | \
+	sed 's/Application/ App/g'
+}
+
+cd "${WORKDIR}"
+
+for dot in *.dot; do
+  base=$(echo "${dot}" | sed 's_\.dot$__')
+  
+  output_fsm "${base}" | dot -Tpng > "${base}.png"
+done
+


### PR DESCRIPTION
### What is this PR for?
Automate generation of .dot/.png files for the core scheduler application state.

New Makefile target `fsm_graph` will generate FSM graphs for the application, task, node, and scheduler states, and output to `_output/fsm` both the original `.dot` files as well as `.png` images. These may be directly used for website documentation.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-887

### How should this be tested?
Test succeeds.

### Screenshots (if appropriate)
![k8shim-application-state](https://user-images.githubusercontent.com/12699633/138322563-0bb3a756-3eb9-4250-ab48-9e2c4f55003a.png)

![k8shim-task-state](https://user-images.githubusercontent.com/12699633/138322578-47fda42c-9747-4d88-98ad-9692ceaf78f4.png)

![k8shim-node-state](https://user-images.githubusercontent.com/12699633/138322585-a6fb51b2-8fbc-4ebf-af35-f475398d228f.png)

![k8shim-scheduler-state](https://user-images.githubusercontent.com/12699633/138322591-5bdef33f-ef9c-4a3a-8e9d-b179282a8f4d.png)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
