### PR TITLE
[YUNIKORN-1197] Placeholders are immediately replaced during recovery

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -336,6 +336,19 @@ func (app *Application) GetAllocatedTasks() []*Task {
 	return app.getTasks(events.States().Task.Allocated)
 }
 
+func (app *Application) GetPlaceHolderTasks() []*Task {
+	app.lock.RLock()
+	defer app.lock.RUnlock()
+	placeholders := make([]*Task, 0)
+	for _, task := range app.taskMap {
+		if task.placeholder {
+			placeholders = append(placeholders, task)
+		}
+	}
+
+	return placeholders
+}
+
 func (app *Application) getTasks(state string) []*Task {
 	taskList := make([]*Task, 0)
 	if len(app.taskMap) > 0 {
@@ -530,7 +543,7 @@ func (app *Application) skipReservationStage() bool {
 	// in this case, we should skip the reservation stage
 	if len(app.taskMap) > 0 {
 		for _, task := range app.taskMap {
-			if task.GetTaskState() != events.States().Task.New {
+			if !task.IsPlaceholder() && task.GetTaskState() != events.States().Task.New {
 				log.Logger().Debug("Skip reservation stage: found task already has been scheduled before.",
 					zap.String("appID", app.applicationID),
 					zap.String("taskID", task.GetTaskID()),

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -1108,3 +1108,27 @@ func TestResumingStateTransitions(t *testing.T) {
 	assert.NilError(t, err)
 	assertAppState(t, app, events.States().Application.Running, 3*time.Second)
 }
+
+func TestGetPlaceholderTasks(t *testing.T) {
+	context := initContextForTest()
+	app := NewApplication(appID, "root.a", "testuser", map[string]string{}, newMockSchedulerAPI())
+	task1 := NewTask("task0001", app, context, &v1.Pod{})
+	task1.placeholder = true
+	task2 := NewTask("task0002", app, context, &v1.Pod{})
+	task2.placeholder = true
+	task3 := NewTask("task0003", app, context, &v1.Pod{})
+
+	app.addTask(task1)
+	app.addTask(task2)
+	app.addTask(task3)
+
+	phTasks := app.GetPlaceHolderTasks()
+	assert.Equal(t, 2, len(phTasks))
+	phTasksMap := map[string]bool{
+		phTasks[0].GetTaskID(): true,
+		phTasks[1].GetTaskID(): true,
+	}
+
+	assert.Assert(t, phTasksMap["task0001"])
+	assert.Assert(t, phTasksMap["task0002"])
+}

--- a/pkg/cache/placeholder_manager.go
+++ b/pkg/cache/placeholder_manager.go
@@ -77,10 +77,21 @@ func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
 	mgr.Lock()
 	defer mgr.Unlock()
 
+	existingPlaceHolders := map[string]struct{}{}
+	for _, phTasks := range app.GetPlaceHolderTasks() {
+		existingPlaceHolders[phTasks.GetTaskPod().GetName()] = struct{}{}
+	}
+
 	// iterate all task groups, create placeholders for all the min members
 	for _, tg := range app.getTaskGroups() {
 		for i := int32(0); i < tg.MinMember; i++ {
 			placeholderName := utils.GeneratePlaceholderName(tg.Name, app.GetApplicationID(), i)
+			// when performing recovery, do not create pods that are already running
+			if _, ok := existingPlaceHolders[placeholderName]; ok {
+				log.Logger().Info("Placeholder pod already exists",
+					zap.String("name", placeholderName))
+				continue
+			}
 			placeholder := newPlaceholder(placeholderName, app, tg)
 			// create the placeholder on K8s
 			_, err := mgr.clients.KubeClient.Create(placeholder.pod)


### PR DESCRIPTION
### What is this PR for?
In certain cases, running placeholders are immediately replaced if Yunikorn is restarted. It's because the `Application` in on the shim side does not stay in `Reserving` state, but transitions to `Running`. This causes resource asks to be added and the scheduler replaces the placeholder pods.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1197

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
