### PR TITLE
[YUNIKORN-1320] [shim] Handle new userInfo annotation

### DIFF
--- a/pkg/appmgmt/general/metadata.go
+++ b/pkg/appmgmt/general/metadata.go
@@ -92,7 +92,7 @@ func getAppMetadata(pod *v1.Pod, recovery bool) (interfaces.ApplicationMetadata,
 	}
 
 	// get the user from Pod Labels
-	user := utils.GetUserFromPod(pod)
+	user, groups := utils.GetUserFromPod(pod)
 
 	var taskGroups []v1alpha1.TaskGroup = nil
 	if !conf.GetSchedulerConf().DisableGangScheduling {
@@ -121,6 +121,7 @@ func getAppMetadata(pod *v1.Pod, recovery bool) (interfaces.ApplicationMetadata,
 		ApplicationID:              appID,
 		QueueName:                  utils.GetQueueNameFromPod(pod),
 		User:                       user,
+		Groups:                     groups,
 		Tags:                       tags,
 		TaskGroups:                 taskGroups,
 		OwnerReferences:            ownerReferences,

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -522,7 +522,7 @@ func TestMergeMaps(t *testing.T) {
 	assert.Equal(t, result["d"], "d2")
 }
 
-func TestGetUserFromPod(t *testing.T) {
+func TestGetUserFromPodLabel(t *testing.T) {
 	userInLabel := "testuser"
 	userNotInLabel := constants.DefaultUser
 	customUserKeyLabel := "test"
@@ -565,10 +565,49 @@ func TestGetUserFromPod(t *testing.T) {
 				conf.UserLabelKey = tc.userLabelKey
 			}
 
-			userID := GetUserFromPod(tc.pod)
+			userID, _ := GetUserFromPod(tc.pod)
 			assert.DeepEqual(t, userID, tc.expectedUser)
 			// The order of test cases is allowed to impact other test case.
 			conf.UserLabelKey = constants.DefaultUserLabel
+		})
+	}
+}
+
+func TestGetUserFromPodAnnotation(t *testing.T) {
+	const userAndGroups = "{\"user\":\"test\",\"groups\":[\"devops\",\"test\"]}"
+	const emptyUserAndGroups = "{\"user\":\"\",\"groups\":[\"devops\",\"test\"]}"
+
+	testCases := []struct {
+		name           string
+		pod            *v1.Pod
+		expectedUser   string
+		expectedGroups []string
+	}{
+		{"User/groups properly defined", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					userInfoKey: userAndGroups},
+			},
+		}, "test", []string{"devops", "test"}},
+		{"Empty username", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					userInfoKey: emptyUserAndGroups},
+			},
+		}, "nobody", []string{"devops", "test"}},
+		{"Invalid JSON", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					userInfoKey: "xyzxyz"},
+			},
+		}, "nobody", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			userID, groups := GetUserFromPod(tc.pod)
+			assert.DeepEqual(t, userID, tc.expectedUser)
+			assert.DeepEqual(t, groups, tc.expectedGroups)
 		})
 	}
 }


### PR DESCRIPTION
### What is this PR for?
Add code which can extract the user-group info from the new annotation.
For backwards compatbility, the original user label is still checked if the annotation is missing.  

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1320

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
