### PR TITLE
[YUNIKORN-1180] JSON parse error when creating placeholders

### DIFF
--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -56,6 +56,16 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup v1alpha1
 	for _, r := range ownerRefs {
 		*r.Controller = false
 	}
+	annotations := utils.MergeMaps(taskGroup.Annotations, map[string]string{
+		constants.AnnotationPlaceholderFlag: "true",
+		constants.AnnotationTaskGroupName:   taskGroup.Name,
+	})
+	tgDef := app.GetTaskGroupsDefinition()
+	if tgDef != "" {
+		annotations = utils.MergeMaps(annotations, map[string]string{
+			constants.AnnotationTaskGroups: tgDef,
+		})
+	}
 	placeholderPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      placeholderName,
@@ -65,11 +75,7 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup v1alpha1
 				constants.LabelQueueName:       app.GetQueue(),
 				constants.LabelPlaceholderFlag: "true",
 			}),
-			Annotations: utils.MergeMaps(taskGroup.Annotations, map[string]string{
-				constants.AnnotationPlaceholderFlag: "true",
-				constants.AnnotationTaskGroupName:   taskGroup.Name,
-				constants.AnnotationTaskGroups:      app.GetTaskGroupsDefinition(),
-			}),
+			Annotations:     annotations,
 			OwnerReferences: ownerRefs,
 		},
 		Spec: v1.PodSpec{

--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -61,7 +61,7 @@ func TestNewPlaceholder(t *testing.T) {
 	assert.Equal(t, len(holder.pod.Labels), 3)
 	assert.Equal(t, holder.pod.Labels[constants.LabelApplicationID], appID)
 	assert.Equal(t, holder.pod.Labels[constants.LabelQueueName], queue)
-	assert.Equal(t, len(holder.pod.Annotations), 3)
+	assert.Equal(t, len(holder.pod.Annotations), 2)
 	assert.Equal(t, holder.pod.Annotations[constants.AnnotationTaskGroupName], app.taskGroups[0].Name)
 	assert.Equal(t, common.GetPodResource(holder.pod).Resources[constants.CPU].Value, int64(500))
 	assert.Equal(t, common.GetPodResource(holder.pod).Resources[constants.Memory].Value, int64(1024*1000*1000))


### PR DESCRIPTION
### What is this PR for?
An error message is logged to the console when a placeholder is created. We should only add the taskGroups annotation if it's set in the Application object.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1180

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
