### PR TITLE
[YUNIKORN-1375] [shim] pass group info from the shim to the core

### DIFF
--- a/pkg/appmgmt/interfaces/amprotocol.go
+++ b/pkg/appmgmt/interfaces/amprotocol.go
@@ -77,6 +77,7 @@ type ApplicationMetadata struct {
 	QueueName                  string
 	User                       string
 	Tags                       map[string]string
+	Groups                     []string
 	TaskGroups                 []v1alpha1.TaskGroup
 	OwnerReferences            []metav1.OwnerReference
 	SchedulingPolicyParameters *SchedulingPolicyParameters

--- a/pkg/cache/amprotocol_mock.go
+++ b/pkg/cache/amprotocol_mock.go
@@ -55,6 +55,7 @@ func (m *MockedAMProtocol) AddApplication(request *interfaces.AddApplicationRequ
 		request.Metadata.ApplicationID,
 		request.Metadata.QueueName,
 		request.Metadata.User,
+		request.Metadata.Groups,
 		request.Metadata.Tags,
 		test.NewSchedulerAPIMock())
 	app.setPlaceholderOwnerReferences(request.Metadata.OwnerReferences)

--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -47,6 +47,7 @@ type Application struct {
 	queue                      string
 	partition                  string
 	user                       string
+	groups                     []string
 	taskMap                    map[string]*Task
 	tags                       map[string]string
 	schedulingPolicy           v1alpha1.SchedulingPolicy
@@ -69,13 +70,14 @@ func (app *Application) String() string {
 		app.applicationID, app.queue, app.partition, len(app.taskMap), app.GetApplicationState())
 }
 
-func NewApplication(appID, queueName, user string, tags map[string]string, scheduler api.SchedulerAPI) *Application {
+func NewApplication(appID, queueName, user string, groups []string, tags map[string]string, scheduler api.SchedulerAPI) *Application {
 	taskMap := make(map[string]*Task)
 	app := &Application{
 		applicationID:           appID,
 		queue:                   queueName,
 		partition:               constants.DefaultPartition,
 		user:                    user,
+		groups:                  groups,
 		taskMap:                 taskMap,
 		tags:                    tags,
 		schedulingPolicy:        v1alpha1.SchedulingPolicy{},
@@ -420,7 +422,8 @@ func (app *Application) handleSubmitApplicationEvent() {
 					QueueName:     app.queue,
 					PartitionName: app.partition,
 					Ugi: &si.UserGroupInformation{
-						User: app.user,
+						User:   app.user,
+						Groups: app.groups,
 					},
 					Tags:                         app.tags,
 					PlaceholderAsk:               app.placeholderAsk,
@@ -450,7 +453,8 @@ func (app *Application) handleRecoverApplicationEvent() {
 					QueueName:     app.queue,
 					PartitionName: app.partition,
 					Ugi: &si.UserGroupInformation{
-						User: app.user,
+						User:   app.user,
+						Groups: app.groups,
 					},
 					Tags:                         app.tags,
 					PlaceholderAsk:               app.placeholderAsk,

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -616,6 +616,7 @@ func (ctx *Context) AddApplication(request *interfaces.AddApplicationRequest) in
 		request.Metadata.ApplicationID,
 		request.Metadata.QueueName,
 		request.Metadata.User,
+		request.Metadata.Groups,
 		request.Metadata.Tags,
 		ctx.apiProvider.GetAPIs().SchedulerAPI)
 	app.setTaskGroups(request.Metadata.TaskGroups)

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -47,6 +47,10 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
+var (
+	testGroups = []string{"dev", "yunikorn"}
+)
+
 func initContextForTest() *Context {
 	conf.GetSchedulerConf().SetTestMode(true)
 	context := NewContext(client.NewMockedAPIProvider(false))
@@ -147,9 +151,9 @@ func TestRemoveApplication(t *testing.T) {
 	appID1 := "app00001"
 	appID2 := "app00002"
 	appID3 := "app00003"
-	app1 := NewApplication(appID1, "root.a", "testuser", map[string]string{}, newMockSchedulerAPI())
-	app2 := NewApplication(appID2, "root.b", "testuser", map[string]string{}, newMockSchedulerAPI())
-	app3 := NewApplication(appID3, "root.c", "testuser", map[string]string{}, newMockSchedulerAPI())
+	app1 := NewApplication(appID1, "root.a", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
+	app2 := NewApplication(appID2, "root.b", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
+	app3 := NewApplication(appID3, "root.c", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
 	context.applications[appID1] = app1
 	context.applications[appID2] = app2
 	context.applications[appID3] = app3
@@ -217,8 +221,8 @@ func TestRemoveApplicationInternal(t *testing.T) {
 	context := initContextForTest()
 	appID1 := "app00001"
 	appID2 := "app00002"
-	app1 := NewApplication(appID1, "root.a", "testuser", map[string]string{}, newMockSchedulerAPI())
-	app2 := NewApplication(appID2, "root.b", "testuser", map[string]string{}, newMockSchedulerAPI())
+	app1 := NewApplication(appID1, "root.a", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
+	app2 := NewApplication(appID2, "root.b", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
 	context.applications[appID1] = app1
 	context.applications[appID2] = app2
 	assert.Equal(t, len(context.applications), 2)
@@ -761,9 +765,9 @@ func TestGetTask(t *testing.T) {
 	appID1 := "app00001"
 	appID2 := "app00002"
 	appID3 := "app00003"
-	app1 := NewApplication(appID1, "root.a", "testuser", map[string]string{}, newMockSchedulerAPI())
-	app2 := NewApplication(appID2, "root.b", "testuser", map[string]string{}, newMockSchedulerAPI())
-	app3 := NewApplication(appID3, "root.c", "testuser", map[string]string{}, newMockSchedulerAPI())
+	app1 := NewApplication(appID1, "root.a", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
+	app2 := NewApplication(appID2, "root.b", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
+	app3 := NewApplication(appID3, "root.c", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
 	context.applications[appID1] = app1
 	context.applications[appID2] = app2
 	context.applications[appID3] = app3

--- a/pkg/cache/placeholder_manager_test.go
+++ b/pkg/cache/placeholder_manager_test.go
@@ -127,7 +127,7 @@ func TestCreateAppPlaceholdersWithOwnReference(t *testing.T) {
 func createAppWIthTaskGroupForTest() *Application {
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication(appID, queue,
-		"bob", map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
 	app.setTaskGroups([]v1alpha1.TaskGroup{
 		{
 			Name:      "test-group-1",
@@ -208,7 +208,7 @@ func TestCleanUp(t *testing.T) {
 	mockedContext := initContextForTest()
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication(appID, queue,
-		"bob", map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
 	mockedContext.applications[appID] = app
 	res := app.getNonTerminatedTaskAlias()
 	assert.Equal(t, len(res), 0)

--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -41,7 +41,7 @@ func TestNewPlaceholder(t *testing.T) {
 	)
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication(appID, queue, "bob",
-		map[string]string{constants.AppTagNamespace: namespace, constants.AppTagImagePullSecrets: "secret1,secret2"},
+		testGroups, map[string]string{constants.AppTagNamespace: namespace, constants.AppTagImagePullSecrets: "secret1,secret2"},
 		mockedSchedulerAPI)
 	app.setTaskGroups([]v1alpha1.TaskGroup{
 		{
@@ -85,7 +85,7 @@ func TestNewPlaceholderWithLabelsAndAnnotations(t *testing.T) {
 	)
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication(appID, queue,
-		"bob", map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
 	taskGroups := []v1alpha1.TaskGroup{
 		{
 			Name:      "test-group-1",
@@ -131,7 +131,7 @@ func TestNewPlaceholderWithNodeSelectors(t *testing.T) {
 	)
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication(appID, queue,
-		"bob", map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
 	app.setTaskGroups([]v1alpha1.TaskGroup{
 		{
 			Name:      "test-group-1",
@@ -161,7 +161,7 @@ func TestNewPlaceholderWithTolerations(t *testing.T) {
 	)
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication(appID, queue,
-		"bob", map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
 	app.setTaskGroups([]v1alpha1.TaskGroup{
 		{
 			Name:      "test-group-1",
@@ -198,7 +198,7 @@ func TestNewPlaceholderWithAffinity(t *testing.T) {
 	)
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication(appID, queue,
-		"bob", map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
 	app.setTaskGroups([]v1alpha1.TaskGroup{
 		{
 			Name:      "test-group-1",
@@ -252,13 +252,13 @@ func TestNewPlaceholderTaskGroupsDefinition(t *testing.T) {
 		},
 	}
 	app := NewApplication(appID, queue,
-		"bob", map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
 	app.setTaskGroups(taskGroup)
 	holder := newPlaceholder("ph-name", app, app.taskGroups[0])
 	assert.Equal(t, "", holder.pod.Annotations[constants.AnnotationTaskGroups])
 
 	app = NewApplication(appID, queue,
-		"bob", map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
 	app.setTaskGroups(taskGroup)
 	app.setTaskGroupsDefinition("taskGroupsDef")
 	holder = newPlaceholder("ph-name", app, app.taskGroups[0])

--- a/pkg/cache/task_graphviz_test.go
+++ b/pkg/cache/task_graphviz_test.go
@@ -35,7 +35,7 @@ func TestTaskFsmGraph(t *testing.T) {
 	mockedContext := initContextForTest()
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication("app01", "root.default",
-		"bob", map[string]string{}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{}, mockedSchedulerAPI)
 
 	// pod has timestamp defined
 	pod := &v1.Pod{

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -65,7 +65,7 @@ func TestTaskStateTransitions(t *testing.T) {
 	}
 
 	app := NewApplication("app01", "root.default",
-		"bob", map[string]string{}, mockedSchedulerApi)
+		"bob", testGroups, map[string]string{}, mockedSchedulerApi)
 	task := NewTask("task01", app, mockedContext, pod)
 	assert.Equal(t, task.GetTaskState(), TaskStates().New)
 
@@ -126,7 +126,7 @@ func TestTaskIllegalEventHandling(t *testing.T) {
 	}
 
 	app := NewApplication("app01", "root.default",
-		"bob", map[string]string{}, mockedSchedulerApi)
+		"bob", testGroups, map[string]string{}, mockedSchedulerApi)
 	task := NewTask("task01", app, mockedContext, pod)
 	assert.Equal(t, task.GetTaskState(), TaskStates().New)
 
@@ -177,7 +177,7 @@ func TestReleaseTaskAllocation(t *testing.T) {
 	}
 
 	app := NewApplication("app01", "root.default",
-		"bob", map[string]string{}, mockedSchedulerApi)
+		"bob", testGroups, map[string]string{}, mockedSchedulerApi)
 	task := NewTask("task01", app, mockedContext, pod)
 	assert.Equal(t, task.GetTaskState(), TaskStates().New)
 
@@ -261,7 +261,7 @@ func TestReleaseTaskAsk(t *testing.T) {
 	}
 
 	app := NewApplication("app01", "root.default",
-		"bob", map[string]string{}, mockedSchedulerApi)
+		"bob", testGroups, map[string]string{}, mockedSchedulerApi)
 	task := NewTask("task01", app, mockedContext, pod)
 	assert.Equal(t, task.GetTaskState(), TaskStates().New)
 
@@ -305,7 +305,7 @@ func TestCreateTask(t *testing.T) {
 	mockedContext := initContextForTest()
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication("app01", "root.default",
-		"bob", map[string]string{}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{}, mockedSchedulerAPI)
 
 	// pod has timestamp defined
 	pod0 := &v1.Pod{
@@ -349,7 +349,7 @@ func TestSortTasks(t *testing.T) {
 	mockedContext := initContextForTest()
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication("app01", "root.default",
-		"bob", map[string]string{}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{}, mockedSchedulerAPI)
 
 	pod0 := &v1.Pod{
 		TypeMeta: apis.TypeMeta{
@@ -405,7 +405,7 @@ func TestIsTerminated(t *testing.T) {
 	mockedContext := initContextForTest()
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication("app01", "root.default",
-		"bob", map[string]string{}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{}, mockedSchedulerAPI)
 	pod := &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
@@ -432,7 +432,7 @@ func TestSetTaskGroup(t *testing.T) {
 	mockedContext := initContextForTest()
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication("app01", "root.default",
-		"bob", map[string]string{}, mockedSchedulerAPI)
+		"bob", testGroups, map[string]string{}, mockedSchedulerAPI)
 	pod := &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
@@ -501,7 +501,7 @@ func TestHandleSubmitTaskEvent(t *testing.T) {
 		},
 	}
 	appID := "app-test-001"
-	app := NewApplication(appID, "root.abc", "testuser", map[string]string{}, mockedSchedulerAPI)
+	app := NewApplication(appID, "root.abc", "testuser", testGroups, map[string]string{}, mockedSchedulerAPI)
 	task1 := NewTask("task01", app, mockedContext, pod1)
 	task2 := NewTask("task02", app, mockedContext, pod2)
 	task1.sm.SetState(TaskStates().Pending)
@@ -560,7 +560,7 @@ func TestSimultaneousTaskCompleteAndAllocate(t *testing.T) {
 	}
 
 	// simulate app has one task waiting for core's allocation
-	app := NewApplication(appID, queueName, "user", map[string]string{}, mockedAPIProvider.GetAPIs().SchedulerAPI)
+	app := NewApplication(appID, queueName, "user", testGroups, map[string]string{}, mockedAPIProvider.GetAPIs().SchedulerAPI)
 	task1 := NewTask(podUID, app, mockedContext, pod1)
 	task1.sm.SetState(TaskStates().Scheduling)
 

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -179,7 +179,7 @@ func (fc *MockScheduler) removeApplication(appId string) error {
 }
 
 func (fc *MockScheduler) newApplication(appID, queueName string) *cache.Application {
-	app := cache.NewApplication(appID, queueName, "testuser", map[string]string{}, fc.apiProvider.GetAPIs().SchedulerAPI)
+	app := cache.NewApplication(appID, queueName, "testuser", []string{"dev"}, map[string]string{}, fc.apiProvider.GetAPIs().SchedulerAPI)
 	return app
 }
 


### PR DESCRIPTION
### What is this PR for?
The list of groups in `si.AddApplicationRequest` is not passed from the shim to core.
We need to make sure that we store the group inside the `Application` object and pass them when needed.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1375

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
