### PR TITLE
[YUNIKORN-1228] Fix race condition when serializing K8s objects

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -398,7 +398,7 @@ func (app *Application) scheduleTasks(taskScheduleCondition func(t *Task) bool) 
 					log.Logger().Warn("init task failed", zap.Error(err))
 				}
 			} else {
-				events.GetRecorder().Eventf(task.GetTaskPod(), nil, v1.EventTypeWarning, "FailedScheduling", "FailedScheduling", err.Error())
+				events.GetRecorder().Eventf(task.GetTaskPod().DeepCopy(), nil, v1.EventTypeWarning, "FailedScheduling", "FailedScheduling", err.Error())
 				log.Logger().Debug("task is not ready for scheduling",
 					zap.String("appID", task.applicationID),
 					zap.String("taskID", task.taskID),
@@ -598,7 +598,7 @@ func (app *Application) handleFailApplicationEvent(errMsg string) {
 			errMsgArr := strings.Split(errMsg, ":")
 			failTaskPodWithReasonAndMsg(task, constants.ApplicationRejectedFailure, errMsgArr[1])
 		}
-		events.GetRecorder().Eventf(task.GetTaskPod(), nil, v1.EventTypeWarning, "ApplicationFailed", "ApplicationFailed",
+		events.GetRecorder().Eventf(task.GetTaskPod().DeepCopy(), nil, v1.EventTypeWarning, "ApplicationFailed", "ApplicationFailed",
 			"Application %s scheduling failed, reason: %s", app.applicationID, errMsg)
 	}
 }
@@ -664,7 +664,7 @@ func (app *Application) publishPlaceholderTimeoutEvents(task *Task) {
 			zap.String("app request originating pod", app.originatingTask.GetTaskPod().String()),
 			zap.String("taskID", task.taskID),
 			zap.String("terminationType", task.terminationType))
-		events.GetRecorder().Eventf(app.originatingTask.GetTaskPod(), nil, v1.EventTypeWarning, "Placeholder timed out",
+		events.GetRecorder().Eventf(app.originatingTask.GetTaskPod().DeepCopy(), nil, v1.EventTypeWarning, "Placeholder timed out",
 			"Placeholder timed out", "Application %s placeholder has been timed out", app.applicationID)
 	}
 }

--- a/pkg/plugin/predicates/predicate_manager.go
+++ b/pkg/plugin/predicates/predicate_manager.go
@@ -77,7 +77,7 @@ func (p *predicateManagerImpl) predicatesAllocate(pod *v1.Pod, node *framework.N
 	state := framework.NewCycleState()
 	plugin, err := p.podFitsNode(ctx, state, *p.allocationPreFilters, *p.allocationFilters, pod, node)
 	if err != nil {
-		events.GetRecorder().Eventf(pod, nil, v1.EventTypeWarning,
+		events.GetRecorder().Eventf(pod.DeepCopy(), nil, v1.EventTypeWarning,
 			"FailedScheduling", "FailedScheduling", "predicate is not satisfied, error: %s", err.Error())
 	}
 	return plugin, err


### PR DESCRIPTION
### What is this PR for?
Fixes a race condition that occurs when K8s objects are serialized for transmission. If the `version` component of the `GroupVersionKind` element (which is part of every K8s object) is not set, the serializer sets it, causing race conditions with concurrent reads. This patch ensures that we defensively copy objects that are sent over the wire.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1228

### How should this be tested?
No functional changes, so all existing unit and e2e tests apply.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
