### PR TITLE
[YUNIKORN-1159] Ensure node occupied resources are updated on added pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,3 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.11
 	vbom.ml/util => github.com/fvbommel/util v0.0.0-20160121211510-db5cfe13f5cc
 )
-
-replace github.com/apache/yunikorn-core => ../yunikorn-core
-
-replace github.com/apache/yunikorn-scheduler-interface => ../yunikorn-scheduler-interface

--- a/go.mod
+++ b/go.mod
@@ -71,3 +71,7 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.11
 	vbom.ml/util => github.com/fvbommel/util v0.0.0-20160121211510-db5cfe13f5cc
 )
+
+replace github.com/apache/yunikorn-core => ../yunikorn-core
+
+replace github.com/apache/yunikorn-scheduler-interface => ../yunikorn-scheduler-interface

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -108,6 +108,7 @@ func (ctx *Context) AddSchedulingEventHandlers() {
 	ctx.apiProvider.AddEventHandler(&client.ResourceEventHandlers{
 		Type:     client.PodInformerHandlers,
 		FilterFn: nodeCoordinator.filterPods,
+		AddFn:    nodeCoordinator.addPod,
 		UpdateFn: nodeCoordinator.updatePod,
 		DeleteFn: nodeCoordinator.deletePod,
 	})

--- a/pkg/cache/node_coordinator.go
+++ b/pkg/cache/node_coordinator.go
@@ -57,6 +57,26 @@ func (c *nodeResourceCoordinator) filterPods(obj interface{}) bool {
 	}
 }
 
+func (c *nodeResourceCoordinator) addPod(new interface{}) {
+	newPod, err := utils.Convert2Pod(new)
+	if err != nil {
+		log.Logger().Error("expecting a pod object", zap.Error(err))
+		return
+	}
+
+	if utils.IsAssignedPod(newPod) && !utils.IsPodTerminated(newPod) {
+		log.Logger().Debug("pod is assigned to a node, trigger occupied resource update",
+			zap.String("namespace", newPod.Namespace),
+			zap.String("podName", newPod.Name),
+			zap.String("podStatusCurrent", string(newPod.Status.Phase)))
+		// if pod is running but not scheduled by us,
+		// we need to notify scheduler-core to re-sync the node resource
+		podResource := common.GetPodResource(newPod)
+		c.nodes.updateNodeOccupiedResources(newPod.Spec.NodeName, podResource, AddOccupiedResource)
+		c.nodes.cache.AddPod(newPod)
+	}
+}
+
 func (c *nodeResourceCoordinator) updatePod(old, new interface{}) {
 	oldPod, err := utils.Convert2Pod(old)
 	if err != nil {

--- a/pkg/cache/node_coordinator_test.go
+++ b/pkg/cache/node_coordinator_test.go
@@ -35,6 +35,48 @@ const (
 	HostEmpty = ""
 )
 
+func TestAddPod(t *testing.T) {
+	mockedSchedulerAPI := newMockSchedulerAPI()
+	nodes := newSchedulerNodes(mockedSchedulerAPI, NewTestSchedulerCache())
+	host1 := utils.NodeForTest(Host1, "10G", "10")
+	host2 := utils.NodeForTest(Host2, "10G", "10")
+	nodes.addNode(host1)
+	nodes.addNode(host2)
+	coordinator := newNodeResourceCoordinator(nodes)
+
+	// pod is not assigned to any node
+	// this won't trigger an update
+	pod := utils.PodForTest("pod1", "1G", "500m")
+	pod.Status.Phase = v1.PodPending
+	pod.Status.Phase = v1.PodPending
+	pod.Spec.NodeName = ""
+	mockedSchedulerAPI.UpdateNodeFn = func(request *si.NodeRequest) error {
+		t.Fatalf("update should not run because state is not changed")
+		return nil
+	}
+	coordinator.addPod(pod)
+
+	// pod is already assigned to a node and state is running
+	// this will trigger an update
+	pod.Status.Phase = v1.PodRunning
+	pod.Spec.NodeName = Host1
+	executed := false
+	mockedSchedulerAPI.UpdateNodeFn = func(request *si.NodeRequest) error {
+		executed = true
+		assert.Equal(t, len(request.Nodes), 1)
+		updatedNode := request.Nodes[0]
+		assert.Equal(t, updatedNode.NodeID, Host1)
+		assert.Equal(t, updatedNode.Action, si.NodeInfo_UPDATE)
+		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000*1000*1000))
+		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.CPU].Value, int64(10000))
+		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000*1000*1000))
+		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.CPU].Value, int64(500))
+		return nil
+	}
+	coordinator.addPod(pod)
+	assert.Assert(t, executed)
+}
+
 func TestUpdatePod(t *testing.T) {
 	mockedSchedulerApi := newMockSchedulerAPI()
 	nodes := newSchedulerNodes(mockedSchedulerApi, NewTestSchedulerCache())

--- a/pkg/cache/node_coordinator_test.go
+++ b/pkg/cache/node_coordinator_test.go
@@ -39,9 +39,7 @@ func TestAddPod(t *testing.T) {
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	nodes := newSchedulerNodes(mockedSchedulerAPI, NewTestSchedulerCache())
 	host1 := utils.NodeForTest(Host1, "10G", "10")
-	host2 := utils.NodeForTest(Host2, "10G", "10")
 	nodes.addNode(host1)
-	nodes.addNode(host2)
 	coordinator := newNodeResourceCoordinator(nodes)
 
 	// pod is not assigned to any node

--- a/pkg/cache/node_coordinator_test.go
+++ b/pkg/cache/node_coordinator_test.go
@@ -48,7 +48,6 @@ func TestAddPod(t *testing.T) {
 	// this won't trigger an update
 	pod := utils.PodForTest("pod1", "1G", "500m")
 	pod.Status.Phase = v1.PodPending
-	pod.Status.Phase = v1.PodPending
 	pod.Spec.NodeName = ""
 	mockedSchedulerAPI.UpdateNodeFn = func(request *si.NodeRequest) error {
 		t.Fatalf("update should not run because state is not changed")


### PR DESCRIPTION
### What is this PR for?
Fixes an issue where non-yunikorn scheduled pods do not cause a node's occupied resources to update properly.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1159

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
