### PR TITLE
[YUNIKORN-1155] Placeholder timeout should not be initialized to the default value during recovery

### DIFF
--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -113,7 +113,7 @@ func (os *Manager) getTaskMetadata(pod *v1.Pod) (interfaces.TaskMetadata, bool) 
 	}, true
 }
 
-func (os *Manager) getAppMetadataInternal(pod *v1.Pod, recovery bool) (interfaces.ApplicationMetadata, bool) {
+func (os *Manager) getAppMetadata(pod *v1.Pod, recovery bool) (interfaces.ApplicationMetadata, bool) {
 	appID, err := utils.GetApplicationIDFromPod(pod)
 	if err != nil {
 		log.Logger().Debug("unable to get application for pod",
@@ -157,7 +157,7 @@ func (os *Manager) getAppMetadataInternal(pod *v1.Pod, recovery bool) (interface
 
 	var creationTime int64
 	if recovery {
-		creationTime = pod.CreationTimestamp.Time.Unix()
+		creationTime = pod.CreationTimestamp.Unix()
 	}
 
 	return interfaces.ApplicationMetadata{
@@ -170,10 +170,6 @@ func (os *Manager) getAppMetadataInternal(pod *v1.Pod, recovery bool) (interface
 		SchedulingPolicyParameters: schedulingPolicyParams,
 		CreationTime:               creationTime,
 	}, true
-}
-
-func (os *Manager) getAppMetadata(pod *v1.Pod) (interfaces.ApplicationMetadata, bool) {
-	return os.getAppMetadataInternal(pod, false)
 }
 
 func isStateAwareDisabled(pod *v1.Pod) bool {
@@ -240,7 +236,7 @@ func (os *Manager) addPod(obj interface{}) {
 		zap.String("Namespace", pod.Namespace))
 
 	// add app
-	if appMeta, ok := os.getAppMetadata(pod); ok {
+	if appMeta, ok := os.getAppMetadata(pod, false); ok {
 		// check if app already exist
 		if app := os.amProtocol.GetApplication(appMeta.ApplicationID); app == nil {
 			os.amProtocol.AddApplication(&interfaces.AddApplicationRequest{
@@ -350,7 +346,7 @@ func (os *Manager) ListApplications() (map[string]interfaces.ApplicationMetadata
 		// general filter passes, and pod is assigned
 		// this means the pod is already scheduled by scheduler for an existing app
 		if utils.GeneralPodFilter(pod) && utils.IsAssignedPod(pod) {
-			if meta, ok := os.getAppMetadataInternal(pod, true); ok {
+			if meta, ok := os.getAppMetadata(pod, true); ok {
 				podsRecovered++
 				log.Logger().Debug("Adding appID as recovery candidate", zap.String("appID", meta.ApplicationID))
 				if _, exist := existingApps[meta.ApplicationID]; !exist {
@@ -371,7 +367,7 @@ func (os *Manager) ListApplications() (map[string]interfaces.ApplicationMetadata
 }
 
 func (os *Manager) GetExistingAllocation(pod *v1.Pod) *si.Allocation {
-	if meta, valid := os.getAppMetadata(pod); valid {
+	if meta, valid := os.getAppMetadata(pod, false); valid {
 		// when submit a task, we use pod UID as the allocationKey,
 		// to keep consistent, during recovery, the pod UID is also used
 		// for an Allocation.

--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -72,7 +72,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok := am.getAppMetadata(&pod)
+	app, ok := am.getAppMetadata(&pod, false)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.ApplicationID, "app00001")
 	assert.Equal(t, app.QueueName, "root.a")
@@ -111,7 +111,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod)
+	app, ok = am.getAppMetadata(&pod, false)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.ApplicationID, "app00002")
 	assert.Equal(t, app.QueueName, "root.b")
@@ -146,7 +146,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod)
+	app, ok = am.getAppMetadata(&pod, false)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.SchedulingPolicyParameters.GetGangSchedulingStyle(), "Soft")
 
@@ -176,7 +176,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod)
+	app, ok = am.getAppMetadata(&pod, false)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.SchedulingPolicyParameters.GetGangSchedulingStyle(), "Soft")
 
@@ -198,7 +198,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod)
+	app, ok = am.getAppMetadata(&pod, false)
 	assert.Equal(t, ok, false)
 	pod = v1.Pod{
 		TypeMeta: apis.TypeMeta{
@@ -218,7 +218,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod)
+	app, ok = am.getAppMetadata(&pod, false)
 	assert.Equal(t, ok, false)
 }
 

--- a/pkg/appmgmt/interfaces/amprotocol.go
+++ b/pkg/appmgmt/interfaces/amprotocol.go
@@ -80,6 +80,7 @@ type ApplicationMetadata struct {
 	TaskGroups                 []v1alpha1.TaskGroup
 	OwnerReferences            []metav1.OwnerReference
 	SchedulingPolicyParameters *SchedulingPolicyParameters
+	CreationTime               int64
 }
 
 type TaskMetadata struct {

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -45,6 +45,7 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 	"github.com/apache/yunikorn-k8shim/pkg/plugin/predicates"
 	"github.com/apache/yunikorn-k8shim/pkg/plugin/support"
+	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -614,7 +615,7 @@ func (ctx *Context) AddApplication(request *interfaces.AddApplicationRequest) in
 	app.setTaskGroups(request.Metadata.TaskGroups)
 	app.setTaskGroupsDefinition(request.Metadata.Tags[constants.AnnotationTaskGroups])
 	if request.Metadata.CreationTime != 0 {
-		app.tags["creationTime"] = strconv.FormatInt(request.Metadata.CreationTime, 10)
+		app.tags[siCommon.DomainYuniKorn+constants.CreationTime] = strconv.FormatInt(request.Metadata.CreationTime, 10)
 	}
 	if request.Metadata.SchedulingPolicyParameters != nil {
 		app.SetPlaceholderTimeout(request.Metadata.SchedulingPolicyParameters.GetPlaceholderTimeout())

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -612,6 +613,9 @@ func (ctx *Context) AddApplication(request *interfaces.AddApplicationRequest) in
 		ctx.apiProvider.GetAPIs().SchedulerAPI)
 	app.setTaskGroups(request.Metadata.TaskGroups)
 	app.setTaskGroupsDefinition(request.Metadata.Tags[constants.AnnotationTaskGroups])
+	if request.Metadata.CreationTime != 0 {
+		app.tags["creationTime"] = strconv.FormatInt(request.Metadata.CreationTime, 10)
+	}
 	if request.Metadata.SchedulingPolicyParameters != nil {
 		app.SetPlaceholderTimeout(request.Metadata.SchedulingPolicyParameters.GetPlaceholderTimeout())
 		app.setSchedulingStyle(request.Metadata.SchedulingPolicyParameters.GetGangSchedulingStyle())

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -74,6 +74,7 @@ const SchedulingPolicyTimeoutParam = "placeholderTimeoutInSeconds"
 const SchedulingPolicyParamDelimiter = " "
 const SchedulingPolicyStyleParam = "gangSchedulingStyle"
 const SchedulingPolicyStyleParamDefault = "Soft"
+const CreationTime = "CreationTime"
 
 var SchedulingPolicyStyleParamValues = map[string]string{"Hard": "Hard", "Soft": "Soft"}
 


### PR DESCRIPTION
### What is this PR for?
When Yunikorn is restarted, the placeholder timeout is reset to the original value, regardless of how much time the placeholder had already spent in pending/running state. This PR fixes this issue by sending the creationTime attribute of the pod to the core which can make a proper calculation about the remaining time.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1155

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
