### PR TITLE
[YUNIKORN-1217] Ensure that Spark driver pod is processed before executor pods during recovery

### DIFF
--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -20,6 +20,7 @@ package appmgmt
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"go.uber.org/zap"
@@ -53,6 +54,10 @@ func (svc *AppManagementService) recoverApps() (map[string]interfaces.ManagedApp
 				log.Logger().Error("failed to list apps", zap.Error(err))
 				return recoveringApps, err
 			}
+
+			sort.Slice(pods, func(i, j int) bool {
+				return pods[i].CreationTimestamp.Unix() < pods[j].CreationTimestamp.Unix()
+			})
 
 			for _, pod := range pods {
 				app := svc.podEventHandler.HandleEvent(general.AddPod, general.Recovery, pod)

--- a/pkg/cache/amprotocol_mock.go
+++ b/pkg/cache/amprotocol_mock.go
@@ -28,6 +28,7 @@ import (
 // implements ApplicationManagementProtocol
 type MockedAMProtocol struct {
 	applications map[string]*Application
+	addTaskFn    func(request *interfaces.AddTaskRequest)
 }
 
 func NewMockedAMProtocol() *MockedAMProtocol {
@@ -70,6 +71,9 @@ func (m *MockedAMProtocol) RemoveApplication(appID string) error {
 }
 
 func (m *MockedAMProtocol) AddTask(request *interfaces.AddTaskRequest) interfaces.ManagedTask {
+	if m.addTaskFn != nil {
+		m.addTaskFn(request)
+	}
 	if app, ok := m.applications[request.Metadata.ApplicationID]; ok {
 		if existingTask, err := app.GetTask(request.Metadata.TaskID); err != nil {
 			task := NewTask(request.Metadata.TaskID, app, nil, request.Metadata.Pod)
@@ -113,4 +117,8 @@ func (m *MockedAMProtocol) NotifyTaskComplete(appID, taskID string) {
 			}
 		}
 	}
+}
+
+func (m *MockedAMProtocol) UseAddTaskFn(fn func(request *interfaces.AddTaskRequest)) {
+	m.addTaskFn = fn
 }


### PR DESCRIPTION
### What is this PR for?
We have to make sure that we always call `addPod()` to the Spark driver pod before the executors (per application) when doing recovery, because that contains annotations which executors don't.
In general, adding the very first pod of the existing application makes sense.

This PR contains the simplest solution: after retrieving the current list of pods from K8s, just sort them based on CreationTime.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1217

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
