### PR TITLE
[YUNIKORN-1382] Update nginx tag in example yaml

### DIFF
--- a/deployments/examples/admission-controller-tests/nginx-yk.yaml
+++ b/deployments/examples/admission-controller-tests/nginx-yk.yaml
@@ -41,7 +41,7 @@ spec:
       schedulerName: yunikorn
       containers:
         - name: nginx
-          image: "nginx:1.11.1-alpine"
+          image: "nginx:latest"
           resources:
             requests:
               cpu: "500m"

--- a/deployments/examples/admission-controller-tests/nginx-yk.yaml
+++ b/deployments/examples/admission-controller-tests/nginx-yk.yaml
@@ -41,7 +41,7 @@ spec:
       schedulerName: yunikorn
       containers:
         - name: nginx
-          image: "nginx:latest"
+          image: "nginx:stable-alpine"
           resources:
             requests:
               cpu: "500m"

--- a/deployments/examples/admission-controller-tests/nginx.yaml
+++ b/deployments/examples/admission-controller-tests/nginx.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: "nginx:latest"
+          image: "nginx:stable-alpine"
           resources:
             requests:
               cpu: "500m"

--- a/deployments/examples/admission-controller-tests/nginx.yaml
+++ b/deployments/examples/admission-controller-tests/nginx.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: "nginx:1.11.1-alpine"
+          image: "nginx:latest"
           resources:
             requests:
               cpu: "500m"

--- a/deployments/examples/nginx/nginx.yaml
+++ b/deployments/examples/nginx/nginx.yaml
@@ -37,7 +37,7 @@ spec:
       schedulerName: yunikorn
       containers:
         - name: nginx
-          image: "nginx:1.11.1-alpine"
+          image: "nginx:latest"
           resources:
             requests:
               cpu: "500m"

--- a/deployments/examples/nginx/nginx.yaml
+++ b/deployments/examples/nginx/nginx.yaml
@@ -37,7 +37,7 @@ spec:
       schedulerName: yunikorn
       containers:
         - name: nginx
-          image: "nginx:latest"
+          image: "nginx:stable-alpine"
           resources:
             requests:
               cpu: "500m"


### PR DESCRIPTION
### What is this PR for?
I use containerd as CRI in kubernetes
I found the nginx tag -- 'nginx:1.11.1-alpine' is too old for containerd to pull
Therefore, I update the nginx tag to 'nginx:latest'

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1382/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)
It's ok for docker to pull 'nginx:1.11.1-alpline', but containerd can't
![{75CF307D-CDBC-4020-87B9-588628E12182}](https://user-images.githubusercontent.com/48400525/199742504-e8866a66-2d74-43c8-90dd-bd50d54d3404.png)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
