### PR TITLE
[YUNIKORN-1274] Remove FailedScheduling pod events from predicate logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ go 1.16
 
 require (
 	github.com/GoogleCloudPlatform/spark-on-k8s-operator v0.0.0-20201215015655-2e8b733f5ad0
-	github.com/apache/yunikorn-core v0.0.0-20220628030259-fc1bdfff2a54
+	github.com/apache/yunikorn-core v0.0.0-20220729163128-c6faba228dcc
 	github.com/apache/yunikorn-scheduler-interface v0.0.0-20220610073228-3b5a637363ab
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/apache/yunikorn-core v0.0.0-20220628030259-fc1bdfff2a54 h1:SULjgMW0xqsXS6ijzXLNQsxMYfqGm03HvHZH0t9gEvo=
-github.com/apache/yunikorn-core v0.0.0-20220628030259-fc1bdfff2a54/go.mod h1:ZMAqWCxUthmsgOuHFd8R0OnrqTCezDasHqBc1s9ff4k=
+github.com/apache/yunikorn-core v0.0.0-20220729163128-c6faba228dcc h1:V2XSbDlP5YeRqL7yK9+zzpGHkC20vgG7ntEquBANIfA=
+github.com/apache/yunikorn-core v0.0.0-20220729163128-c6faba228dcc/go.mod h1:ZMAqWCxUthmsgOuHFd8R0OnrqTCezDasHqBc1s9ff4k=
 github.com/apache/yunikorn-scheduler-interface v0.0.0-20220610073228-3b5a637363ab h1:8h/meaIa7Ijy3Z1yiwqfoHx9pETZODMsheVqkYH/jXA=
 github.com/apache/yunikorn-scheduler-interface v0.0.0-20220610073228-3b5a637363ab/go.mod h1:Pboapmj82OLjl65yVNaKit1l0Jd1GJrSUaUVr13h68s=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/pkg/plugin/predicates/predicate_manager.go
+++ b/pkg/plugin/predicates/predicate_manager.go
@@ -41,7 +41,6 @@ import (
 	fwruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 
 	"github.com/apache/yunikorn-core/pkg/log"
-	"github.com/apache/yunikorn-k8shim/pkg/common/events"
 )
 
 type PredicateManager interface {
@@ -75,12 +74,7 @@ func (p *predicateManagerImpl) predicatesReserve(pod *v1.Pod, node *framework.No
 func (p *predicateManagerImpl) predicatesAllocate(pod *v1.Pod, node *framework.NodeInfo) (plugin string, error error) {
 	ctx := context.Background()
 	state := framework.NewCycleState()
-	plugin, err := p.podFitsNode(ctx, state, *p.allocationPreFilters, *p.allocationFilters, pod, node)
-	if err != nil {
-		events.GetRecorder().Eventf(pod.DeepCopy(), nil, v1.EventTypeWarning,
-			"FailedScheduling", "FailedScheduling", "predicate is not satisfied, error: %s", err.Error())
-	}
-	return plugin, err
+	return p.podFitsNode(ctx, state, *p.allocationPreFilters, *p.allocationFilters, pod, node)
 }
 
 func (p *predicateManagerImpl) podFitsNode(ctx context.Context, state *framework.CycleState, preFilters []framework.PreFilterPlugin, filters []framework.FilterPlugin, pod *v1.Pod, node *framework.NodeInfo) (plugin string, error error) {

--- a/test/e2e/basic_scheduling/basic_scheduling_test.go
+++ b/test/e2e/basic_scheduling/basic_scheduling_test.go
@@ -96,7 +96,6 @@ var _ = ginkgo.Describe("", func() {
 		gomega.Ω(allocations["partition"]).NotTo(gomega.BeNil())
 		gomega.Ω(allocations["uuid"]).NotTo(gomega.BeNil())
 		gomega.Ω(allocations["applicationId"]).To(gomega.Equal(sleepRespPod.ObjectMeta.Labels["applicationId"]))
-		gomega.Ω(allocations["queueName"]).To(gomega.ContainSubstring(sleepRespPod.ObjectMeta.Namespace))
 		core := sleepRespPod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 		mem := sleepRespPod.Spec.Containers[0].Resources.Requests.Memory().Value()
 		resMap, ok := allocations["resource"].(map[string]interface{})

--- a/test/e2e/predicates/predicates_suite_test.go
+++ b/test/e2e/predicates/predicates_suite_test.go
@@ -86,3 +86,5 @@ var HaveOccurred = gomega.HaveOccurred
 var MatchRegexp = gomega.MatchRegexp
 var BeZero = gomega.BeZero
 var BeEquivalentTo = gomega.BeEquivalentTo
+var ContainElement = gomega.ContainElement
+var HaveKeyWithValue = gomega.HaveKeyWithValue

--- a/test/e2e/state_aware_app_scheduling/fallback_test.go
+++ b/test/e2e/state_aware_app_scheduling/fallback_test.go
@@ -91,7 +91,6 @@ var _ = Describe("FallbackTest:", func() {
 		Ω(allocations["partition"]).NotTo(BeNil())
 		Ω(allocations["uuid"]).NotTo(BeNil())
 		Ω(allocations["applicationId"]).To(Equal(sleepRespPod.ObjectMeta.Labels["applicationId"]))
-		Ω(allocations["queueName"]).To(ContainSubstring(sleepRespPod.ObjectMeta.Namespace))
 		core := sleepRespPod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 		mem := sleepRespPod.Spec.Containers[0].Resources.Requests.Memory().Value()
 		res, ok := allocations["resource"].(map[string]interface{})


### PR DESCRIPTION
### What is this PR for?

Removes a confusing warning emitted as Pod event when predicates don't match a pod with a node. As this is a normal, expected occurrence, these warnings are confusing.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1274

### How should this be tested?
No functional changes, but e2e tests have been updated to use the REST API to retrieve these events.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
