### PR TITLE
[YUNIKORN-1314] The current UserkeyLabel is showed in log when user name couldn't be found in pod's labels.

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -240,18 +240,21 @@ func MergeMaps(first, second map[string]string) map[string]string {
 // find user name from pod label
 func GetUserFromPod(pod *v1.Pod) string {
 	userLabelKey := conf.GetSchedulerConf().UserLabelKey
-	// User name to be defined in labels
-	for name, value := range pod.Labels {
-		if name == userLabelKey {
-			log.Logger().Info("Found user name from pod labels.",
-				zap.String("userLabel", userLabelKey), zap.String("user", value))
-			return value
-		}
+	// UserLabelKey should not be empty
+	if len(userLabelKey) == 0 {
+		userLabelKey = constants.DefaultUserLabel
+		log.Logger().Debug("userLabelKey is empty and replaced by default setting",
+			zap.String("userLabel", userLabelKey))
 	}
-	value := constants.DefaultUser
 
+	// User name to be defined in labels
+	if username, ok := pod.Labels[userLabelKey]; ok {
+		log.Logger().Info("Found user name from pod labels.",
+			zap.String("userLabel", userLabelKey), zap.String("user", username))
+		return username
+	}
 	log.Logger().Debug("Unable to retrieve user name from pod labels. Empty user label",
-		zap.String("userLabel", constants.DefaultUserLabel))
+		zap.String("userLabel", userLabelKey))
 
-	return value
+	return constants.DefaultUser
 }

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -244,16 +244,16 @@ func GetUserFromPod(pod *v1.Pod) string {
 	if len(userLabelKey) == 0 {
 		userLabelKey = constants.DefaultUserLabel
 	}
-
-	username := constants.DefaultUser
 	// User name to be defined in labels
 	if username, ok := pod.Labels[userLabelKey]; ok {
 		log.Logger().Info("Found user name from pod labels.",
 			zap.String("userLabel", userLabelKey), zap.String("user", username))
 		return username
 	}
+	value := constants.DefaultUser
+
 	log.Logger().Debug("Unable to retrieve user name from pod labels. Empty user label",
 		zap.String("userLabel", userLabelKey))
 
-	return username
+	return value
 }

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -245,7 +245,7 @@ func GetUserFromPod(pod *v1.Pod) string {
 		userLabelKey = constants.DefaultUserLabel
 	}
 
-        username := constants.DefaultUser
+	username := constants.DefaultUser
 	// User name to be defined in labels
 	if username, ok := pod.Labels[userLabelKey]; ok {
 		log.Logger().Info("Found user name from pod labels.",

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -243,10 +243,9 @@ func GetUserFromPod(pod *v1.Pod) string {
 	// UserLabelKey should not be empty
 	if len(userLabelKey) == 0 {
 		userLabelKey = constants.DefaultUserLabel
-		log.Logger().Debug("userLabelKey is empty and replaced by default setting",
-			zap.String("userLabel", userLabelKey))
 	}
 
+        username := constants.DefaultUser
 	// User name to be defined in labels
 	if username, ok := pod.Labels[userLabelKey]; ok {
 		log.Logger().Info("Found user name from pod labels.",
@@ -256,5 +255,5 @@ func GetUserFromPod(pod *v1.Pod) string {
 	log.Logger().Debug("Unable to retrieve user name from pod labels. Empty user label",
 		zap.String("userLabel", userLabelKey))
 
-	return constants.DefaultUser
+	return username
 }

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -245,7 +245,7 @@ func GetUserFromPod(pod *v1.Pod) string {
 		userLabelKey = constants.DefaultUserLabel
 	}
 	// User name to be defined in labels
-	if username, ok := pod.Labels[userLabelKey]; ok {
+	if username, ok := pod.Labels[userLabelKey]; ok && len(username) > 0 {
 		log.Logger().Info("Found user name from pod labels.",
 			zap.String("userLabel", userLabelKey), zap.String("user", username))
 		return username

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -537,6 +537,11 @@ func TestGetUserFromPod(t *testing.T) {
 				Labels: map[string]string{constants.DefaultUserLabel: userInLabel},
 			},
 		}, userInLabel},
+		{"The length of UserKeyLabel value is 0", constants.DefaultUserLabel, &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{customUserKeyLabel: ""},
+			},
+		}, userNotInLabel},
 		{"User not defined in label", constants.DefaultUserLabel, &v1.Pod{}, userNotInLabel},
 		{"UserKeyLabel is empty and the user definded in the pod labels with default key", "", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -555,12 +555,14 @@ func TestGetUserFromPod(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			conf := conf.GetSchedulerConf()
+			// The default UserLabelKey could be set with the custom UserLabelKey.
 			if tc.userLabelKey != constants.DefaultUserLabel {
 				conf.UserLabelKey = tc.userLabelKey
 			}
 
 			userID := GetUserFromPod(tc.pod)
 			assert.DeepEqual(t, userID, tc.expectedUser)
+			// The order of test cases is allowed to impact other test case.
 			conf.UserLabelKey = constants.DefaultUserLabel
 		})
 	}

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/apache/yunikorn-k8shim/pkg/common"
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
@@ -524,23 +525,43 @@ func TestMergeMaps(t *testing.T) {
 func TestGetUserFromPod(t *testing.T) {
 	userInLabel := "testuser"
 	userNotInLabel := constants.DefaultUser
+	customUserKeyLabel := "test"
 	testCases := []struct {
 		name         string
+		userLabelKey string
 		pod          *v1.Pod
 		expectedUser string
 	}{
-		{"User defined in label with default key", &v1.Pod{
+		{"User defined in label with default key", constants.DefaultUserLabel, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{constants.DefaultUserLabel: userInLabel},
 			},
 		}, userInLabel},
-		{"User not defined in label", &v1.Pod{}, userNotInLabel},
+		{"User not defined in label", constants.DefaultUserLabel, &v1.Pod{}, userNotInLabel},
+		{"UserKeyLabel is empty and the user definded in the pod labels with default key", "", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{constants.DefaultUserLabel: userInLabel},
+			},
+		}, userInLabel},
+		{"UserKeyLabel is empty and the user isn't defined in the pod labels", "", &v1.Pod{}, userNotInLabel},
+		{"UserKeyLabel is changed and the user definded in the pod labels", customUserKeyLabel, &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{customUserKeyLabel: userInLabel},
+			},
+		}, userInLabel},
+		{"UserKeyLabel is changed and the user isn't defined in the pod labels", customUserKeyLabel, &v1.Pod{}, userNotInLabel},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			conf := conf.GetSchedulerConf()
+			if tc.userLabelKey != constants.DefaultUserLabel {
+				conf.UserLabelKey = tc.userLabelKey
+			}
+
 			userID := GetUserFromPod(tc.pod)
 			assert.DeepEqual(t, userID, tc.expectedUser)
+			conf.UserLabelKey = constants.DefaultUserLabel
 		})
 	}
 }


### PR DESCRIPTION
### What is this PR for?
1.  The iteration is not required for searching userLabelKey.
2.  The logger adopting debug level show the current userLabelKey
3.  The userLabelKey would be replaced by the default userLabelKey when the userLabelKey returned from the configuration is empty.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1314

### How should this be tested?
Pods' labels contains userLabelKey and the username rule is added to the partition.
```
metadata:
  labels:
    app: nginx
    applicationId: "username-rule-example02"
    yunikorn.apache.org/username: developer
  name: task1
spec:
  schedulerName: yunikorn
```

```
  partitions:
    -
      name: default
      placementrules:
        - name: user
          create: true
        - name: tag
          value: namespace
          create: true
      queues:
        - name: root
          submitacl: '*'
```

### Screenshots (if appropriate)
For example, an user, called developer, owns a pod. 
The queue doesn't exist or the queue label is not added in the pod.
The pod would be assigned to root.developer.
<img width="1512" alt="截圖 2022-09-09 下午11 24 30" src="https://user-images.githubusercontent.com/45888688/189388641-d9c974db-9855-4bf9-80ab-56a8879b3e38.png">

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
