### PR TITLE
[YUNIKORN-1116] Update SchedulerNode properties using proper locks

### DIFF
--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -135,19 +135,7 @@ func (nc *schedulerNodes) updateNodeOccupiedResources(name string, resource *si.
 	}
 
 	if schedulerNode := nc.getNode(name); schedulerNode != nil {
-		nc.lock.Lock()
-		defer nc.lock.Unlock()
-
-		switch opt {
-		case AddOccupiedResource:
-			schedulerNode.occupied = common.Add(schedulerNode.occupied, resource)
-		case SubOccupiedResource:
-			schedulerNode.occupied = common.Sub(schedulerNode.occupied, resource)
-		default:
-			// noop
-			return
-		}
-
+		schedulerNode.updateOccupiedResource(resource, opt)
 		request := common.CreateUpdateRequestForUpdatedNode(name, schedulerNode.capacity, schedulerNode.occupied, schedulerNode.ready)
 		log.Logger().Info("report occupied resources updates",
 			zap.String("node", schedulerNode.name),


### PR DESCRIPTION
### What is this PR for?
schedulerNode.updateOccupiedResource has been used to add and sub the occupied resource with proper lock.

### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1116

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
