### PR TITLE
[YUNIKORN-1369] Shim: Read configuration from configmaps and deprecate legacy configs

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
+	schedulerconf "github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/dispatcher"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 	"github.com/apache/yunikorn-k8shim/pkg/plugin/predicates"
@@ -55,6 +56,7 @@ type Context struct {
 	predManager    predicates.PredicateManager    // K8s predicates
 	pluginMode     bool                           // true if we are configured as a scheduler plugin
 	namespace      string                         // yunikorn namespace
+	configMaps     []*v1.ConfigMap                // cached yunikorn configmaps
 	lock           *sync.RWMutex                  // lock
 }
 
@@ -68,7 +70,8 @@ func NewContext(apis client.APIProvider) *Context {
 	ctx := &Context{
 		applications: make(map[string]*Application),
 		apiProvider:  apis,
-		namespace:    apis.GetAPIs().Conf.Namespace,
+		namespace:    apis.GetAPIs().GetConf().Namespace,
+		configMaps:   []*v1.ConfigMap{nil, nil},
 		lock:         &sync.RWMutex{},
 	}
 
@@ -280,7 +283,9 @@ func (ctx *Context) filterPods(obj interface{}) bool {
 func (ctx *Context) filterConfigMaps(obj interface{}) bool {
 	switch obj := obj.(type) {
 	case *v1.ConfigMap:
-		return obj.Name == constants.DefaultConfigMapName && obj.Namespace == ctx.namespace
+		return (obj.Name == constants.DefaultConfigMapName || obj.Name == constants.ConfigMapName) && obj.Namespace == ctx.namespace
+	case cache.DeletedFinalStateUnknown:
+		return ctx.filterConfigMaps(obj.Obj)
 	default:
 		return false
 	}
@@ -290,33 +295,79 @@ func (ctx *Context) filterConfigMaps(obj interface{}) bool {
 func (ctx *Context) addConfigMaps(obj interface{}) {
 	log.Logger().Debug("configMap added")
 	configmap := utils.Convert2ConfigMap(obj)
-	ctx.triggerReloadConfig(configmap)
+	switch configmap.Name {
+	case constants.DefaultConfigMapName:
+		ctx.configMaps[0] = configmap
+	case constants.ConfigMapName:
+		ctx.configMaps[1] = configmap
+	default:
+		// ignore
+		return
+	}
+	ctx.triggerReloadConfig()
 }
 
 // when the configMap for the scheduler is updated, trigger hot-refresh
-func (ctx *Context) updateConfigMaps(obj, newObj interface{}) {
+func (ctx *Context) updateConfigMaps(_, newObj interface{}) {
 	log.Logger().Debug("configMap updated")
 	configmap := utils.Convert2ConfigMap(newObj)
-	ctx.triggerReloadConfig(configmap)
+	switch configmap.Name {
+	case constants.DefaultConfigMapName:
+		ctx.configMaps[0] = configmap
+	case constants.ConfigMapName:
+		ctx.configMaps[1] = configmap
+	default:
+		// ignore
+		return
+	}
+	ctx.triggerReloadConfig()
 }
 
 // when the configMap for the scheduler is deleted, trigger refresh using default config
 func (ctx *Context) deleteConfigMaps(obj interface{}) {
 	log.Logger().Debug("configMap deleted")
-	ctx.triggerReloadConfig(nil)
+	var configmap *v1.ConfigMap = nil
+	switch t := obj.(type) {
+	case *v1.ConfigMap:
+		configmap = t
+	case cache.DeletedFinalStateUnknown:
+		configmap = utils.Convert2ConfigMap(obj)
+	default:
+		log.Logger().Debug("unable to convert to configmap")
+		return
+	}
+
+	switch configmap.Name {
+	case constants.DefaultConfigMapName:
+		ctx.configMaps[0] = nil
+	case constants.ConfigMapName:
+		ctx.configMaps[1] = nil
+	default:
+		// ignore
+		return
+	}
+	ctx.triggerReloadConfig()
 }
 
-func (ctx *Context) triggerReloadConfig(configMap *v1.ConfigMap) {
-	conf := ctx.apiProvider.GetAPIs().Conf
-
+func (ctx *Context) triggerReloadConfig() {
+	conf := ctx.apiProvider.GetAPIs().GetConf()
 	if !conf.EnableConfigHotRefresh {
 		log.Logger().Info("hot-refresh disabled, skipping scheduler configuration update")
 		return
 	}
 
+	err := schedulerconf.UpdateConfigMaps(ctx.configMaps, false)
+	if err != nil {
+		log.Logger().Error("Unable to update configmap, ignoring changes", zap.Error(err))
+		return
+	}
+
+	confMap := schedulerconf.FlattenConfigMaps(ctx.configMaps)
+
+	conf = ctx.apiProvider.GetAPIs().GetConf()
 	log.Logger().Info("reloading scheduler configuration")
-	config := utils.GetCoreSchedulerConfigFromConfigMap(configMap)
-	extraConfig := utils.GetExtraConfigFromConfigMap(configMap)
+	config := utils.GetCoreSchedulerConfigFromConfigMap(confMap)
+	extraConfig := utils.GetExtraConfigFromConfigMap(confMap)
 
 	request := &si.UpdateConfigurationRequest{
 		RmID:        conf.ClusterID,
@@ -950,6 +1001,18 @@ func (ctx *Context) SchedulerNodeEventHandler() func(obj interface{}) {
 	return nil
 }
 
-func (ctx *Context) LoadConfigMap() (*v1.ConfigMap, error) {
-	return ctx.apiProvider.GetAPIs().KubeClient.GetConfigMap(ctx.namespace, constants.DefaultConfigMapName)
+func (ctx *Context) LoadConfigMaps() ([]*v1.ConfigMap, error) {
+	kubeClient := ctx.apiProvider.GetAPIs().KubeClient
+
+	defaults, err := kubeClient.GetConfigMap(ctx.namespace, constants.DefaultConfigMapName)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := kubeClient.GetConfigMap(ctx.namespace, constants.ConfigMapName)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*v1.ConfigMap{defaults, config}, nil
 }

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -121,7 +121,7 @@ func NewAPIFactory(scheduler api.SchedulerAPI, informerFactory informers.SharedI
 
 	return &APIFactory{
 		clients: &Clients{
-			Conf:              configs,
+			conf:              configs,
 			KubeClient:        kubeClient,
 			AppClient:         appClient,
 			SchedulerAPI:      scheduler,

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -38,15 +38,13 @@ type MockedAPIProvider struct {
 func NewMockedAPIProvider(showError bool) *MockedAPIProvider {
 	return &MockedAPIProvider{
 		clients: &Clients{
-			Conf: &conf.SchedulerConf{
+			conf: &conf.SchedulerConf{
 				ClusterID:            "yk-test-cluster",
 				ClusterVersion:       "0.1",
 				PolicyGroup:          "queues",
 				Interval:             0,
 				KubeConfig:           "",
 				LoggingLevel:         0,
-				LogEncoding:          "",
-				LogFile:              "",
 				VolumeBindTimeout:    0,
 				TestMode:             true,
 				EventChannelCapacity: 0,

--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -39,7 +39,7 @@ import (
 // or the scheduler core.
 type Clients struct {
 	// configs
-	Conf *conf.SchedulerConf
+	conf *conf.SchedulerConf
 
 	// client apis
 	KubeClient   KubeClient
@@ -61,6 +61,10 @@ type Clients struct {
 
 	// volume binder handles PV/PVC related operations
 	VolumeBinder volumebinding.SchedulerVolumeBinder
+}
+
+func (c *Clients) GetConf() *conf.SchedulerConf {
+	return c.conf
 }
 
 func (c *Clients) WaitForSync(interval time.Duration, timeout time.Duration) error {

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -54,3 +54,7 @@ type KubeClient interface {
 func NewKubeClient(kc string) KubeClient {
 	return newSchedulerKubeClient(kc)
 }
+
+func NewBootstrapKubeClient(kc string) KubeClient {
+	return newBootstrapSchedulerKubeClient(kc)
+}

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -46,7 +46,8 @@ const SparkLabelRole = "spark-role"
 const SparkLabelRoleDriver = "driver"
 
 // Configuration
-const DefaultConfigMapName = "yunikorn-configs"
+const ConfigMapName = "yunikorn-configs"
+const DefaultConfigMapName = "yunikorn-defaults"
 const SchedulerName = "yunikorn"
 
 // OwnerReferences
@@ -56,7 +57,7 @@ const DaemonSetType = "DaemonSet"
 const AppManagerHandlerName = "yunikorn-app"
 
 // Gang scheduling
-const PlaceholderContainerImage = "k8s.gcr.io/pause"
+const PlaceholderContainerImage = "registry.k8s.io/pause:3.7"
 const PlaceholderContainerName = "pause"
 const PlaceholderPodRestartPolicy = "Never"
 const LabelPlaceholderFlag = "placeholder"

--- a/pkg/common/test/configmap_lister_mock.go
+++ b/pkg/common/test/configmap_lister_mock.go
@@ -34,7 +34,7 @@ type ConfigMapListerMock struct {
 func NewConfigMapListerMock() *ConfigMapListerMock {
 	YKConfigmap := v1.ConfigMap{
 		ObjectMeta: apis.ObjectMeta{
-			Name:   constants.DefaultConfigMapName,
+			Name:   constants.ConfigMapName,
 			Labels: map[string]string{"app": "yunikorn", "label2": "value2"},
 		},
 		Data: map[string]string{"queues.yaml": "OldData"},

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -27,6 +27,8 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/apache/yunikorn-k8shim/pkg/conf"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +36,6 @@ import (
 
 	"github.com/apache/yunikorn-k8shim/pkg/common"
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
-	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
@@ -292,28 +293,26 @@ func GetUserFromPod(pod *v1.Pod) (string, []string) {
 
 // GetCoreSchedulerConfigFromConfigMap resolves a yunikorn configmap into a core scheduler config.
 // If the configmap is missing or the policy group doesn't exist, uses a default configuration
-func GetCoreSchedulerConfigFromConfigMap(configMap *v1.ConfigMap) string {
+func GetCoreSchedulerConfigFromConfigMap(config map[string]string) string {
 	// use default config if there isn't one
-	if configMap == nil {
+	if len(config) == 0 {
 		return ""
 	}
 	policyGroup := conf.GetSchedulerConf().PolicyGroup
-	if data, ok := configMap.Data[fmt.Sprintf("%s.yaml", policyGroup)]; ok {
+	if data, ok := config[fmt.Sprintf("%s.yaml", policyGroup)]; ok {
 		return data
 	}
 	return ""
 }
 
 // GetExtraConfigFromConfigMap filters the configmap entries, returning those that are not yaml
-func GetExtraConfigFromConfigMap(configMap *v1.ConfigMap) map[string]string {
+func GetExtraConfigFromConfigMap(config map[string]string) map[string]string {
 	result := make(map[string]string)
-	if configMap != nil {
-		for k, v := range configMap.Data {
-			if strings.HasSuffix(k, ".yaml") {
-				continue
-			}
-			result[k] = v
+	for k, v := range config {
+		if strings.HasSuffix(k, ".yaml") {
+			continue
 		}
+		result[k] = v
 	}
 	return result
 }

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -741,14 +741,14 @@ func TestGetCoreSchedulerConfigFromConfigMapNil(t *testing.T) {
 }
 
 func TestGetCoreSchedulerConfigFromConfigMapEmpty(t *testing.T) {
-	cm := &v1.ConfigMap{Data: map[string]string{}}
+	cm := map[string]string{}
 	assert.Equal(t, "", GetCoreSchedulerConfigFromConfigMap(cm))
 }
 
 func TestGetCoreSchedulerConfigFromConfigMap(t *testing.T) {
-	cm := &v1.ConfigMap{Data: map[string]string{
+	cm := map[string]string{
 		"queues.yaml": "test",
-	}}
+	}
 	assert.Equal(t, "test", GetCoreSchedulerConfigFromConfigMap(cm))
 }
 
@@ -758,23 +758,23 @@ func TestGetExtraConfigFromConfigMapNil(t *testing.T) {
 }
 
 func TestGetExtraConfigFromConfigMapEmpty(t *testing.T) {
-	cm := &v1.ConfigMap{Data: map[string]string{}}
+	cm := map[string]string{}
 	res := GetExtraConfigFromConfigMap(cm)
 	assert.Equal(t, 0, len(res))
 }
 
 func TestGetExtraConfigFromConfigMapQueuesYaml(t *testing.T) {
-	cm := &v1.ConfigMap{Data: map[string]string{
+	cm := map[string]string{
 		"queues.yaml": "test",
-	}}
+	}
 	res := GetExtraConfigFromConfigMap(cm)
 	assert.Equal(t, 0, len(res))
 }
 
 func TestGetExtraConfigFromConfigMap(t *testing.T) {
-	cm := &v1.ConfigMap{Data: map[string]string{
+	cm := map[string]string{
 		"key": "value",
-	}}
+	}
 	res := GetExtraConfigFromConfigMap(cm)
 	assert.Equal(t, 1, len(res))
 	value, ok := res["key"]

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -19,50 +19,136 @@
 package conf
 
 import (
+	"encoding/json"
+	"errors"
 	"flag"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/yunikorn-k8shim/pkg/log"
 )
 
 type SchedulerConfFactory = func() *SchedulerConf
 
-// env vars
 const (
-	NamespaceEnv     = "NAMESPACE"
-	DefaultNamespace = "default"
-)
+	// env vars
+	EnvHome       = "HOME"
+	EnvKubeConfig = "KUBECONFIG"
+	EnvNamespace  = "NAMESPACE"
 
-// default configuration values, these can be override by CLI options
-const (
-	DefaultClusterID            = "my-kube-cluster"
-	DefaultClusterVersion       = "0.1"
-	DefaultPolicyGroup          = "queues"
-	DefaultLoggingLevel         = 0
-	DefaultLogEncoding          = "console"
-	DefaultVolumeBindTimeout    = 10 * time.Second
-	DefaultSchedulingInterval   = time.Second
-	DefaultEventChannelCapacity = 1024 * 1024
-	DefaultDispatchTimeout      = 300 * time.Second
-	DefaultKubeQPS              = 1000
-	DefaultKubeBurst            = 1000
-)
+	// deprecated env vars
+	DeprecatedEnvUserLabelKey     = "USER_LABEL_KEY"
+	DeprecatedEnvOperatorPlugins  = "OPERATOR_PLUGINS"
+	DeprecatedEnvPlaceholderImage = "PLACEHOLDER_IMAGE"
 
-var once sync.Once
-var configuration *SchedulerConf
-var factory = initConfigs
+	// deprecated cli options
+	DeprecatedCliClusterID              = "clusterId"
+	DeprecatedCliClusterVersion         = "clusterVersion"
+	DeprecatedCliDisableGangScheduling  = "disableGangScheduling"
+	DeprecatedCliDispatchTimeout        = "dispatchTimeout"
+	DeprecatedCliEnableConfigHotRefresh = "enableConfigHotRefresh"
+	DeprecatedCliEventChannelCapacity   = "eventChannelCapacity"
+	DeprecatedCliInterval               = "interval"
+	DeprecatedCliKubeQPS                = "kubeQPS"
+	DeprecatedCliKubeBurst              = "kubeBurst"
+	DeprecatedCliKubeConfig             = "kubeConfig"
+	DeprecatedCliLogEncoding            = "logEncoding"
+	DeprecatedCliLogFile                = "logFile"
+	DeprecatedCliLogLevel               = "logLevel"
+	DeprecatedCliOperatorPlugins        = "operatorPlugins"
+	DeprecatedCliPlaceHolderImage       = "placeHolderImage"
+	DeprecatedCliPolicyGroup            = "policyGroup"
+	DeprecatedCliUserLabelKey           = "userLabelKey"
+	DeprecatedCliVolumeBindTimeout      = "volumeBindTimeout"
+
+	// configmap prefixes
+	PrefixService    = "service."
+	PrefixLog        = "log."
+	PrefixKubernetes = "kubernetes."
+
+	// configmap service
+	CMSvcClusterID              = PrefixService + "clusterId"
+	CMSvcPolicyGroup            = PrefixService + "policyGroup"
+	CMSvcSchedulingInterval     = PrefixService + "schedulingInterval"
+	CMSvcVolumeBindTimeout      = PrefixService + "volumeBindTimeout"
+	CMSvcEventChannelCapacity   = PrefixService + "eventChannelCapacity"
+	CMSvcDispatchTimeout        = PrefixService + "dispatchTimeout"
+	CMSvcOperatorPlugins        = PrefixService + "operatorPlugins"
+	CMSvcDisableGangScheduling  = PrefixService + "disableGangScheduling"
+	CMSvcEnableConfigHotRefresh = PrefixService + "enableConfigHotRefresh"
+	CMSvcPlaceholderImage       = PrefixService + "placeholderImage"
+
+	// configmap log
+	CMLogLevel = PrefixLog + "level"
+
+	// configmap kubernetes
+	CMKubeQPS   = PrefixKubernetes + "qps"
+	CMKubeBurst = PrefixKubernetes + "burst"
+
+	// defaults
+	DefaultNamespace              = "default"
+	DefaultClusterID              = "mycluster"
+	DefaultPolicyGroup            = "queues"
+	DefaultSchedulingInterval     = time.Second
+	DefaultVolumeBindTimeout      = 10 * time.Second
+	DefaultEventChannelCapacity   = 1024 * 1024
+	DefaultDispatchTimeout        = 300 * time.Second
+	DefaultOperatorPlugins        = "general"
+	DefaultDisableGangScheduling  = false
+	DefaultEnableConfigHotRefresh = true
+	DefaultLoggingLevel           = 0
+	DefaultLogEncoding            = "console"
+	DefaultKubeQPS                = 1000
+	DefaultKubeBurst              = 1000
+)
 
 var (
 	BuildVersion    string
 	BuildDate       string
 	IsPluginVersion bool
 )
+
+var once sync.Once
+var confHolder atomic.Value
+var cliParserFunc = parseCliConfig
+var envLookupFunc = os.LookupEnv
+var cliArgsFunc = getCommandLineArgs
+
+type OptionParser func(prev *SchedulerConf, seen map[string]string) (*SchedulerConf, []string)
+type envLookup func(string) (string, bool)
+type cliLookup func() (string, []string)
+
+// SetCliParser replaces the default CLI parser with an alternate (used for scheduler plugin configuration)
+func SetCliParser(parser OptionParser) OptionParser {
+	oldParser := cliParserFunc
+	cliParserFunc = parser
+	return oldParser
+}
+
+// used for testing
+func setEnvLookupFunc(lookup envLookup) envLookup {
+	prev := envLookupFunc
+	envLookupFunc = lookup
+	return prev
+}
+
+// used for testing
+func setCliLookupFunc(lookup cliLookup) cliLookup {
+	prev := cliArgsFunc
+	cliArgsFunc = lookup
+	return prev
+}
 
 type SchedulerConf struct {
 	SchedulerName          string        `json:"schedulerName"`
@@ -72,15 +158,12 @@ type SchedulerConf struct {
 	Interval               time.Duration `json:"schedulingIntervalSecond"`
 	KubeConfig             string        `json:"absoluteKubeConfigFilePath"`
 	LoggingLevel           int           `json:"loggingLevel"`
-	LogEncoding            string        `json:"logEncoding"`
-	LogFile                string        `json:"logFilePath"`
 	VolumeBindTimeout      time.Duration `json:"volumeBindTimeout"`
 	TestMode               bool          `json:"testMode"`
 	EventChannelCapacity   int           `json:"eventChannelCapacity"`
 	DispatchTimeout        time.Duration `json:"dispatchTimeout"`
 	KubeQPS                int           `json:"kubeQPS"`
 	KubeBurst              int           `json:"kubeBurst"`
-	Predicates             string        `json:"predicates"`
 	OperatorPlugins        string        `json:"operatorPlugins"`
 	EnableConfigHotRefresh bool          `json:"enableConfigHotRefresh"`
 	DisableGangScheduling  bool          `json:"disableGangScheduling"`
@@ -90,13 +173,154 @@ type SchedulerConf struct {
 	sync.RWMutex
 }
 
-func SetSchedulerConfFactory(confFactory SchedulerConfFactory) {
-	factory = confFactory
+func (conf *SchedulerConf) Clone() *SchedulerConf {
+	conf.RLock()
+	defer conf.RUnlock()
+
+	return &SchedulerConf{
+		SchedulerName:          conf.SchedulerName,
+		ClusterID:              conf.ClusterID,
+		ClusterVersion:         conf.ClusterVersion,
+		PolicyGroup:            conf.PolicyGroup,
+		Interval:               conf.Interval,
+		KubeConfig:             conf.KubeConfig,
+		LoggingLevel:           conf.LoggingLevel,
+		VolumeBindTimeout:      conf.VolumeBindTimeout,
+		TestMode:               conf.TestMode,
+		EventChannelCapacity:   conf.EventChannelCapacity,
+		DispatchTimeout:        conf.DispatchTimeout,
+		KubeQPS:                conf.KubeQPS,
+		KubeBurst:              conf.KubeBurst,
+		OperatorPlugins:        conf.OperatorPlugins,
+		EnableConfigHotRefresh: conf.EnableConfigHotRefresh,
+		DisableGangScheduling:  conf.DisableGangScheduling,
+		UserLabelKey:           conf.UserLabelKey,
+		PlaceHolderImage:       conf.PlaceHolderImage,
+		Namespace:              conf.Namespace,
+	}
+}
+
+func UpdateConfigMaps(configMaps []*v1.ConfigMap, initial bool) error {
+	log.Logger().Info("reloading configuration")
+
+	// start with defaults
+	prev := CreateDefaultConfig()
+	seen := make(map[string]string)
+
+	// convert configmaps to map
+	config := FlattenConfigMaps(configMaps)
+
+	// parse values from configmaps
+	cmConf, cmErrors := parseConfig(config, prev, seen)
+	if cmErrors != nil {
+		for _, err := range cmErrors {
+			log.Logger().Error("failed to parse configmap entry", zap.Error(err))
+		}
+		return errors.New("failed to load configmap")
+	}
+
+	// parse values from CLI
+	cliConf, cliWarnings := cliParserFunc(cmConf, seen)
+	for _, warn := range cliWarnings {
+		log.Logger().Warn("warning while parsing CLI entry", zap.String("warning", warn))
+	}
+
+	// parse values from ENV
+	newConf, envWarnings := parseEnvConfig(cliConf, seen)
+	for _, warn := range envWarnings {
+		log.Logger().Warn("warning while parsing env configuration", zap.String("warning", warn))
+	}
+
+	// check for settings which cannot be hot-reloaded
+	if !initial {
+		oldConf := GetSchedulerConf()
+		handleNonReloadableConfig(oldConf, newConf)
+	}
+
+	// update scheduler config with merged version
+	SetSchedulerConf(newConf)
+	conf := GetSchedulerConf()
+
+	// update logger configuration
+	log.GetZapConfigs().Level.SetLevel(zapcore.Level(conf.LoggingLevel))
+
+	// update Kubernetes logger configuration
+	updateKubeLogger(conf)
+
+	// dump new scheduler configuration
+	DumpConfiguration()
+
+	return nil
+}
+
+func handleNonReloadableConfig(old *SchedulerConf, new *SchedulerConf) {
+	// warn about and revert any settings which cannot be hot-reloaded
+	checkNonReloadableString(CMSvcClusterID, &old.ClusterID, &new.ClusterID)
+	checkNonReloadableString(CMSvcPolicyGroup, &old.PolicyGroup, &new.PolicyGroup)
+	checkNonReloadableDuration(CMSvcSchedulingInterval, &old.Interval, &new.Interval)
+	checkNonReloadableDuration(CMSvcVolumeBindTimeout, &old.VolumeBindTimeout, &new.VolumeBindTimeout)
+	checkNonReloadableInt(CMSvcEventChannelCapacity, &old.EventChannelCapacity, &new.EventChannelCapacity)
+	checkNonReloadableDuration(CMSvcDispatchTimeout, &old.DispatchTimeout, &new.DispatchTimeout)
+	checkNonReloadableInt(CMKubeQPS, &old.KubeQPS, &new.KubeQPS)
+	checkNonReloadableInt(CMKubeBurst, &old.KubeBurst, &new.KubeBurst)
+	checkNonReloadableString(CMSvcOperatorPlugins, &old.OperatorPlugins, &new.OperatorPlugins)
+	checkNonReloadableBool(CMSvcDisableGangScheduling, &old.DisableGangScheduling, &new.DisableGangScheduling)
+	checkNonReloadableString(CMSvcPlaceholderImage, &old.PlaceHolderImage, &new.PlaceHolderImage)
+}
+
+const warningNonReloadable = "ignoring non-reloadable configuration change (restart required to update)"
+
+func checkNonReloadableString(name string, old *string, new *string) {
+	if *old != *new {
+		log.Logger().Warn(warningNonReloadable, zap.String("config", name), zap.String("existing", *old), zap.String("new", *new))
+		*new = *old
+	}
+}
+
+func checkNonReloadableDuration(name string, old *time.Duration, new *time.Duration) {
+	if *old != *new {
+		log.Logger().Warn(warningNonReloadable, zap.String("config", name), zap.Duration("existing", *old), zap.Duration("new", *new))
+		*new = *old
+	}
+}
+
+func checkNonReloadableInt(name string, old *int, new *int) {
+	if *old != *new {
+		log.Logger().Warn(warningNonReloadable, zap.String("config", name), zap.Int("existing", *old), zap.Int("new", *new))
+		*new = *old
+	}
+}
+
+func checkNonReloadableBool(name string, old *bool, new *bool) {
+	if *old != *new {
+		log.Logger().Warn(warningNonReloadable, zap.String("config", name), zap.Bool("existing", *old), zap.Bool("new", *new))
+		*new = *old
+	}
+}
+
+func getCommandLineArgs() (string, []string) {
+	args := make([]string, 0)
+	if len(os.Args) > 1 {
+		for _, arg := range os.Args[1:] {
+			// workaround: ignore test args
+			if strings.HasPrefix(arg, "-test") || strings.HasPrefix(arg, "--test") {
+				continue
+			}
+			args = append(args, arg)
+		}
+	}
+	return os.Args[0], args
 }
 
 func GetSchedulerConf() *SchedulerConf {
 	once.Do(createConfigs)
-	return configuration
+	return confHolder.Load().(*SchedulerConf)
+}
+
+func SetSchedulerConf(conf *SchedulerConf) {
+	// this is just to ensure that the original is in place first
+	once.Do(createConfigs)
+	confHolder.Store(conf)
 }
 
 func (conf *SchedulerConf) SetTestMode(testMode bool) {
@@ -141,66 +365,380 @@ func (conf *SchedulerConf) IsOperatorPluginEnabled(name string) bool {
 }
 
 func GetSchedulerNamespace() string {
-	if value, ok := os.LookupEnv(NamespaceEnv); ok {
+	if value, ok := os.LookupEnv(EnvNamespace); ok {
 		return value
 	}
 	return DefaultNamespace
 }
 
 func createConfigs() {
-	configuration = factory()
+	confHolder.Store(CreateDefaultConfig())
 }
 
-func initConfigs() *SchedulerConf {
-	conf := &SchedulerConf{
-		SchedulerName: constants.SchedulerName,
-		Namespace:     GetSchedulerNamespace(),
+func GetDefaultKubeConfigPath() string {
+	conf, ok := os.LookupEnv(EnvKubeConfig)
+	if ok {
+		return conf
+	}
+	home, ok := os.LookupEnv(EnvHome)
+	if !ok {
+		home = ""
+	}
+	return fmt.Sprintf("%s/.kube/config", home)
+}
+
+// CreateDefaultConfig creates and returns a configuration representing all default values
+func CreateDefaultConfig() *SchedulerConf {
+	return &SchedulerConf{
+		SchedulerName:          constants.SchedulerName,
+		Namespace:              GetSchedulerNamespace(),
+		ClusterID:              DefaultClusterID,
+		ClusterVersion:         BuildVersion,
+		PolicyGroup:            DefaultPolicyGroup,
+		Interval:               DefaultSchedulingInterval,
+		KubeConfig:             GetDefaultKubeConfigPath(),
+		LoggingLevel:           DefaultLoggingLevel,
+		VolumeBindTimeout:      DefaultVolumeBindTimeout,
+		TestMode:               false,
+		EventChannelCapacity:   DefaultEventChannelCapacity,
+		DispatchTimeout:        DefaultDispatchTimeout,
+		KubeQPS:                DefaultKubeQPS,
+		KubeBurst:              DefaultKubeBurst,
+		OperatorPlugins:        DefaultOperatorPlugins,
+		EnableConfigHotRefresh: DefaultEnableConfigHotRefresh,
+		DisableGangScheduling:  DefaultDisableGangScheduling,
+		UserLabelKey:           constants.DefaultUserLabel,
+		PlaceHolderImage:       constants.PlaceholderContainerImage,
+	}
+}
+
+func parseConfig(config map[string]string, prev *SchedulerConf, seen map[string]string) (*SchedulerConf, []error) {
+	conf := prev.Clone()
+
+	if len(config) == 0 {
+		// no changes
+		return conf, nil
 	}
 
+	parser := newConfigParser(config, seen)
+
+	// service
+	parser.stringVar(&conf.ClusterID, CMSvcClusterID)
+	parser.stringVar(&conf.PolicyGroup, CMSvcPolicyGroup)
+	parser.durationVar(&conf.Interval, CMSvcSchedulingInterval)
+	parser.durationVar(&conf.VolumeBindTimeout, CMSvcVolumeBindTimeout)
+	parser.intVar(&conf.EventChannelCapacity, CMSvcEventChannelCapacity)
+	parser.durationVar(&conf.DispatchTimeout, CMSvcDispatchTimeout)
+	parser.stringVar(&conf.OperatorPlugins, CMSvcOperatorPlugins)
+	parser.boolVar(&conf.DisableGangScheduling, CMSvcDisableGangScheduling)
+	parser.boolVar(&conf.EnableConfigHotRefresh, CMSvcEnableConfigHotRefresh)
+	parser.stringVar(&conf.PlaceHolderImage, CMSvcPlaceholderImage)
+
+	// log
+	parser.intVar(&conf.LoggingLevel, CMLogLevel)
+
+	// kubernetes
+	parser.intVar(&conf.KubeQPS, CMKubeQPS)
+	parser.intVar(&conf.KubeBurst, CMKubeBurst)
+
+	if len(parser.errors) > 0 {
+		return nil, parser.errors
+	}
+	return conf, nil
+}
+
+type configParser struct {
+	errors []error
+	config map[string]string
+	seen   map[string]string
+}
+
+func newConfigParser(config map[string]string, seen map[string]string) *configParser {
+	return &configParser{
+		errors: make([]error, 0),
+		config: config,
+		seen:   seen,
+	}
+}
+
+func (cp *configParser) stringVar(p *string, name string) {
+	if newValue, ok := cp.config[name]; ok {
+		*p = newValue
+		cp.seen[name] = name
+	}
+}
+
+func (cp *configParser) intVar(p *int, name string) {
+	if newValue, ok := cp.config[name]; ok {
+		int64Value, err := strconv.ParseInt(newValue, 10, 32)
+		intValue := int(int64Value)
+		if err != nil {
+			log.Logger().Error("Unable to parse configmap entry", zap.String("key", name), zap.String("value", newValue), zap.Error(err))
+			cp.errors = append(cp.errors, err)
+			return
+		}
+		*p = intValue
+		cp.seen[name] = name
+	}
+}
+
+func (cp *configParser) boolVar(p *bool, name string) {
+	if newValue, ok := cp.config[name]; ok {
+		boolValue, err := strconv.ParseBool(newValue)
+		if err != nil {
+			log.Logger().Error("Unable to parse configmap entry", zap.String("key", name), zap.String("value", newValue), zap.Error(err))
+			cp.errors = append(cp.errors, err)
+			return
+		}
+		*p = boolValue
+		cp.seen[name] = name
+	}
+}
+
+func (cp *configParser) durationVar(p *time.Duration, name string) {
+	if newValue, ok := cp.config[name]; ok {
+		durationValue, err := time.ParseDuration(newValue)
+		if err != nil {
+			log.Logger().Error("Unable to parse configmap entry", zap.String("key", name), zap.String("value", newValue), zap.Error(err))
+			cp.errors = append(cp.errors, err)
+			return
+		}
+		*p = durationValue
+		cp.seen[name] = name
+	}
+}
+
+type envParser struct {
+	warnings []string
+	seen     map[string]string
+	lookup   envLookup
+}
+
+func newEnvParser(seen map[string]string, lookup envLookup) *envParser {
+	return &envParser{
+		warnings: make([]string, 0),
+		seen:     seen,
+		lookup:   lookup,
+	}
+}
+
+func (ep *envParser) obsoleteStringVar(name string) {
+	if newValue, ok := ep.lookup(name); ok {
+		ep.warnings = append(ep.warnings, fmt.Sprintf("Obsolete environment variable '%s' found. Ignoring value: '%s'", name, newValue))
+	}
+}
+
+func (ep *envParser) deprecatedStringVar(p *string, d *string, name string, cName string) {
+	if newValue, ok := ep.lookup(name); ok {
+		if _, prev := ep.seen[cName]; prev {
+			if newValue != *d {
+				ep.warnings = append(ep.warnings, fmt.Sprintf("Deprecated environment variable '%s' found with inconsistent value. Provided: '%s', used: '%s'", name, newValue, *d))
+				return
+			}
+		} else {
+			*p = newValue
+			ep.seen[cName] = name
+		}
+	}
+}
+
+type cliParser struct {
+	warnings []string
+	seen     map[string]string
+	visitors map[string]func(f *flag.Flag)
+	flags    *flag.FlagSet
+}
+
+func newCliParser(flags *flag.FlagSet, seen map[string]string) *cliParser {
+	return &cliParser{
+		warnings: make([]string, 0),
+		seen:     seen,
+		visitors: make(map[string]func(f *flag.Flag)),
+		flags:    flags,
+	}
+}
+
+func (cp *cliParser) obsoleteStringVar(name string, value string, usage string) {
+	var newValue string
+	cp.flags.StringVar(&newValue, name, value, usage)
+	cp.visitors[name] = func(f *flag.Flag) {
+		cp.warnings = append(cp.warnings, fmt.Sprintf("Obsolete CLI option '%s' found. Ignoring value: '%s'", name, newValue))
+	}
+}
+
+func (cp *cliParser) deprecatedStringVar(p *string, d *string, name string, cName string, value string, usage string) {
+	var newValue string
+	cp.flags.StringVar(&newValue, name, value, usage)
+	cp.visitors[name] = func(f *flag.Flag) {
+		if _, prev := cp.seen[cName]; prev {
+			if newValue != *d {
+				cp.warnings = append(cp.warnings, fmt.Sprintf("Deprecated CLI option '%s' found with inconsistent value. Provided: '%s', used: '%s'", name, newValue, *d))
+			}
+		} else {
+			cp.seen[cName] = name
+			*p = newValue
+		}
+	}
+}
+
+func (cp *cliParser) deprecatedIntVar(p *int, d *int, name string, cName string, value int, usage string) {
+	var newValue int
+	cp.flags.IntVar(&newValue, name, value, usage)
+	cp.visitors[name] = func(f *flag.Flag) {
+		if _, prev := cp.seen[cName]; prev {
+			if newValue != *d {
+				cp.warnings = append(cp.warnings, fmt.Sprintf("Deprecated CLI option '%s' found with inconsistent value. Provided: '%d', used: '%d'", name, newValue, *d))
+			}
+		} else {
+			cp.seen[cName] = name
+			*p = newValue
+		}
+	}
+}
+
+func (cp *cliParser) deprecatedBoolVar(p *bool, d *bool, name string, cName string, value bool, usage string) {
+	var newValue bool
+	cp.flags.BoolVar(&newValue, name, value, usage)
+	cp.visitors[name] = func(f *flag.Flag) {
+		if _, prev := cp.seen[cName]; prev {
+			if newValue != *d {
+				cp.warnings = append(cp.warnings, fmt.Sprintf("Deprecated CLI option '%s' found with inconsistent value. Provided: '%t', used: '%t'", name, newValue, *d))
+			}
+		} else {
+			cp.seen[cName] = name
+			*p = newValue
+		}
+	}
+}
+
+func (cp *cliParser) deprecatedDurationVar(p *time.Duration, d *time.Duration, name string, cName string, value time.Duration, usage string) {
+	var newValue time.Duration
+	cp.flags.DurationVar(&newValue, name, value, usage)
+	cp.visitors[name] = func(f *flag.Flag) {
+		if _, prev := cp.seen[cName]; prev {
+			if newValue != *d {
+				cp.warnings = append(cp.warnings, fmt.Sprintf("Deprecated CLI option '%s' found with inconsistent value. Provided: '%s', used: '%s'", name, newValue, *d))
+			}
+		} else {
+			cp.seen[cName] = name
+			*p = newValue
+		}
+	}
+}
+
+func (cp *cliParser) finish() {
+	cp.flags.Visit(func(f *flag.Flag) {
+		if visitor, ok := cp.visitors[f.Name]; ok {
+			visitor(f)
+		}
+	})
+}
+
+// parseEnvConfig parses and returns a configuration populated from environment variables
+func parseEnvConfig(prev *SchedulerConf, seen map[string]string) (*SchedulerConf, []string) {
+	conf := prev.Clone()
+
+	parser := newEnvParser(seen, envLookupFunc)
+
+	parser.obsoleteStringVar(DeprecatedEnvUserLabelKey)
+	parser.deprecatedStringVar(&conf.OperatorPlugins, &prev.OperatorPlugins, DeprecatedEnvOperatorPlugins, CMSvcOperatorPlugins)
+	parser.deprecatedStringVar(&conf.PlaceHolderImage, &prev.PlaceHolderImage, DeprecatedEnvPlaceholderImage, CMSvcPlaceholderImage)
+
+	if len(parser.warnings) > 0 {
+		return conf, parser.warnings
+	}
+	return conf, nil
+}
+
+// parseCliConfig parses and returns a configuration populated from command-line arguments
+func parseCliConfig(prev *SchedulerConf, seen map[string]string) (*SchedulerConf, []string) {
+	conf := prev.Clone()
+
+	cmd, args := cliArgsFunc()
+	flags := flag.NewFlagSet(cmd, flag.ExitOnError)
+
+	parser := newCliParser(flags, seen)
+
 	// scheduler options
-	flag.StringVar(&conf.KubeConfig, "kubeConfig", "",
-		"absolute path to the kubeconfig file")
-	flag.DurationVar(&conf.Interval, "interval", DefaultSchedulingInterval,
-		"scheduling interval in seconds")
-	flag.StringVar(&conf.ClusterID, "clusterId", DefaultClusterID,
-		"cluster id")
-	flag.StringVar(&conf.ClusterVersion, "clusterVersion", DefaultClusterVersion,
-		"cluster version")
-	flag.StringVar(&conf.PolicyGroup, "policyGroup", DefaultPolicyGroup,
-		"policy group")
-	flag.DurationVar(&conf.VolumeBindTimeout, "volumeBindTimeout", DefaultVolumeBindTimeout,
-		"timeout in seconds when binding a volume")
-	flag.IntVar(&conf.EventChannelCapacity, "eventChannelCapacity", DefaultEventChannelCapacity,
-		"event channel capacity of dispatcher")
-	flag.DurationVar(&conf.DispatchTimeout, "dispatchTimeout", DefaultDispatchTimeout,
-		"timeout in seconds when dispatching an event")
-	flag.IntVar(&conf.KubeQPS, "kubeQPS", DefaultKubeQPS,
-		"the maximum QPS to kubernetes master from this client")
-	flag.IntVar(&conf.KubeBurst, "kubeBurst", DefaultKubeBurst,
-		"the maximum burst for throttle to kubernetes master from this client")
-	flag.StringVar(&conf.OperatorPlugins, "operatorPlugins", "general",
-		"comma-separated list of operator plugin names, currently, only \"spark-k8s-operator\""+
-			"and"+constants.AppManagerHandlerName+"is supported.")
-	flag.StringVar(&conf.PlaceHolderImage, "placeHolderImage", constants.PlaceholderContainerImage,
-		"docker image of the placeholder pod")
+	parser.deprecatedStringVar(&conf.KubeConfig, &prev.KubeConfig,
+		DeprecatedCliKubeConfig, EnvKubeConfig, GetDefaultKubeConfigPath(),
+		fmt.Sprintf("DEPRECATED: absolute path to the kubeconfig file (use env: %s)", EnvKubeConfig))
+	parser.deprecatedDurationVar(&conf.Interval, &prev.Interval,
+		DeprecatedCliInterval, CMSvcSchedulingInterval, DefaultSchedulingInterval,
+		fmt.Sprintf("DEPRECATED: scheduling interval in seconds (use configmap: %s/%s)",
+			constants.ConfigMapName, CMSvcSchedulingInterval))
+	parser.deprecatedStringVar(&conf.ClusterID, &prev.ClusterID,
+		DeprecatedCliClusterID, CMSvcClusterID, DefaultClusterID,
+		fmt.Sprintf("DEPRECATED: cluster id (use configmap: %s/%s)",
+			constants.ConfigMapName, CMSvcClusterID))
+	parser.obsoleteStringVar(DeprecatedCliClusterVersion, BuildVersion,
+		"DEPRECATED: cluster version (ignored)")
+	parser.deprecatedStringVar(&conf.PolicyGroup, &prev.PolicyGroup,
+		DeprecatedCliPolicyGroup, CMSvcPolicyGroup, DefaultPolicyGroup,
+		fmt.Sprintf("DEPRECATED: policy group (use configmap: %s/%s)",
+			constants.ConfigMapName, CMSvcPolicyGroup))
+	parser.deprecatedDurationVar(&conf.VolumeBindTimeout, &prev.VolumeBindTimeout,
+		DeprecatedCliVolumeBindTimeout, CMSvcVolumeBindTimeout, DefaultVolumeBindTimeout,
+		fmt.Sprintf("DEPRECATED: timeout in seconds when binding a volume (use configmap: %s/%s)",
+			constants.ConfigMapName, CMSvcVolumeBindTimeout))
+	parser.deprecatedIntVar(&conf.EventChannelCapacity, &prev.EventChannelCapacity,
+		DeprecatedCliEventChannelCapacity, CMSvcEventChannelCapacity, DefaultEventChannelCapacity,
+		fmt.Sprintf("DEPRECATED: event channel capacity of dispatcher (use configmap: %s/%s)",
+			constants.ConfigMapName, CMSvcEventChannelCapacity))
+	parser.deprecatedDurationVar(&conf.DispatchTimeout, &prev.DispatchTimeout,
+		DeprecatedCliDispatchTimeout, CMSvcDispatchTimeout, DefaultDispatchTimeout,
+		fmt.Sprintf("DEPRECATED: timeout in seconds when dispatching an event (use configmap: %s/%s)",
+			constants.ConfigMapName, CMSvcDispatchTimeout))
+	parser.deprecatedIntVar(&conf.KubeQPS, &prev.KubeQPS,
+		DeprecatedCliKubeQPS, CMKubeQPS, DefaultKubeQPS,
+		fmt.Sprintf("DEPRECATED: maximum QPS to Kubernetes master from this client (use configmap: %s/%s)",
+			constants.ConfigMapName, CMKubeQPS))
+	parser.deprecatedIntVar(&conf.KubeBurst, &prev.KubeBurst,
+		DeprecatedCliKubeBurst, CMKubeBurst, DefaultKubeBurst,
+		fmt.Sprintf("DEPRECATED: maximum burst for throttle to Kubernetes master from this client (use configmap: %s/%s)",
+			constants.ConfigMapName, CMKubeBurst))
+	parser.deprecatedStringVar(&conf.OperatorPlugins, &prev.OperatorPlugins,
+		DeprecatedCliOperatorPlugins, CMSvcOperatorPlugins, DefaultOperatorPlugins,
+		fmt.Sprintf("DEPRECATED: comma-separated list of operator plugin names [general,spark-k8s-operator,%s] (use configmap: %s/%s)",
+			constants.AppManagerHandlerName, CMSvcOperatorPlugins, constants.ConfigMapName))
+	parser.deprecatedStringVar(&conf.PlaceHolderImage, &prev.PlaceHolderImage,
+		DeprecatedCliPlaceHolderImage, CMSvcPlaceholderImage, constants.PlaceholderContainerImage,
+		fmt.Sprintf("DEPRECATED: Docker image of the placeholder pod (use configmap: %s/%s)",
+			constants.ConfigMapName, CMSvcPlaceholderImage))
 
 	// logging options
-	flag.IntVar(&conf.LoggingLevel, "logLevel", DefaultLoggingLevel,
-		"logging level, available range [-1, 5], from DEBUG to FATAL.")
-	flag.StringVar(&conf.LogEncoding, "logEncoding", DefaultLogEncoding,
-		"log encoding, json or console.")
-	flag.StringVar(&conf.LogFile, "logFile", "",
-		"absolute log file path")
-	flag.BoolVar(&conf.EnableConfigHotRefresh, "enableConfigHotRefresh", false, "Flag for enabling "+
-		"configuration hot-refresh. If this value is set to true, the configuration updates in the configmap will be "+
-		"automatically reloaded without restarting the scheduler.")
-	flag.BoolVar(&conf.DisableGangScheduling, "disableGangScheduling", false, "Flag for disabling "+
-		"gang scheduling. If this value is set to true, task-group metadata will be ignored by the scheduler.")
-	flag.StringVar(&conf.UserLabelKey, "userLabelKey", constants.DefaultUserLabel,
-		"provide pod label key to be used to identify an user")
+	parser.deprecatedIntVar(&conf.LoggingLevel, &prev.LoggingLevel,
+		DeprecatedCliLogLevel, CMLogLevel, DefaultLoggingLevel,
+		fmt.Sprintf("DEPRECATED: logging level, from DEBUG (-1) to FATAL (5) (use configmap: %s/%s)",
+			constants.ConfigMapName, CMLogLevel))
+	parser.obsoleteStringVar(DeprecatedCliLogEncoding, "", "DEPRECATED: log encoding (ignored)")
+	parser.obsoleteStringVar(DeprecatedCliLogFile, "", "DEPRECATED: log file (ignored)")
 
-	flag.Parse()
+	parser.deprecatedBoolVar(&conf.EnableConfigHotRefresh, &prev.EnableConfigHotRefresh,
+		DeprecatedCliEnableConfigHotRefresh, CMSvcEnableConfigHotRefresh, DefaultEnableConfigHotRefresh,
+		fmt.Sprintf("DEPRECATED: enable automatic configuration reloading (use configmap: %s/%s)",
+			constants.ConfigMapName, CMSvcEnableConfigHotRefresh))
+	parser.deprecatedBoolVar(&conf.DisableGangScheduling, &prev.DisableGangScheduling,
+		DeprecatedCliDisableGangScheduling, CMSvcDisableGangScheduling, DefaultDisableGangScheduling,
+		fmt.Sprintf("DEPRECATED: disable gang scheduling (use configmap: %s/%s)",
+			constants.ConfigMapName, CMSvcDisableGangScheduling))
+	parser.obsoleteStringVar(DeprecatedCliUserLabelKey, constants.DefaultUserLabel,
+		"DEPRECATED: pod label key to be used to identify a user (ignored)")
 
+	err := flags.Parse(args)
+	if err != nil {
+		// this will not happen as we parse with ExitOnError
+		panic(err)
+	}
+
+	parser.finish()
+	if len(parser.warnings) > 0 {
+		return conf, parser.warnings
+	}
+	return conf, nil
+}
+
+func updateKubeLogger(conf *SchedulerConf) {
 	// if log level is debug, enable klog and set its log level verbosity to 4 (represents debug level),
 	// For details refer to the Logging Conventions of klog at
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
@@ -210,6 +748,32 @@ func initConfigs() *SchedulerConf {
 		//nolint:errcheck
 		_ = flag.Set("v", "4")
 	}
+}
 
-	return conf
+func DumpConfiguration() {
+	configs := GetSchedulerConf()
+	c, err := json.MarshalIndent(configs, "", " ")
+
+	logger := log.Logger()
+
+	//nolint:errcheck
+	defer logger.Sync()
+
+	if err != nil {
+		logger.Info("scheduler configuration, json conversion failed", zap.Any("configs", configs))
+	} else {
+		logger.Info("scheduler configuration, pretty print", zap.ByteString("configs", c))
+	}
+}
+
+func FlattenConfigMaps(configMaps []*v1.ConfigMap) map[string]string {
+	result := make(map[string]string)
+	for _, configMap := range configMaps {
+		if configMap != nil {
+			for k, v := range configMap.Data {
+				result[k] = v
+			}
+		}
+	}
+	return result
 }

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -1,40 +1,380 @@
 /*
- Licensed to the Apache Software Foundation (ASF) under one
- or more contributor license agreements.  See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership.  The ASF licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package conf
 
 import (
+	"fmt"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 )
 
 func TestDefaultValues(t *testing.T) {
 	conf := GetSchedulerConf()
+	assertDefaults(t, conf)
+}
+
+func TestNilConfigMaps(t *testing.T) {
+	err := UpdateConfigMaps([]*v1.ConfigMap{nil, nil}, true)
+	assert.NilError(t, err, "UpdateConfigMap failed")
+
+	conf := GetSchedulerConf()
+	assertDefaults(t, conf)
+}
+
+func TestEmptyConfigMap(t *testing.T) {
+	err := UpdateConfigMaps([]*v1.ConfigMap{nil, {Data: map[string]string{}}}, true)
+	assert.NilError(t, err, "UpdateConfigMap failed")
+
+	conf := GetSchedulerConf()
+	assertDefaults(t, conf)
+}
+
+func TestOverriddenConfigMap(t *testing.T) {
+	err := UpdateConfigMaps([]*v1.ConfigMap{
+		{Data: map[string]string{CMSvcClusterID: "default"}},
+		{Data: map[string]string{CMSvcClusterID: "override"}},
+	}, true)
+	assert.NilError(t, err, "UpdateConfigMap failed")
+
+	conf := GetSchedulerConf()
+	assert.Equal(t, "override", conf.ClusterID)
+}
+
+func assertDefaults(t *testing.T, conf *SchedulerConf) {
 	assert.Equal(t, conf.ClusterID, DefaultClusterID)
 	assert.Equal(t, conf.PolicyGroup, DefaultPolicyGroup)
-	assert.Equal(t, conf.ClusterVersion, DefaultClusterVersion)
+	assert.Equal(t, conf.ClusterVersion, BuildVersion)
 	assert.Equal(t, conf.LoggingLevel, DefaultLoggingLevel)
-	assert.Equal(t, conf.LogEncoding, DefaultLogEncoding)
 	assert.Equal(t, conf.EventChannelCapacity, DefaultEventChannelCapacity)
 	assert.Equal(t, conf.DispatchTimeout, DefaultDispatchTimeout)
 	assert.Equal(t, conf.KubeQPS, DefaultKubeQPS)
 	assert.Equal(t, conf.KubeBurst, DefaultKubeBurst)
 	assert.Equal(t, conf.UserLabelKey, constants.DefaultUserLabel)
+}
+
+func TestParseConfigMap(t *testing.T) {
+	testCases := []struct {
+		name  string
+		field string
+		value interface{}
+	}{
+		{CMSvcClusterID, "ClusterID", "test-cluster"},
+		{CMSvcPolicyGroup, "PolicyGroup", "test-policy-group"},
+		{CMSvcSchedulingInterval, "Interval", 5 * time.Second},
+		{CMSvcVolumeBindTimeout, "VolumeBindTimeout", 15 * time.Second},
+		{CMSvcEventChannelCapacity, "EventChannelCapacity", 1234},
+		{CMSvcDispatchTimeout, "DispatchTimeout", 3 * time.Minute},
+		{CMSvcOperatorPlugins, "OperatorPlugins", "test-operators"},
+		{CMSvcDisableGangScheduling, "DisableGangScheduling", true},
+		{CMSvcEnableConfigHotRefresh, "EnableConfigHotRefresh", false},
+		{CMSvcPlaceholderImage, "PlaceHolderImage", "test-image"},
+		{CMLogLevel, "LoggingLevel", -1},
+		{CMKubeQPS, "KubeQPS", 2345},
+		{CMKubeBurst, "KubeBurst", 3456},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := CreateDefaultConfig()
+			seen := make(map[string]string)
+			conf, errs := parseConfig(map[string]string{tc.name: fmt.Sprintf("%v", tc.value)}, prev, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Assert(t, errs == nil, errs)
+			assert.Equal(t, tc.value, getConfValue(t, conf, tc.field))
+		})
+	}
+}
+
+func TestUpdateConfigMapNonReloadable(t *testing.T) {
+	testCases := []struct {
+		name       string
+		field      string
+		value      interface{}
+		reloadable bool
+	}{
+		{CMSvcClusterID, "ClusterID", "test-cluster", false},
+		{CMSvcPolicyGroup, "PolicyGroup", "test-policy-group", false},
+		{CMSvcSchedulingInterval, "Interval", 5 * time.Second, false},
+		{CMSvcVolumeBindTimeout, "VolumeBindTimeout", 15 * time.Second, false},
+		{CMSvcEventChannelCapacity, "EventChannelCapacity", 1234, false},
+		{CMSvcDispatchTimeout, "DispatchTimeout", 3 * time.Minute, false},
+		{CMSvcOperatorPlugins, "OperatorPlugins", "test-operators", false},
+		{CMSvcDisableGangScheduling, "DisableGangScheduling", true, false},
+		{CMSvcPlaceholderImage, "PlaceHolderImage", "test-image", false},
+		{CMLogLevel, "LoggingLevel", -1, true},
+		{CMKubeQPS, "KubeQPS", 2345, false},
+		{CMKubeBurst, "KubeBurst", 3456, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				err := UpdateConfigMaps([]*v1.ConfigMap{nil, nil}, true)
+				assert.NilError(t, err, "failed to reset configmap")
+			}()
+
+			err := UpdateConfigMaps([]*v1.ConfigMap{nil, nil}, true)
+			assert.NilError(t, err, "failed to set configmap")
+			oldConf := GetSchedulerConf()
+
+			err = UpdateConfigMaps([]*v1.ConfigMap{nil, {Data: map[string]string{tc.name: fmt.Sprintf("%v", tc.value)}}}, false)
+			assert.NilError(t, err, "failed to update configmap")
+			newConf := GetSchedulerConf()
+			if tc.reloadable {
+				assert.Equal(t, tc.value, getConfValue(t, newConf, tc.field), "reloadable field not updated")
+			} else {
+				assert.Equal(t, getConfValue(t, oldConf, tc.field), getConfValue(t, newConf, tc.field), "non-reloadable field updated")
+			}
+		})
+	}
+}
+
+func TestParseConfigMapWithUnknownKeyDoesNotFail(t *testing.T) {
+	prev := CreateDefaultConfig()
+	seen := make(map[string]string)
+	conf, errs := parseConfig(map[string]string{"key": "value"}, prev, seen)
+	assert.Assert(t, conf != nil)
+	assert.Assert(t, errs == nil, errs)
+}
+
+func TestParseConfigMapWithInvalidInt(t *testing.T) {
+	prev := CreateDefaultConfig()
+	seen := make(map[string]string)
+	conf, errs := parseConfig(map[string]string{CMSvcEventChannelCapacity: "x"}, prev, seen)
+	assert.Assert(t, conf == nil, "conf exists")
+	assert.Equal(t, 1, len(errs), "wrong error count")
+	assert.ErrorContains(t, errs[0], "invalid syntax", "wrong error type")
+}
+
+func TestParseConfigMapWithInvalidBool(t *testing.T) {
+	prev := CreateDefaultConfig()
+	seen := make(map[string]string)
+	conf, errs := parseConfig(map[string]string{CMSvcEnableConfigHotRefresh: "x"}, prev, seen)
+	assert.Assert(t, conf == nil, "conf exists")
+	assert.Equal(t, 1, len(errs), "wrong error count")
+	assert.ErrorContains(t, errs[0], "invalid syntax", "wrong error type")
+}
+
+func TestParseConfigMapWithInvalidDuration(t *testing.T) {
+	prev := CreateDefaultConfig()
+	seen := make(map[string]string)
+	conf, errs := parseConfig(map[string]string{CMSvcSchedulingInterval: "x"}, prev, seen)
+	assert.Assert(t, conf == nil, "conf exists")
+	assert.Equal(t, 1, len(errs), "wrong error count")
+	assert.ErrorContains(t, errs[0], "invalid duration", "wrong error type")
+}
+
+func TestParseEnv(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		obsolete bool
+		getter   func(conf *SchedulerConf) string
+	}{
+		{DeprecatedEnvUserLabelKey, "test-user-label-key", true, nil},
+		{DeprecatedEnvOperatorPlugins, "test-plugins", false, func(c *SchedulerConf) string { return c.OperatorPlugins }},
+		{DeprecatedEnvPlaceholderImage, "test-image", false, func(c *SchedulerConf) string { return c.PlaceHolderImage }},
+	}
+
+	oldLookup := setEnvLookupFunc(envLookupFunc)
+	defer setEnvLookupFunc(oldLookup)
+
+	for _, tc := range testCases {
+		env := map[string]string{tc.name: tc.value}
+		_ = setEnvLookupFunc(func(s string) (string, bool) {
+			val, ok := env[s]
+			return val, ok
+		})
+
+		t.Run(tc.name, func(t *testing.T) {
+			prev := CreateDefaultConfig()
+			seen := make(map[string]string)
+			conf, warns := parseEnvConfig(prev, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			if tc.obsolete {
+				assert.Equal(t, 1, len(warns), "wrong warning count")
+				assert.Assert(t, strings.Contains(warns[0], "Obsolete"))
+			} else {
+				assert.Assert(t, warns == nil, warns)
+			}
+			if tc.getter != nil {
+				assert.Equal(t, tc.value, tc.getter(conf))
+			}
+		})
+	}
+}
+func TestParseEnvDeprecated(t *testing.T) {
+	testCases := []struct {
+		name  string
+		key   string
+		value string
+		field string
+	}{
+		{DeprecatedEnvOperatorPlugins, CMSvcOperatorPlugins, "test-plugins", "OperatorPlugins"},
+		{DeprecatedEnvPlaceholderImage, CMSvcPlaceholderImage, "test-image", "PlaceHolderImage"},
+	}
+
+	oldLookup := setEnvLookupFunc(envLookupFunc)
+	defer setEnvLookupFunc(oldLookup)
+
+	for _, tc := range testCases {
+		env := map[string]string{tc.name: tc.value}
+		_ = setEnvLookupFunc(func(s string) (string, bool) {
+			val, ok := env[s]
+			return val, ok
+		})
+
+		t.Run(tc.name, func(t *testing.T) {
+			prev := CreateDefaultConfig()
+			seen := make(map[string]string)
+
+			// check for consistent override
+			cm, errs := parseConfig(map[string]string{tc.key: tc.value}, prev, seen)
+			assert.Assert(t, errs == nil, errs)
+			conf, warns := parseEnvConfig(cm, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Equal(t, tc.value, getConfValue(t, conf, tc.field))
+			assert.Assert(t, warns == nil, warns)
+
+			// check for inconsistent override
+			cm, errs = parseConfig(map[string]string{tc.key: "original-value"}, prev, seen)
+			assert.Assert(t, errs == nil, errs)
+			conf, warns = parseEnvConfig(cm, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Equal(t, "original-value", getConfValue(t, conf, tc.field))
+			assert.Equal(t, 1, len(warns), "warning not present")
+			assert.Assert(t, strings.Contains(warns[0], "inconsistent"), "foo", "wrong warning")
+		})
+	}
+}
+
+func TestParseCliDefaults(t *testing.T) {
+	prev := CreateDefaultConfig()
+	seen := make(map[string]string)
+	conf, warns := parseCliConfig(prev, seen)
+	assert.Assert(t, warns == nil, warns)
+	assertDefaults(t, conf)
+}
+
+func TestParseCli(t *testing.T) {
+	testCases := []struct {
+		name      string
+		key       string
+		field     string
+		value     interface{}
+		prevValue interface{}
+	}{
+		{DeprecatedCliClusterID, CMSvcClusterID, "ClusterID", "test-cluster", "prev-cluster"},
+		{DeprecatedCliPolicyGroup, CMSvcPolicyGroup, "PolicyGroup", "test-policy-group", "prev-policy-group"},
+		{DeprecatedCliInterval, CMSvcSchedulingInterval, "Interval", 5 * time.Second, 15 * time.Second},
+		{DeprecatedCliLogLevel, CMLogLevel, "LoggingLevel", -1, 0},
+		{DeprecatedCliVolumeBindTimeout, CMSvcVolumeBindTimeout, "VolumeBindTimeout", 3 * time.Minute, 5 * time.Minute},
+		{DeprecatedCliEventChannelCapacity, CMSvcEventChannelCapacity, "EventChannelCapacity", 1234, 4321},
+		{DeprecatedCliDispatchTimeout, CMSvcDispatchTimeout, "DispatchTimeout", 15 * time.Second, 5 * time.Second},
+		{DeprecatedCliKubeQPS, CMKubeQPS, "KubeQPS", 2345, 5432},
+		{DeprecatedCliKubeBurst, CMKubeBurst, "KubeBurst", 3456, 6543},
+		{DeprecatedCliOperatorPlugins, CMSvcOperatorPlugins, "OperatorPlugins", "test-operators", "prev-operators"},
+		{DeprecatedCliEnableConfigHotRefresh, CMSvcEnableConfigHotRefresh, "EnableConfigHotRefresh", false, true},
+		{DeprecatedCliDisableGangScheduling, CMSvcDisableGangScheduling, "DisableGangScheduling", true, false},
+		{DeprecatedCliPlaceHolderImage, CMSvcPlaceholderImage, "PlaceHolderImage", "test-image", "prev-image"},
+	}
+
+	oldLookup := setCliLookupFunc(cliArgsFunc)
+	defer setCliLookupFunc(oldLookup)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setCliLookupFunc(func() (string, []string) {
+				return "test", []string{fmt.Sprintf("-%s=%v", tc.name, tc.value)}
+			})
+
+			// validate updates
+			prev := CreateDefaultConfig()
+			seen := make(map[string]string)
+			conf, warns := parseCliConfig(prev, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Assert(t, warns == nil, warns)
+			assert.Equal(t, tc.value, getConfValue(t, conf, tc.field))
+
+			// validate conflicting overrides
+			prev = CreateDefaultConfig()
+			seen[tc.key] = tc.key
+			setConfValue(t, prev, tc.field, tc.prevValue)
+			conf, warns = parseCliConfig(prev, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Equal(t, 1, len(warns), "warnings not present")
+			assert.Assert(t, strings.Contains(warns[0], "inconsistent"), warns[0])
+			assert.Equal(t, tc.prevValue, getConfValue(t, conf, tc.field))
+		})
+	}
+}
+
+func TestParseCliObsolete(t *testing.T) {
+	testCases := []struct {
+		name  string
+		key   string
+		field string
+		value interface{}
+	}{
+		{DeprecatedCliClusterVersion, DeprecatedCliClusterVersion, "ClusterVersion", "1.0"},
+		{DeprecatedCliUserLabelKey, DeprecatedCliUserLabelKey, "UserLabelKey", "test-user-label"},
+		{DeprecatedCliLogEncoding, DeprecatedCliLogEncoding, "", "test-encoding"},
+		{DeprecatedCliLogFile, DeprecatedCliLogFile, "", "test-log-file"},
+	}
+
+	oldLookup := setCliLookupFunc(cliArgsFunc)
+	defer setCliLookupFunc(oldLookup)
+
+	for _, tc := range testCases {
+		setCliLookupFunc(func() (string, []string) {
+			return "test", []string{fmt.Sprintf("-%s=%v", tc.key, tc.value)}
+		})
+		t.Run(tc.name, func(t *testing.T) {
+			prev := CreateDefaultConfig()
+			seen := make(map[string]string)
+			conf, warns := parseCliConfig(prev, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Equal(t, 1, len(warns), "warnings not present")
+			assert.Assert(t, strings.Contains(warns[0], "Obsolete"), warns[0])
+			if tc.field != "" {
+				assert.Equal(t, getConfValue(t, prev, tc.field), getConfValue(t, conf, tc.field))
+			}
+		})
+	}
+}
+
+// set a configuration value by field name
+func setConfValue(t *testing.T, conf *SchedulerConf, name string, value interface{}) {
+	val := reflect.ValueOf(conf).Elem().FieldByName(name)
+	assert.Assert(t, val.IsValid(), "Field not valid: "+name)
+	val.Set(reflect.ValueOf(value))
+}
+
+// get a configuration value by field name
+func getConfValue(t *testing.T, conf *SchedulerConf, name string) interface{} {
+	val := reflect.ValueOf(conf).Elem().FieldByName(name)
+	assert.Assert(t, val.IsValid(), "Field not valid: "+name)
+	return val.Interface()
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -19,14 +19,11 @@
 package log
 
 import (
-	"encoding/json"
 	"fmt"
 	"sync"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/apache/yunikorn-k8shim/pkg/conf"
 )
 
 var once sync.Once
@@ -39,20 +36,15 @@ func Logger() *zap.Logger {
 }
 
 func initLogger() {
-	configs := conf.GetSchedulerConf()
-
 	outputPaths := []string{"stdout"}
-	if configs.LogFile != "" {
-		outputPaths = append(outputPaths, configs.LogFile)
-	}
 
 	zapConfigs = &zap.Config{
-		Level:             zap.NewAtomicLevelAt(zapcore.Level(configs.LoggingLevel)),
+		Level:             zap.NewAtomicLevelAt(zapcore.Level(0)),
 		Development:       false,
 		DisableCaller:     false,
 		DisableStacktrace: false,
 		Sampling:          nil,
-		Encoding:          configs.LogEncoding,
+		Encoding:          "console",
 		EncoderConfig: zapcore.EncoderConfig{
 			MessageKey:    "message",
 			LevelKey:      "level",
@@ -78,15 +70,6 @@ func initLogger() {
 	if err != nil {
 		fmt.Printf("Logging disabled, logger init failed with error: %v", err)
 		logger = zap.NewNop()
-	}
-
-	// dump configuration
-	var c []byte
-	c, err = json.MarshalIndent(&configs, "", " ")
-	if err != nil {
-		logger.Info("scheduler configuration, json conversion failed", zap.Any("configs", configs))
-	} else {
-		logger.Info("scheduler configuration, pretty print", zap.ByteString("configs", c))
 	}
 
 	// make sure logs are flushed

--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
@@ -480,7 +480,7 @@ func (c *admissionController) shouldLabelNamespace(namespace string) bool {
 }
 
 func (c *admissionController) validateConfigMap(cm *v1.ConfigMap) error {
-	if cm.Name == constants.DefaultConfigMapName {
+	if cm.Name == constants.ConfigMapName {
 		if content, ok := cm.Data[c.configName]; ok {
 			checksum := fmt.Sprintf("%X", sha256.Sum256([]byte(content)))
 			log.Logger().Info("Validating YuniKorn configuration", zap.String("checksum", checksum))

--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
@@ -272,7 +272,7 @@ func TestValidateConfigMap(t *testing.T) {
 	}
 	configmap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: constants.DefaultConfigMapName,
+			Name: constants.ConfigMapName,
 		},
 		Data: make(map[string]string),
 	}
@@ -351,7 +351,7 @@ func TestValidateConfigMapServerError(t *testing.T) {
 func prepareConfigMap(data string) *v1.ConfigMap {
 	configmap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: constants.DefaultConfigMapName,
+			Name: constants.ConfigMapName,
 		},
 		Data: map[string]string{"queues.yaml": data},
 	}

--- a/pkg/schedulerplugin/conf/pluginconf_test.go
+++ b/pkg/schedulerplugin/conf/pluginconf_test.go
@@ -18,7 +18,11 @@
 package conf
 
 import (
+	"fmt"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gotest.tools/assert"
@@ -27,26 +31,138 @@ import (
 	defaults "github.com/apache/yunikorn-k8shim/pkg/conf"
 )
 
-func TestDefaultValues(t *testing.T) {
+func TestParsePluginCliDefaultValues(t *testing.T) {
 	cmd := &cobra.Command{}
 	InitCliFlagSet(cmd)
-	conf := NewSchedulerConf()
+
+	seen := make(map[string]string)
+	defConfig := defaults.CreateDefaultConfig()
+	conf := defConfig.Clone()
+
+	ParsePluginCli(defConfig, seen)
 
 	assert.Equal(t, conf.ClusterID, defaults.DefaultClusterID, "wrong cluster id")
-	assert.Equal(t, conf.ClusterVersion, defaults.DefaultClusterVersion, "wrong cluster version")
+	assert.Equal(t, conf.ClusterVersion, defaults.BuildVersion, "wrong cluster version")
 	assert.Equal(t, conf.PolicyGroup, defaults.DefaultPolicyGroup, "wrong policy group")
 	assert.Equal(t, conf.Interval, defaults.DefaultSchedulingInterval, "wrong scheduling interval")
-	assert.Equal(t, conf.KubeConfig, "", "wrong kube config path")
+	assert.Equal(t, conf.KubeConfig, defaults.GetDefaultKubeConfigPath(), "wrong kube config path")
 	assert.Equal(t, conf.LoggingLevel, defaults.DefaultLoggingLevel, "wrong logging level")
-	assert.Equal(t, conf.LogEncoding, defaults.DefaultLogEncoding, "wrong log encoding")
-	assert.Equal(t, conf.LogFile, "", "wrong log file")
 	assert.Equal(t, conf.EventChannelCapacity, defaults.DefaultEventChannelCapacity, "wrong event channel capacity")
 	assert.Equal(t, conf.DispatchTimeout, defaults.DefaultDispatchTimeout, "wrong dispatch timeout")
 	assert.Equal(t, conf.KubeQPS, defaults.DefaultKubeQPS, "wrong kube qps")
 	assert.Equal(t, conf.KubeBurst, defaults.DefaultKubeBurst, "wrong kube burst")
-	assert.Equal(t, conf.OperatorPlugins, "general", "wrong operator plugins")
-	assert.Equal(t, conf.EnableConfigHotRefresh, true, "config hot refresh not enabled")
-	assert.Equal(t, conf.DisableGangScheduling, false, "gang scheduling not enabled")
+	assert.Equal(t, conf.OperatorPlugins, defaults.DefaultOperatorPlugins, "wrong operator plugins")
+	assert.Equal(t, conf.EnableConfigHotRefresh, defaults.DefaultEnableConfigHotRefresh, "config hot refresh not enabled")
+	assert.Equal(t, conf.DisableGangScheduling, defaults.DefaultDisableGangScheduling, "gang scheduling not enabled")
 	assert.Equal(t, conf.UserLabelKey, constants.DefaultUserLabel, "wrong user label")
 	assert.Equal(t, conf.SchedulerName, DefaultSchedulerName, "wrong scheduler name")
+}
+
+func TestParsePluginCliDeprecatedValues(t *testing.T) {
+	testCases := []struct {
+		name      string
+		key       string
+		field     string
+		value     interface{}
+		prevValue interface{}
+	}{
+		{DeprecatedArgClusterID, defaults.CMSvcClusterID, "ClusterID", "test-cluster-id", "cluster-id"},
+		{DeprecatedArgPolicyGroup, defaults.CMSvcPolicyGroup, "PolicyGroup", "test-policy-group", "policy-group"},
+		{DeprecatedArgSchedulingInterval, defaults.CMSvcSchedulingInterval, "Interval", 5 * time.Second, 3 * time.Second},
+		{DeprecatedArgKubeConfig, defaults.EnvKubeConfig, "KubeConfig", "test-kube-config", "kube-config"},
+		{DeprecatedArgLogLevel, defaults.CMLogLevel, "LoggingLevel", -1, 0},
+		{DeprecatedArgEventChannelCapacity, defaults.CMSvcEventChannelCapacity, "EventChannelCapacity", 2345, 1234},
+		{DeprecatedArgDispatchTimeout, defaults.CMSvcDispatchTimeout, "DispatchTimeout", 20 * time.Second, 10 * time.Second},
+		{DeprecatedArgKubeQPS, defaults.CMKubeQPS, "KubeQPS", 2345, 1234},
+		{DeprecatedArgKubeBurst, defaults.CMKubeBurst, "KubeBurst", 2345, 1234},
+		{DeprecatedArgOperatorPlugins, defaults.CMSvcOperatorPlugins, "OperatorPlugins", "test-plugins", "plugins"},
+		{DeprecatedArgEnableConfigHotRefresh, defaults.CMSvcEnableConfigHotRefresh, "EnableConfigHotRefresh", false, true},
+		{DeprecatedArgDisableGangScheduling, defaults.CMSvcDisableGangScheduling, "DisableGangScheduling", true, false},
+		{DeprecatedArgPlaceHolderImage, defaults.CMSvcOperatorPlugins, "PlaceHolderImage", "test-image", "image"},
+	}
+
+	oldFlags := pluginFlags
+	defer func() { pluginFlags = oldFlags }()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// validate no overrides
+			InitCliFlagSet(&cobra.Command{})
+			args := []string{
+				fmt.Sprintf("--%s=%v", tc.name, tc.value),
+			}
+			err := pluginFlags.Parse(args)
+			assert.NilError(t, err, "errors in parsing")
+			prev := defaults.CreateDefaultConfig()
+			seen := make(map[string]string)
+			conf, warns := ParsePluginCli(prev, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Equal(t, 0, len(warns), "warnings present")
+			assert.Equal(t, tc.value, getConfValue(t, conf, tc.field))
+
+			// validate incompatible overrides
+			InitCliFlagSet(&cobra.Command{})
+			err = pluginFlags.Parse(args)
+			assert.NilError(t, err, "errors in parsing")
+			setConfValue(t, prev, tc.field, tc.prevValue)
+			seen[tc.key] = tc.key
+			conf, warns = ParsePluginCli(prev, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Equal(t, 1, len(warns), "warning not present")
+			assert.Assert(t, strings.Contains(warns[0], "inconsistent"), warns[0])
+			assert.Equal(t, getConfValue(t, prev, tc.field), getConfValue(t, conf, tc.field))
+		})
+	}
+}
+
+func TestParsePluginCliObsoleteValues(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value interface{}
+		field string
+	}{
+		{DeprecatedArgSchedulerName, "test-scheduler-name", "SchedulerName"},
+		{DeprecatedArgClusterVersion, "test-cluster-version", "ClusterVersion"},
+		{DeprecatedArgUserLabelKey, "test-user-label-key", "UserLabelKey"},
+		{DeprecatedArgLogEncoding, "test-log-encoding", ""},
+		{DeprecatedArgLogFile, "test-log-file", ""},
+	}
+
+	oldFlags := pluginFlags
+	defer func() { pluginFlags = oldFlags }()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			InitCliFlagSet(cmd)
+			args := []string{
+				fmt.Sprintf("--%s=%v", tc.name, tc.value),
+			}
+			err := pluginFlags.Parse(args)
+			assert.NilError(t, err, "errors in parsing")
+			prev := defaults.CreateDefaultConfig()
+			seen := make(map[string]string)
+			conf, warns := ParsePluginCli(prev, seen)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Equal(t, 1, len(warns), "warning not present")
+			assert.Assert(t, strings.Contains(warns[0], "Obsolete"), warns[0])
+			if tc.field != "" {
+				assert.Equal(t, getConfValue(t, prev, tc.field), getConfValue(t, conf, tc.field))
+			}
+		})
+	}
+}
+
+// set a configuration value by field name
+func setConfValue(t *testing.T, conf *defaults.SchedulerConf, name string, value interface{}) {
+	val := reflect.ValueOf(conf).Elem().FieldByName(name)
+	assert.Assert(t, val.IsValid(), "Field not valid: "+name)
+	val.Set(reflect.ValueOf(value))
+}
+
+// get a configuration value by field name
+func getConfValue(t *testing.T, conf *defaults.SchedulerConf, name string) interface{} {
+	val := reflect.ValueOf(conf).Elem().FieldByName(name)
+	assert.Assert(t, val.IsValid(), "Field not valid: "+name)
+	return val.Interface()
 }

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
+	"github.com/apache/yunikorn-k8shim/pkg/client"
+
 	"github.com/apache/yunikorn-core/pkg/entrypoint"
 	"github.com/apache/yunikorn-k8shim/pkg/cache"
 	"github.com/apache/yunikorn-k8shim/pkg/common/events"
@@ -204,6 +206,16 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 // NewSchedulerPlugin initializes a new plugin and returns it
 func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
 	log.Logger().Info("Build info", zap.String("version", conf.BuildVersion), zap.String("date", conf.BuildDate))
+
+	configMaps, err := client.LoadBootstrapConfigMaps()
+	if err != nil {
+		log.Logger().Fatal("Unable to bootstrap configuration", zap.Error(err))
+	}
+
+	err = conf.UpdateConfigMaps(configMaps, true)
+	if err != nil {
+		log.Logger().Fatal("Unable to load initial configmaps", zap.Error(err))
+	}
 
 	// start the YK core scheduler
 	serviceContext := entrypoint.StartAllServicesWithLogger(log.Logger(), log.GetZapConfigs())

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -214,13 +214,15 @@ func (ss *KubernetesShim) registerShimLayer() error {
 	buildInfoMap["buildDate"] = conf.BuildDate
 	buildInfoMap["isPluginVersion"] = strconv.FormatBool(conf.IsPluginVersion)
 
-	configMap, err := ss.context.LoadConfigMap()
+	configMaps, err := ss.context.LoadConfigMaps()
 	if err != nil {
-		log.Logger().Error("failed to load yunikorn configmap", zap.Error(err))
+		log.Logger().Error("failed to load yunikorn configmaps", zap.Error(err))
 		return err
 	}
-	config := utils.GetCoreSchedulerConfigFromConfigMap(configMap)
-	extraConfig := utils.GetExtraConfigFromConfigMap(configMap)
+
+	confMap := conf.FlattenConfigMaps(configMaps)
+	config := utils.GetCoreSchedulerConfigFromConfigMap(confMap)
+	extraConfig := utils.GetExtraConfigFromConfigMap(confMap)
 
 	registerMessage := si.RegisterResourceManagerRequest{
 		RmID:        configuration.ClusterID,

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -232,7 +232,7 @@ partitions:
 
 	// one task get bound, one ask failed, so we are expecting only 1 allocation in the scheduler
 	err = cluster.waitAndVerifySchedulerAllocations("root.a",
-		"[my-kube-cluster]default", "app0001", 1)
+		"[mycluster]default", "app0001", 1)
 	assert.NilError(t, err, "number of allocations is not expected, error")
 }
 

--- a/test/e2e/admission_controller/admission_controller_suite_test.go
+++ b/test/e2e/admission_controller/admission_controller_suite_test.go
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 	Ω(namespace.Status.Phase).Should(Equal(v1.NamespaceActive))
 
 	By("Get the default ConfigMap and copy it")
-	cm, err := kubeClient.GetConfigMaps(configmanager.YuniKornTestConfig.YkNamespace, constants.DefaultConfigMapName)
+	cm, err := kubeClient.GetConfigMaps(configmanager.YuniKornTestConfig.YkNamespace, constants.ConfigMapName)
 	Ω(err).ShouldNot(HaveOccurred())
 
 	oldConfigMap = cm.DeepCopy()

--- a/test/e2e/admission_controller/admission_controller_test.go
+++ b/test/e2e/admission_controller/admission_controller_test.go
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("AdmissionController", func() {
 
 		invalidConfigMap := v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      constants.DefaultConfigMapName,
+				Name:      constants.ConfigMapName,
 				Namespace: configmanager.YuniKornTestConfig.YkNamespace,
 			},
 			Data: make(map[string]string),
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("AdmissionController", func() {
 	ginkgo.It("Configure the scheduler with invalid configmap", func() {
 		invalidConfigMap := v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      constants.DefaultConfigMapName,
+				Name:      constants.ConfigMapName,
 				Namespace: configmanager.YuniKornTestConfig.YkNamespace,
 			},
 			Data: make(map[string]string),


### PR DESCRIPTION
### What is this PR for?
Read configuration from new ConfigMap entries in addition to legacy values, and deprecate old configuration sources.

[WIP] Based on and depends on from YUNIKORN-1365.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1369

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
