### PR TITLE
[YUNIKORN-1206] Fix admission controller namespace handling

### DIFF
--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
@@ -409,11 +409,7 @@ func errorResponseMock(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestGenerateAppID(t *testing.T) {
-	appID := generateAppID("")
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-default", autoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 24)
-
-	appID = generateAppID("this-is-a-namespace")
+	appID := generateAppID("this-is-a-namespace")
 	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-this-is-a-namespace", autoGenAppPrefix)), true)
 	assert.Equal(t, len(appID), 36)
 


### PR DESCRIPTION
### What is this PR for?
Fixes an issue where the admission controller can pick up the wrong namespace from a submitted pod (if the pod is created as part of a job). Also adds some additional logging of pod name / generatedName and filters.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1206

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
