### PR TITLE
[YUNIKORN-1161] Pods not linked to placeholders are stuck in Running state if YK is restarted

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -51,6 +51,7 @@ type Application struct {
 	tags                       map[string]string
 	schedulingPolicy           v1alpha1.SchedulingPolicy
 	taskGroups                 []v1alpha1.TaskGroup
+	taskGroupsDefinition       string
 	placeholderOwnerReferences []metav1.OwnerReference
 	sm                         *fsm.FSM
 	lock                       *sync.RWMutex
@@ -230,6 +231,18 @@ func (app *Application) getSchedulingPolicy() v1alpha1.SchedulingPolicy {
 	app.lock.RLock()
 	defer app.lock.RUnlock()
 	return app.schedulingPolicy
+}
+
+func (app *Application) setTaskGroupsDefinition(taskGroupsDef string) {
+	app.lock.Lock()
+	defer app.lock.Unlock()
+	app.taskGroupsDefinition = taskGroupsDef
+}
+
+func (app *Application) GetTaskGroupsDefinition() string {
+	app.lock.RLock()
+	defer app.lock.RUnlock()
+	return app.taskGroupsDefinition
 }
 
 func (app *Application) setTaskGroups(taskGroups []v1alpha1.TaskGroup) {
@@ -476,6 +489,7 @@ func (app *Application) handleRecoverApplicationEvent(event *fsm.Event) {
 						User: app.user,
 					},
 					Tags:                         app.tags,
+					PlaceholderAsk:               app.placeholderAsk,
 					ExecutionTimeoutMilliSeconds: app.placeholderTimeoutInSec * 1000,
 					GangSchedulingStyle:          app.schedulingStyle,
 				},

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -611,6 +611,7 @@ func (ctx *Context) AddApplication(request *interfaces.AddApplicationRequest) in
 		request.Metadata.Tags,
 		ctx.apiProvider.GetAPIs().SchedulerAPI)
 	app.setTaskGroups(request.Metadata.TaskGroups)
+	app.setTaskGroupsDefinition(request.Metadata.Tags[constants.AnnotationTaskGroups])
 	if request.Metadata.SchedulingPolicyParameters != nil {
 		app.SetPlaceholderTimeout(request.Metadata.SchedulingPolicyParameters.GetPlaceholderTimeout())
 		app.setSchedulingStyle(request.Metadata.SchedulingPolicyParameters.GetGangSchedulingStyle())

--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -20,7 +20,6 @@ package cache
 
 import (
 	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -69,6 +68,7 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup v1alpha1
 			Annotations: utils.MergeMaps(taskGroup.Annotations, map[string]string{
 				constants.AnnotationPlaceholderFlag: "true",
 				constants.AnnotationTaskGroupName:   taskGroup.Name,
+				constants.AnnotationTaskGroups:      app.GetTaskGroupsDefinition(),
 			}),
 			OwnerReferences: ownerRefs,
 		},


### PR DESCRIPTION
### What is this PR for?
If we create pods where the name of the task group does not match the task-group-name annotation, then the real pods will not transition to Running state when the placeholder pods expire and Yunikorn was restarted.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1161

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
