### PR TITLE
[YUNIKORN-1162] Ensure occupied node resources are updated on recovery

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -108,7 +108,6 @@ func (ctx *Context) AddSchedulingEventHandlers() {
 	ctx.apiProvider.AddEventHandler(&client.ResourceEventHandlers{
 		Type:     client.PodInformerHandlers,
 		FilterFn: nodeCoordinator.filterPods,
-		AddFn:    nodeCoordinator.addPod,
 		UpdateFn: nodeCoordinator.updatePod,
 		DeleteFn: nodeCoordinator.deletePod,
 	})

--- a/pkg/cache/node_coordinator.go
+++ b/pkg/cache/node_coordinator.go
@@ -57,26 +57,6 @@ func (c *nodeResourceCoordinator) filterPods(obj interface{}) bool {
 	}
 }
 
-func (c *nodeResourceCoordinator) addPod(new interface{}) {
-	newPod, err := utils.Convert2Pod(new)
-	if err != nil {
-		log.Logger().Error("expecting a pod object", zap.Error(err))
-		return
-	}
-
-	if utils.IsAssignedPod(newPod) && !utils.IsPodTerminated(newPod) {
-		log.Logger().Debug("pod is assigned to a node, trigger occupied resource update",
-			zap.String("namespace", newPod.Namespace),
-			zap.String("podName", newPod.Name),
-			zap.String("podStatusCurrent", string(newPod.Status.Phase)))
-		// if pod is running but not scheduled by us,
-		// we need to notify scheduler-core to re-sync the node resource
-		podResource := common.GetPodResource(newPod)
-		c.nodes.updateNodeOccupiedResources(newPod.Spec.NodeName, podResource, AddOccupiedResource)
-		c.nodes.cache.AddPod(newPod)
-	}
-}
-
 func (c *nodeResourceCoordinator) updatePod(old, new interface{}) {
 	oldPod, err := utils.Convert2Pod(old)
 	if err != nil {

--- a/pkg/cache/node_coordinator_test.go
+++ b/pkg/cache/node_coordinator_test.go
@@ -35,45 +35,6 @@ const (
 	HostEmpty = ""
 )
 
-func TestAddPod(t *testing.T) {
-	mockedSchedulerAPI := newMockSchedulerAPI()
-	nodes := newSchedulerNodes(mockedSchedulerAPI, NewTestSchedulerCache())
-	host1 := utils.NodeForTest(Host1, "10G", "10")
-	nodes.addNode(host1)
-	coordinator := newNodeResourceCoordinator(nodes)
-
-	// pod is not assigned to any node
-	// this won't trigger an update
-	pod := utils.PodForTest("pod1", "1G", "500m")
-	pod.Status.Phase = v1.PodPending
-	pod.Spec.NodeName = ""
-	mockedSchedulerAPI.UpdateNodeFn = func(request *si.NodeRequest) error {
-		t.Fatalf("update should not run because state is not changed")
-		return nil
-	}
-	coordinator.addPod(pod)
-
-	// pod is already assigned to a node and state is running
-	// this will trigger an update
-	pod.Status.Phase = v1.PodRunning
-	pod.Spec.NodeName = Host1
-	executed := false
-	mockedSchedulerAPI.UpdateNodeFn = func(request *si.NodeRequest) error {
-		executed = true
-		assert.Equal(t, len(request.Nodes), 1)
-		updatedNode := request.Nodes[0]
-		assert.Equal(t, updatedNode.NodeID, Host1)
-		assert.Equal(t, updatedNode.Action, si.NodeInfo_UPDATE)
-		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000*1000*1000))
-		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.CPU].Value, int64(10000))
-		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000*1000*1000))
-		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.CPU].Value, int64(500))
-		return nil
-	}
-	coordinator.addPod(pod)
-	assert.Assert(t, executed)
-}
-
 func TestUpdatePod(t *testing.T) {
 	mockedSchedulerApi := newMockSchedulerAPI()
 	nodes := newSchedulerNodes(mockedSchedulerApi, NewTestSchedulerCache())

--- a/pkg/cache/node_test.go
+++ b/pkg/cache/node_test.go
@@ -51,14 +51,24 @@ func TestAddExistingAllocation(t *testing.T) {
 	assert.Equal(t, alloc02.PartitionName, alloc01.PartitionName)
 }
 
-func TestSetOccupiedResource(t *testing.T) {
+func TestUpdateOccupiedResource(t *testing.T) {
 	node := NewTestSchedulerNode()
 	r1 := common.NewResourceBuilder().
-		AddResource(constants.Memory, 2).
-		AddResource(constants.CPU, 2).
+		AddResource(constants.Memory, 5).
+		AddResource(constants.CPU, 5).
 		Build()
-	node.setOccupiedResource(r1)
-	assert.Equal(t, node.occupied, r1)
+	r2 := common.NewResourceBuilder().
+		AddResource(constants.Memory, 1).
+		AddResource(constants.CPU, 1).
+		Build()
+	r3 := common.NewResourceBuilder().
+		AddResource(constants.Memory, 4).
+		AddResource(constants.CPU, 4).
+		Build()
+	node.updateOccupiedResource(r1, AddOccupiedResource)
+	assert.DeepEqual(t, node.occupied, r1)
+	node.updateOccupiedResource(r2, SubOccupiedResource)
+	assert.DeepEqual(t, node.occupied, r3)
 }
 
 func NewTestSchedulerNode() *SchedulerNode {

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -135,13 +135,14 @@ func CreateReleaseAllocationRequestForTask(appID, allocUUID, partition, terminat
 }
 
 // CreateUpdateRequestForNewNode builds a NodeRequest for new node addition and restoring existing node
-func CreateUpdateRequestForNewNode(nodeID string, capacity *si.Resource, existingAllocations []*si.Allocation,
-	ready bool) si.NodeRequest {
+func CreateUpdateRequestForNewNode(nodeID string, capacity *si.Resource, occupied *si.Resource,
+	existingAllocations []*si.Allocation, ready bool) si.NodeRequest {
 	// Use node's name as the NodeID, this is because when bind pod to node,
 	// name of node is required but uid is optional.
 	nodeInfo := &si.NodeInfo{
 		NodeID:              nodeID,
 		SchedulableResource: capacity,
+		OccupiedResource:    occupied,
 		Attributes: map[string]string{
 			constants.DefaultNodeAttributeHostNameKey: nodeID,
 			constants.DefaultNodeAttributeRackNameKey: constants.DefaultRackName,

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -206,12 +206,14 @@ func TestCreateTagsForTask(t *testing.T) {
 
 func TestCreateUpdateRequestForNewNode(t *testing.T) {
 	capacity := NewResourceBuilder().AddResource(constants.Memory, 200).AddResource(constants.CPU, 2).Build()
+	occupied := NewResourceBuilder().AddResource(constants.Memory, 50).AddResource(constants.CPU, 1).Build()
 	var existingAllocations []*si.Allocation
 	ready := true
-	request := CreateUpdateRequestForNewNode(nodeID, capacity, existingAllocations, ready)
+	request := CreateUpdateRequestForNewNode(nodeID, capacity, occupied, existingAllocations, ready)
 	assert.Equal(t, len(request.Nodes), 1)
 	assert.Equal(t, request.Nodes[0].NodeID, nodeID)
 	assert.Equal(t, request.Nodes[0].SchedulableResource, capacity)
+	assert.Equal(t, request.Nodes[0].OccupiedResource, occupied)
 	assert.Equal(t, len(request.Nodes[0].Attributes), 3)
 	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeHostNameKey], nodeID)
 	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeRackNameKey], constants.DefaultRackName)

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -213,7 +213,7 @@ func (ss *KubernetesShim) recoverSchedulerState(e *fsm.Event) {
 				recoverableAppManagers = append(recoverableAppManagers, m)
 			}
 		}
-		if err := ss.context.WaitForRecovery(recoverableAppManagers, 30*time.Second); err != nil {
+		if err := ss.context.WaitForRecovery(recoverableAppManagers, 5*time.Minute); err != nil {
 			// failed
 			log.Logger().Error("scheduler recovery failed", zap.Error(err))
 			dispatcher.Dispatch(ShimSchedulerEvent{

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -91,7 +91,7 @@ func (fc *MockScheduler) addNode(nodeName string, memory, cpu int64) error {
 		AddResource(constants.Memory, memory).
 		AddResource(constants.CPU, cpu).
 		Build()
-	request := common.CreateUpdateRequestForNewNode(nodeName, nodeResource, nil, true)
+	request := common.CreateUpdateRequestForNewNode(nodeName, nodeResource, nil, nil, true)
 	fmt.Printf("report new nodes to scheduler, request: %s", request.String())
 	return fc.apiProvider.GetAPIs().SchedulerAPI.UpdateNode(&request)
 }


### PR DESCRIPTION
### What is this PR for?
Fixes an issue where node recovery doesn't account for occupied resources.

* Revert fix in YUNIKORN-1159
* Ensure common.CreateUpdateRequestForNewNode() handles occupied resources
* Add more debug logging around node recovery
* Fix race condition in occupied resource update by always adding rather than setting
* Avoid transitioning node to Recovering more than once
* Increase recovery timeout to avoid possible failure on large clusters

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1162

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
