### PR TITLE
[YUNIKORN-1256] license issues in deployments examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,14 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+--------------------------------------------------------------------------------
+This product bundles various third-party components under other open source
+licenses. This section summarizes those components and their licenses.
+
+
+Apache Software Foundation License 2.0
+--------------------------------------
+
+deployments/examples/tfjob/dist_mnist.py
+deployments/examples/tfjob/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,9 @@ OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 license-check:
 	@echo "checking license headers:"
 ifeq (darwin,$(OS))
-	$(shell find -E . -not -path "./.git*" -regex ".*\.(go|sh|md|yaml|yml|mod)" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES)
+	$(shell find -E . -not -path "./.git*" -regex ".*\.(go|sh|md|conf|yaml|yml|html|mod)" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES)
 else
-	$(shell find . -not -path "./.git*" -regex ".*\.\(go\|sh\|md\|yaml\|yml\|mod\)" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES)
+	$(shell find . -not -path "./.git*" -regex ".*\.\(go\|sh\|md\|conf\|yaml\|yml\|html\|mod\)" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES)
 endif
 	@if [ -s LICRES ]; then \
 		echo "following files are missing license header:" ; \
@@ -142,6 +142,7 @@ endif
 		exit 1; \
 	fi ; \
 	rm -f LICRES
+	@echo "  all OK"
 
 .PHONY: run
 run: build

--- a/deployments/image/webtest/nginx/index.html
+++ b/deployments/image/webtest/nginx/index.html
@@ -1,3 +1,20 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one
+ - or more contributor license agreements.  See the NOTICE file
+ - distributed with this work for additional information
+ - regarding copyright ownership.  The ASF licenses this file
+ - to you under the Apache License, Version 2.0 (the
+ - "License"); you may not use this file except in compliance
+ - with the License.  You may obtain a copy of the License at
+ -
+ -      http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+-->
 <!DOCTYPE html>
 <html lang="en">
 <body>

--- a/deployments/image/webtest/nginx/nginx.conf
+++ b/deployments/image/webtest/nginx/nginx.conf
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 worker_processes  auto;
 daemon            off;
 error_log         /tmp/nginx-error.log crit;


### PR DESCRIPTION
### What is this PR for?
In the k8shim the tfjob contains files that are not part of Apache. The
LICENSE file should show this. It also should show correctly in the
source release and be merged as part of the release build.

Fixing license issues:
- inconsistent formatting (line endings and empty lines)
- missing license in two k8shim files
- update make target to cover new dile types

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
 https://issues.apache.org/jira/browse/YUNIKORN-1256

### How should this be tested?
build locally and ran all updated make targets
