### PR TITLE
[YUNIKORN-1273] Add configurable option to have unique application ids in a namespace

### DIFF
--- a/deployments/scheduler/admission-controller.yaml
+++ b/deployments/scheduler/admission-controller.yaml
@@ -66,6 +66,8 @@ spec:
             value: yunikorn-service
           - name: ENABLE_CONFIG_HOT_REFRESH
             value: "true"
+          - name: ENABLE_AUTOGEN_UNIQUE_APP_ID
+            value: "false"
           - name: ADMISSION_CONTROLLER_NAMESPACE
             valueFrom:
               fieldRef:

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -41,6 +41,8 @@ const AppTagStateAwareDisable = "application.stateaware.disable"
 const DefaultAppNamespace = "default"
 const DefaultUserLabel = "yunikorn.apache.org/username"
 const DefaultUser = "nobody"
+const EnableAutogenUniqueAppId = "ENABLE_AUTOGEN_UNIQUE_APP_ID"
+const True = "true"
 
 // Resource
 const Memory = "memory"


### PR DESCRIPTION
### What is this PR for?
Ability to configure autogenerated application ids. Currently if the app id is not specified, yunikorn generates the application id with the name 'yunikorn-<name_space>-autogen' and all the pods with no application id are bundled under that name. This change adds an option to have unique auto-generated names. Appends timestamp after the namespace name to make it unique.

By default this option is not enabled and will be only turned on for specific use-cases where the user requires it.


### What type of PR is it?
- Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1273

### How should this be tested?
During deployment, change the value of environment variable 'ENABLE_AUTOGEN_UNIQUE_APP_ID' in the admission-controller.yaml to 'true'. For any apps that are scheduled without app id, should get unique application id in the following format: <namespace>_<timestamp>. eg: if namespace is default, app id will be 'default_1662060985351413000'
