### PR TITLE
[YUNIKORN-1172] Clean up e2e test pods immediately

### DIFF
--- a/test/e2e/recovery_and_restart/recovery_and_restart_test.go
+++ b/test/e2e/recovery_and_restart/recovery_and_restart_test.go
@@ -85,7 +85,7 @@ var _ = ginkgo.Describe("", func() {
 		ginkgo.By("Restart the scheduler pod")
 		schedulerPodName, err := kClient.GetSchedulerPod()
 		Ω(err).NotTo(gomega.HaveOccurred())
-		err = kClient.DeletePod(schedulerPodName, configmanager.YuniKornTestConfig.YkNamespace)
+		err = kClient.DeletePodGracefully(schedulerPodName, configmanager.YuniKornTestConfig.YkNamespace)
 		Ω(err).NotTo(gomega.HaveOccurred())
 		err = kClient.WaitForPodBySelectorRunning(configmanager.YuniKornTestConfig.YkNamespace, fmt.Sprintf("component=%s", configmanager.YKScheduler), 10)
 		Ω(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
### What is this PR for?
Speed up e2e tests and make them more resilient to pod cleanup timeouts by terminating pods immediately.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1172

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
