### PR TITLE
[POC][YUNIKORN-1194] Task objects are not created when applications are restored in recoverApps()

### DIFF
--- a/pkg/appmgmt/appmgmt.go
+++ b/pkg/appmgmt/appmgmt.go
@@ -37,24 +37,28 @@ type AppManagementService struct {
 	apiProvider client.APIProvider
 	amProtocol  interfaces.ApplicationManagementProtocol
 	managers    []interfaces.AppManager
+	generalMgr  *general.Manager
 }
 
 func NewAMService(amProtocol interfaces.ApplicationManagementProtocol,
 	apiProvider client.APIProvider) *AppManagementService {
+	generalMgr := general.NewManager(amProtocol, apiProvider)
 	appManager := &AppManagementService{
 		amProtocol:  amProtocol,
 		apiProvider: apiProvider,
 		managers:    make([]interfaces.AppManager, 0),
+		generalMgr:  generalMgr,
 	}
 
 	log.Logger().Info("Initializing new AppMgmt service")
 
 	if !apiProvider.IsTestingMode() {
 		log.Logger().Info("Registering Spark operator with the AppMgmt service")
+
 		appManager.register(
 			// registered app plugins
 			// for general apps
-			general.NewManager(amProtocol, apiProvider),
+			generalMgr,
 			// for spark operator - SparkApplication
 			sparkoperator.NewManager(amProtocol, apiProvider),
 			// for application crds

--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -47,25 +47,52 @@ func (svc *AppManagementService) recoverApps() (map[string]interfaces.ManagedApp
 	recoveringApps := make(map[string]interfaces.ManagedApp)
 	for _, mgr := range svc.managers {
 		if m, ok := mgr.(interfaces.Recoverable); ok {
-			appMetas, err := m.ListApplications()
+			appMetas, pods, err := m.ListApplications()
 			if err != nil {
 				log.Logger().Error("failed to list apps", zap.Error(err))
 				return recoveringApps, err
 			}
 
-			// trigger recovery of the apps
-			// this is simply submit the app again
+			// Collect the ManagedApp objects and also call AddApplication()
+			// to register the app
+			log.Logger().Debug("Adding retrieved applications")
+			apps := make([]interfaces.ManagedApp, 0)
 			for _, appMeta := range appMetas {
+				log.Logger().Debug("Adding application", zap.String("appId", appMeta.ApplicationID))
 				if app := svc.amProtocol.AddApplication(
 					&interfaces.AddApplicationRequest{
-						Metadata: appMeta,
+						Metadata:    appMeta,
+						ForceUpdate: true,
 					}); app != nil {
+
 					recoveringApps[app.GetApplicationID()] = app
-					if err := app.TriggerAppRecovery(); err != nil {
-						log.Logger().Error("failed to recover app", zap.Error(err))
-						return recoveringApps, fmt.Errorf("failed to recover app %s, reason: %v",
-							app.GetApplicationID(), err)
+					apps = append(apps, app)
+				}
+			}
+
+			// Collect the tasks and call AddTask()
+			log.Logger().Debug("Adding tasks from retrieved pods")
+			for _, pod := range pods {
+				if taskMeta, ok := svc.generalMgr.GetTaskMetadata(pod); ok {
+					if app := svc.amProtocol.GetApplication(taskMeta.ApplicationID); app != nil {
+						if _, taskErr := app.GetTask(string(pod.UID)); taskErr != nil {
+							log.Logger().Debug("Adding task", zap.Any("taskMeta", taskMeta.TaskID))
+							svc.amProtocol.AddTask(&interfaces.AddTaskRequest{
+								Metadata: taskMeta,
+							})
+						}
 					}
+				}
+			}
+
+			// trigger recovery of the apps
+			// this is simply submit the app again
+			for _, app := range apps {
+				log.Logger().Info("Triggering recovery for app", zap.String("appId", app.GetApplicationID()))
+				if err := app.TriggerAppRecovery(); err != nil {
+					log.Logger().Error("failed to recover app", zap.Error(err))
+					return recoveringApps, fmt.Errorf("failed to recover app %s, reason: %v",
+						app.GetApplicationID(), err)
 				}
 			}
 		}

--- a/pkg/appmgmt/appmgmt_recovery_test.go
+++ b/pkg/appmgmt/appmgmt_recovery_test.go
@@ -171,7 +171,7 @@ func (ma *mockedAppManager) Stop() {
 	// noop
 }
 
-func (ma *mockedAppManager) ListApplications() (map[string]interfaces.ApplicationMetadata, error) {
+func (ma *mockedAppManager) ListApplications() (map[string]interfaces.ApplicationMetadata, []*v1.Pod, error) {
 	apps := make(map[string]interfaces.ApplicationMetadata)
 	apps["app01"] = interfaces.ApplicationMetadata{
 		ApplicationID: "app01",
@@ -185,7 +185,7 @@ func (ma *mockedAppManager) ListApplications() (map[string]interfaces.Applicatio
 		User:          "",
 		Tags:          nil,
 	}
-	return apps, nil
+	return apps, nil, nil
 }
 
 func (ma *mockedAppManager) GetExistingAllocation(pod *v1.Pod) *si.Allocation {

--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -72,7 +72,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok := am.getAppMetadata(&pod, false)
+	app, ok := am.GetAppMetadata(&pod, false)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.ApplicationID, "app00001")
 	assert.Equal(t, app.QueueName, "root.a")
@@ -113,7 +113,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod, false)
+	app, ok = am.GetAppMetadata(&pod, false)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.ApplicationID, "app00002")
 	assert.Equal(t, app.QueueName, "root.b")
@@ -146,7 +146,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod, false)
+	app, ok = am.GetAppMetadata(&pod, false)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.SchedulingPolicyParameters.GetGangSchedulingStyle(), "Soft")
 
@@ -176,7 +176,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod, false)
+	app, ok = am.GetAppMetadata(&pod, false)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.SchedulingPolicyParameters.GetGangSchedulingStyle(), "Soft")
 
@@ -198,7 +198,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod, false)
+	app, ok = am.GetAppMetadata(&pod, false)
 	assert.Equal(t, ok, false)
 	pod = v1.Pod{
 		TypeMeta: apis.TypeMeta{
@@ -218,7 +218,7 @@ func TestGetAppMetadata(t *testing.T) {
 		},
 	}
 
-	app, ok = am.getAppMetadata(&pod, false)
+	app, ok = am.GetAppMetadata(&pod, false)
 	assert.Equal(t, ok, false)
 }
 
@@ -248,13 +248,13 @@ func TestGetTaskMetadata(t *testing.T) {
 		},
 	}
 
-	task, ok := am.getTaskMetadata(&pod)
+	task, ok := am.GetTaskMetadata(&pod)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, task.ApplicationID, "app00001")
 	assert.Equal(t, task.TaskID, "UID-POD-00001")
 	assert.Equal(t, task.TaskGroupName, "test-group-01")
 	pod.Annotations = map[string]string{}
-	task, ok = am.getTaskMetadata(&pod)
+	task, ok = am.GetTaskMetadata(&pod)
 	assert.Equal(t, ok, true)
 	assert.Equal(t, task.TaskGroupName, "")
 
@@ -274,7 +274,7 @@ func TestGetTaskMetadata(t *testing.T) {
 		},
 	}
 
-	task, ok = am.getTaskMetadata(&pod)
+	task, ok = am.GetTaskMetadata(&pod)
 	assert.Equal(t, ok, false)
 }
 
@@ -758,7 +758,7 @@ func TestListApplication(t *testing.T) {
 	}
 	// init the app manager and run listApp
 	am := NewManager(cache.NewMockedAMProtocol(), mockedAPIProvider)
-	apps, err := am.ListApplications()
+	apps, _, err := am.ListApplications()
 	assert.NilError(t, err)
 	assert.Equal(t, len(apps), 3)
 	for name := range apps {

--- a/pkg/appmgmt/interfaces/amprotocol.go
+++ b/pkg/appmgmt/interfaces/amprotocol.go
@@ -65,7 +65,8 @@ type ApplicationManagementProtocol interface {
 }
 
 type AddApplicationRequest struct {
-	Metadata ApplicationMetadata
+	Metadata    ApplicationMetadata
+	ForceUpdate bool
 }
 
 type AddTaskRequest struct {

--- a/pkg/appmgmt/interfaces/recoverable.go
+++ b/pkg/appmgmt/interfaces/recoverable.go
@@ -24,7 +24,7 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-// recoverable interface defines a certain type of app that can be recovered upon scheduler' restart
+// Recoverable interface defines a certain type of app that can be recovered upon scheduler' restart
 // each app manager needs to implement this interface in order to support fault recovery
 //
 // why we need this?
@@ -35,7 +35,7 @@ import (
 // and then properly recover these applications before recovering nodes.
 type Recoverable interface {
 	// list applications returns all existing applications known to this app manager.
-	ListApplications() (map[string]ApplicationMetadata, error)
+	ListApplications() (map[string]ApplicationMetadata, []*v1.Pod, error)
 
 	// this is called during recovery
 	// for a given pod, return an allocation if found

--- a/pkg/common/test/recoverable_apps_mock.go
+++ b/pkg/common/test/recoverable_apps_mock.go
@@ -33,8 +33,8 @@ func NewMockedRecoverableAppManager() *MockedRecoverableAppManager {
 	return &MockedRecoverableAppManager{}
 }
 
-func (m *MockedRecoverableAppManager) ListApplications() (map[string]interfaces.ApplicationMetadata, error) {
-	return nil, nil
+func (m *MockedRecoverableAppManager) ListApplications() (map[string]interfaces.ApplicationMetadata, []*v1.Pod, error) {
+	return nil, nil, nil
 }
 
 func (m *MockedRecoverableAppManager) GetExistingAllocation(pod *v1.Pod) *si.Allocation {


### PR DESCRIPTION
### What is this PR for?
The code inside `AppManagementService.recoverApps()` does not call `Context.AddTask()`. Which means that the generated `Application` object will be invalid since it won't include any `Task` object in the `taskMap`.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1194

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
