### PR TITLE
[YUNIKORN-909] Updated k8s version tests to drop 1.18 and add 1.21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [v1.20.7, v1.19.11, v1.18.19]
+        k8s: [v1.21.2, v1.20.7, v1.19.11]
     steps:
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
### What is this PR for?
Start running tests on k8s 1.21. Dropping tests on 1.18 since it has been EOL'ed

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-909

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
