### PR TITLE
[YUNIKORN-1245] Clean up usage of cache GetNodesInfoMap

### DIFF
--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -70,18 +70,10 @@ func NewSchedulerCache(clients *client.Clients) *SchedulerCache {
 	return cache
 }
 
+// GetNodesInfoMap returns a reference to the internal node map. This is explicitly for the use of the predicate
+// shared lister and requires that the scheduler cache lock be held while accessing.
 func (cache *SchedulerCache) GetNodesInfoMap() map[string]*framework.NodeInfo {
 	return cache.nodesMap
-}
-
-func (cache *SchedulerCache) GetNodesInfoMapCopy() map[string]*framework.NodeInfo {
-	cache.lock.RLock()
-	defer cache.lock.RUnlock()
-	copyOfMap := make(map[string]*framework.NodeInfo, len(cache.nodesMap))
-	for k, v := range cache.nodesMap {
-		copyOfMap[k] = v.Clone()
-	}
-	return copyOfMap
 }
 
 func (cache *SchedulerCache) LockForReads() {

--- a/pkg/cache/external/scheduler_cache_test.go
+++ b/pkg/cache/external/scheduler_cache_test.go
@@ -280,11 +280,11 @@ func add2Cache(cache *SchedulerCache, objects ...interface{}) error {
 	return nil
 }
 
-func TestGetNodesInfoMapCopy(t *testing.T) {
+func TestGetNodesInfoMap(t *testing.T) {
 	// empty map
 	cache := NewSchedulerCache(client.NewMockedAPIProvider(false).GetAPIs())
-	copyOfMap := cache.GetNodesInfoMapCopy()
-	assert.Equal(t, len(copyOfMap), 0)
+	ref := cache.GetNodesInfoMap()
+	assert.Equal(t, len(ref), 0)
 
 	for i := 0; i < 10; i++ {
 		cache.AddNode(&v1.Node{
@@ -303,9 +303,9 @@ func TestGetNodesInfoMapCopy(t *testing.T) {
 		})
 	}
 
-	copyOfMap = cache.GetNodesInfoMapCopy()
-	assert.Equal(t, len(copyOfMap), 10)
-	for k, v := range copyOfMap {
+	ref = cache.GetNodesInfoMap()
+	assert.Equal(t, len(ref), 10)
+	for k, v := range ref {
 		assert.Assert(t, v.Node() != nil, "node %s should not be nil", k)
 		assert.Equal(t, len(v.Node().Labels), 2)
 		assert.Equal(t, len(v.Node().Annotations), 3)


### PR DESCRIPTION
### What is this PR for?
Removes GetNodesInfoMapCopy() from the cache and updates the caller to use only lock-free methods, as the scheduler cache lock needs to be held when accessing the node map.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1245

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
