### PR TITLE
[YUNIKORN-1190] Account for usage of pods without applicationId

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -267,7 +267,11 @@ func (ctx *Context) updatePodInCache(oldObj, newObj interface{}) {
 func (ctx *Context) filterPods(obj interface{}) bool {
 	switch obj := obj.(type) {
 	case *v1.Pod:
-		return utils.GeneralPodFilter(obj)
+		if utils.GeneralPodFilter(obj) {
+			_, err := utils.GetApplicationIDFromPod(obj)
+			return err == nil
+		}
+		return false
 	default:
 		return false
 	}

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -263,9 +263,22 @@ func TestFilterPods(t *testing.T) {
 		},
 		Spec: v1.PodSpec{SchedulerName: "default-scheduler"},
 	}
+	pod3 := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name:   "yunikorn-test-00003",
+			UID:    "UID-00003",
+			Labels: map[string]string{"applicationId": "test-00003"},
+		},
+		Spec: v1.PodSpec{SchedulerName: "yunikorn"},
+	}
 	assert.Check(t, !context.filterPods(nil), "nil object was allowed")
-	assert.Check(t, context.filterPods(pod1), "yunikorn-managed pod was filtered")
+	assert.Check(t, !context.filterPods(pod1), "yunikorn-managed pod with no app id was allowed")
 	assert.Check(t, !context.filterPods(pod2), "non-yunikorn-managed pod was allowed")
+	assert.Check(t, context.filterPods(pod3), "yunikorn-managed pod was filtered")
 }
 
 func TestAddPodToCache(t *testing.T) {

--- a/pkg/cache/node_coordinator.go
+++ b/pkg/cache/node_coordinator.go
@@ -48,10 +48,13 @@ func newNodeResourceCoordinator(nodes *schedulerNodes) *nodeResourceCoordinator 
 
 // filter pods that not scheduled by us
 func (c *nodeResourceCoordinator) filterPods(obj interface{}) bool {
-	switch obj.(type) {
+	switch obj := obj.(type) {
 	case *v1.Pod:
-		pod := obj.(*v1.Pod)
-		return !utils.GeneralPodFilter(pod)
+		if utils.GeneralPodFilter(obj) {
+			_, err := utils.GetApplicationIDFromPod(obj)
+			return err != nil
+		}
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
### What is this PR for?
Fixes accounting of pods which have schedulerName: yunikorn set but not an applicationId. This causes incorrect node accounting when running in plugin mode.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1190

### How should this be tested?
Unit tests updated and manually verified on test cluster.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
