### PR TITLE
[YUNIKORN-1165] Ensure StartPodAllocation() only matches selected node

### DIFF
--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -1130,3 +1130,103 @@ func TestSaveConfigmap(t *testing.T) {
 	assert.Equal(t, false, resp.Success, "Failure is expected")
 	assert.Assert(t, strings.Contains(resp.Reason, "hot-refresh is enabled"), "Unexpected reason")
 }
+
+func TestPendingPodAllocations(t *testing.T) {
+	context := initContextForTest()
+	context.SetPluginMode(true)
+
+	node1 := v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      "host0001",
+			Namespace: "default",
+			UID:       "uid_0001",
+		},
+	}
+	context.addNode(&node1)
+
+	node2 := v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      "host0002",
+			Namespace: "default",
+			UID:       "uid_0002",
+		},
+	}
+	context.addNode(&node2)
+
+	// add a new application
+	context.AddApplication(&interfaces.AddApplicationRequest{
+		Metadata: interfaces.ApplicationMetadata{
+			ApplicationID: "app00001",
+			QueueName:     "root.a",
+			User:          "test-user",
+			Tags:          nil,
+		},
+	})
+
+	pod := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name: "test-00001",
+			UID:  "UID-00001",
+		},
+	}
+
+	// add a tasks to the existing application
+	task := context.AddTask(&interfaces.AddTaskRequest{
+		Metadata: interfaces.TaskMetadata{
+			ApplicationID: "app00001",
+			TaskID:        "task00001",
+			Pod:           pod,
+		},
+	})
+	assert.Assert(t, task != nil, "task was nil")
+
+	// add the allocation
+	context.AddPendingPodAllocation("UID-00001", "host0001")
+
+	// validate that the pending allocation matches
+	nodeID, ok := context.GetPendingPodAllocation("UID-00001")
+	if !ok {
+		t.Fatalf("no pending pod allocation found")
+	}
+	assert.Equal(t, nodeID, "host0001", "wrong host")
+
+	// validate that there is not an in-progress allocation
+	if _, ok = context.GetInProgressPodAllocation("UID-00001"); ok {
+		t.Fatalf("in-progress allocation exists when it should be pending")
+	}
+
+	if context.StartPodAllocation("UID-00001", "host0002") {
+		t.Fatalf("attempt to start pod allocation on wrong node succeeded")
+	}
+
+	if !context.StartPodAllocation("UID-00001", "host0001") {
+		t.Fatalf("attempt to start pod allocation on correct node failed")
+	}
+
+	if _, ok = context.GetPendingPodAllocation("UID-00001"); ok {
+		t.Fatalf("pending pod allocation still exists after transition to in-progress")
+	}
+
+	nodeID, ok = context.GetInProgressPodAllocation("UID-00001")
+	if !ok {
+		t.Fatalf("in-progress allocation does not exist")
+	}
+	assert.Equal(t, nodeID, "host0001", "wrong host")
+
+	context.RemovePodAllocation("UID-00001")
+	if _, ok = context.GetInProgressPodAllocation("UID-00001"); ok {
+		t.Fatalf("in-progress pod allocation still exists after removal")
+	}
+
+	// re-add to validate pending pod removal
+	context.AddPendingPodAllocation("UID-00001", "host0001")
+	context.RemovePodAllocation("UID-00001")
+
+	if _, ok = context.GetPendingPodAllocation("UID-00001"); ok {
+		t.Fatalf("pending pod allocation still exists after removal")
+	}
+}

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -209,8 +209,9 @@ func (cache *SchedulerCache) StartPodAllocation(podKey string, nodeID string) bo
 	if ok && expectedNodeID == nodeID {
 		delete(cache.pendingAllocations, podKey)
 		cache.inProgressAllocations[podKey] = nodeID
+		return true
 	}
-	return ok
+	return false
 }
 
 // return if pod is assumed in cache, avoid nil


### PR DESCRIPTION
### What is this PR for?
Fixes an issue with plugin mode where multiple nodes are returned to the scheduler as matches for a pod.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1165

### How should this be tested?
Unit tests added to cover this case.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
