### PR TITLE
[YUNIKORN-1305] git sha label substitution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ DOCKER_ARCH := amd64
 endif
 
 # Image hashes
-CORE_SHA=$$(go list -m "github.com/apache/yunikorn-core" | cut -d "-" -f4)
-SI_SHA=$$(go list -m "github.com/apache/yunikorn-scheduler-interface" | cut -d "-" -f5)
-SHIM_SHA=$$(git rev-parse --short=12 HEAD)
+CORE_SHA=$(shell go list -m "github.com/apache/yunikorn-core" | cut -d "-" -f4)
+SI_SHA=$(shell go list -m "github.com/apache/yunikorn-scheduler-interface" | cut -d "-" -f5)
+SHIM_SHA=$(shell git rev-parse --short=12 HEAD)
 
 # Kubeconfig
 ifeq ($(KUBECONFIG),)


### PR DESCRIPTION
### What is this PR for?
The sha label on the image is not set correctly during local builds and
as part of the release process.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1305

### How should this be tested?
The image should contain labels called "yunikorn-*-revision" with a sha reference and not empty or a command
