### PR TITLE
[YUNIKORN-75] REST API for changing log level

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -31,6 +31,7 @@ import (
 
 var once sync.Once
 var logger *zap.Logger
+var zapConfigs *zap.Config
 
 func Logger() *zap.Logger {
 	once.Do(initLogger)
@@ -45,7 +46,7 @@ func initLogger() {
 		outputPaths = append(outputPaths, configs.LogFile)
 	}
 
-	zapConfigs := zap.Config{
+	zapConfigs = &zap.Config{
 		Level:             zap.NewAtomicLevelAt(zapcore.Level(configs.LoggingLevel)),
 		Development:       false,
 		DisableCaller:     false,
@@ -79,11 +80,6 @@ func initLogger() {
 		logger = zap.NewNop()
 	}
 
-	// set as global logging
-	// when k8s-shim runs with core, core side can directly reuse this logger,
-	// this way we are making consistent logging configs in shim and core.
-	zap.ReplaceGlobals(logger)
-
 	// dump configuration
 	var c []byte
 	c, err = json.MarshalIndent(&configs, "", " ")
@@ -96,4 +92,8 @@ func initLogger() {
 	// make sure logs are flushed
 	//nolint:errcheck
 	defer logger.Sync()
+}
+
+func GetZapConfigs() *zap.Config {
+	return zapConfigs
 }

--- a/pkg/shim/main.go
+++ b/pkg/shim/main.go
@@ -42,7 +42,7 @@ func main() {
 	log.Logger().Info("starting scheduler",
 		zap.String("name", constants.SchedulerName))
 
-	serviceContext := entrypoint.StartAllServices()
+	serviceContext := entrypoint.StartAllServicesWithLogger(log.Logger(), log.GetZapConfigs())
 
 	if sa, ok := serviceContext.RMProxy.(api.SchedulerAPI); ok {
 		ss := newShimScheduler(sa, conf.GetSchedulerConf())


### PR DESCRIPTION
### What is this PR for?
Calling the core entrypoint with a new function `StartAllServicesWithLogger()`, passing both the zap logger and configuration instance.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-75

### How should this be tested?
Use the new REST endpoints /ws/v1/loglevel/<newlevel> (PUT) for changing the log level and /ws/v1/loglevel/ (GET) for retrieving it.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
