### PR TITLE
YUNIKORN-1390 - MPI Operator Example in k8-shim repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The simplest way to get a local binary that can be run on a local Kubernetes env
 ```
 make build
 ```
-This command will build a binary `k8s_yunikorn_scheduler` under `_output/bin` dir. This binary is executable on local environment, as long as `kubectl` is properly configured.
+This command will build a binary `k8s_yunikorn_scheduler` under `_output/dev` dir. This binary is executable on local environment, as long as `kubectl` is properly configured.
 Run `./k8s_yunikorn_scheduler -help` to see all options.
 
 **Note**: It may take few minutes to run this command for the first time, because it needs to download all dependencies.

--- a/deployments/examples/mpioperator/Pi/README.md
+++ b/deployments/examples/mpioperator/Pi/README.md
@@ -1,3 +1,21 @@
+<!--
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+-->
+
 # MPI Operator
 
 For more details, please read https://github.com/kubeflow/mpi-operator for deploying this operator.

--- a/deployments/examples/mpioperator/Pi/README.md
+++ b/deployments/examples/mpioperator/Pi/README.md
@@ -1,0 +1,18 @@
+# MPI Operator
+
+For more details, please read https://github.com/kubeflow/mpi-operator for deploying this operator.
+
+This example assumes that the mpi operator v2beta is deployed to your kubernetes environment.
+
+# Pure MPI example
+
+This example shows to run a pure MPI application.
+
+The program prints some basic information about the workers.
+Then, it calculates an approximate value for pi.
+
+```
+kubectl create -f pi.yaml
+```
+
+We added Yunikorn labels to the Pi example to demonstrate using the yunikorn scheduler.

--- a/deployments/examples/mpioperator/Pi/pi.yaml
+++ b/deployments/examples/mpioperator/Pi/pi.yaml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Running a PI job using MPIOperator
+
 apiVersion: kubeflow.org/v2beta1
 kind: MPIJob
 metadata:

--- a/deployments/examples/mpioperator/Pi/pi.yaml
+++ b/deployments/examples/mpioperator/Pi/pi.yaml
@@ -1,0 +1,57 @@
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: pi
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: Running
+    ttlSecondsAfterFinished: 60
+  sshAuthMountPath: /home/mpiuser/.ssh
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        labels:
+          applicationId: "mpi_job_pi"
+          queue: root.mpi
+        spec:
+          schedulerName: yunikorn
+          containers:
+          - image: mpioperator/mpi-pi
+            name: mpi-launcher
+            securityContext:
+              runAsUser: 1000
+            command:
+            - mpirun
+            args:
+            - -n
+            - "2"
+            - /home/mpiuser/pi
+            resources:
+              limits:
+                cpu: 1
+                memory: 1Gi
+    Worker:
+      replicas: 2
+      template:
+        labels:
+          applicationId: "mpi_job_pi"
+          queue: root.mpi
+        spec:
+          schedulerName: yunikorn
+          containers:
+          - image: mpioperator/mpi-pi
+            name: mpi-worker
+            securityContext:
+              runAsUser: 1000
+            command:
+            - /usr/sbin/sshd
+            args:
+            - -De
+            - -f
+            - /home/mpiuser/.sshd_config
+            resources:
+              limits:
+                cpu: 1
+                memory: 1Gi

--- a/deployments/examples/sleep/sleeppods.yaml
+++ b/deployments/examples/sleep/sleeppods.yaml
@@ -26,6 +26,7 @@ metadata:
   name: task0
 spec:
   schedulerName: yunikorn
+  restartPolicy: Never
   containers:
     - name: sleep-30s
       image: "alpine:latest"
@@ -45,6 +46,7 @@ metadata:
   name: task1
 spec:
   schedulerName: yunikorn
+  restartPolicy: Never
   containers:
     - name: sleep-30s
       image: "alpine:latest"
@@ -64,6 +66,7 @@ metadata:
   name: task2
 spec:
   schedulerName: yunikorn
+  restartPolicy: Never
   containers:
     - name: sleep-30s
       image: "alpine:latest"


### PR DESCRIPTION
### What is this PR for?

In my researching Yunikorn, I wanted to see if its possible to use MPIJob from Kubeflow with Yunikorn.  

I added an example from the Kubeflow examples and adding some yunikorn annotations.  

This PR adds an example to the deployment/examples repo to show how you could use yunikorn and MPIJob.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

1) Clone Kubeflow mpijob repo.
2) Deploy v2beta controller
3) Run the pi.yaml job
4) Use the UI to view that yunikorn correctly reports the MPIJob

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
