### PR TITLE
[YUNIKORN-1391] Use consistent locking in shim node cache

### DIFF
--- a/pkg/cache/node_test.go
+++ b/pkg/cache/node_test.go
@@ -65,10 +65,16 @@ func TestUpdateOccupiedResource(t *testing.T) {
 		AddResource(siCommon.Memory, 4).
 		AddResource(siCommon.CPU, 4).
 		Build()
-	node.updateOccupiedResource(r1, AddOccupiedResource)
-	assert.DeepEqual(t, node.occupied, r1)
-	node.updateOccupiedResource(r2, SubOccupiedResource)
-	assert.DeepEqual(t, node.occupied, r3)
+
+	capacity, occupied, ready := node.updateOccupiedResource(r1, AddOccupiedResource)
+	assert.DeepEqual(t, capacity, r2)
+	assert.DeepEqual(t, occupied, r1)
+	assert.Assert(t, ready)
+
+	capacity, occupied, ready = node.updateOccupiedResource(r2, SubOccupiedResource)
+	assert.DeepEqual(t, capacity, r2)
+	assert.DeepEqual(t, occupied, r3)
+	assert.Assert(t, ready)
 }
 
 func NewTestSchedulerNode() *SchedulerNode {

--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -135,8 +135,8 @@ func (nc *schedulerNodes) updateNodeOccupiedResources(name string, resource *si.
 	}
 
 	if schedulerNode := nc.getNode(name); schedulerNode != nil {
-		schedulerNode.updateOccupiedResource(resource, opt)
-		request := common.CreateUpdateRequestForUpdatedNode(name, schedulerNode.capacity, schedulerNode.occupied, schedulerNode.ready)
+		capacity, occupied, ready := schedulerNode.updateOccupiedResource(resource, opt)
+		request := common.CreateUpdateRequestForUpdatedNode(name, capacity, occupied, ready)
 		log.Logger().Info("report occupied resources updates",
 			zap.String("node", schedulerNode.name),
 			zap.Any("request", request))
@@ -186,8 +186,9 @@ func (nc *schedulerNodes) updateNode(oldNode, newNode *v1.Node) {
 
 	log.Logger().Info("Node's ready status flag", zap.String("Node name", newNode.Name),
 		zap.Bool("ready", ready))
-	request := common.CreateUpdateRequestForUpdatedNode(newNode.Name, cachedNode.capacity,
-		cachedNode.occupied, cachedNode.ready)
+
+	capacity, occupied, ready := cachedNode.snapshotState()
+	request := common.CreateUpdateRequestForUpdatedNode(newNode.Name, capacity, occupied, ready)
 	log.Logger().Info("report updated nodes to scheduler", zap.Any("request", request))
 	if err := nc.proxy.UpdateNode(&request); err != nil {
 		log.Logger().Info("hitting error while handling UpdateNode", zap.Error(err))


### PR DESCRIPTION
### What is this PR for?
Updates locking in shim's node cache to ensure consistent reads and writes of mutable state.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1391

### How should this be tested?
Tests updated to use new methods.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
