### PR TITLE
[YUNIKORN-1381] Stop default scheduler from preempting YuniKorn pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,12 +204,11 @@ run: build
 .PHONY: run_plugin
 run_plugin: build_plugin
 	@echo "running scheduler plugin locally"
-	./scripts/plugin-conf-gen.sh $(KUBECONFIG) "${LOCAL_CONF}/scheduler-config-local.yaml"
 	cd ${DEV_BIN_DIR} && \
 	  ./${PLUGIN_BINARY} \
 	    --address=0.0.0.0 \
 	    --leader-elect=false \
-	    --config=../../${LOCAL_CONF}/scheduler-config-local.yaml \
+	    --config=../../conf/scheduler-config-local.yaml \
 	    -v=2 \
 	    --yk-scheduler-name=yunikorn \
 	    --yk-kube-config=$(KUBECONFIG) \
@@ -223,6 +222,7 @@ init:
 	mkdir -p ${DEV_BIN_DIR}
 	mkdir -p ${RELEASE_BIN_DIR}
 	mkdir -p ${ADMISSION_CONTROLLER_BIN_DIR}
+	./scripts/plugin-conf-gen.sh $(KUBECONFIG) "conf/scheduler-config.yaml" "conf/scheduler-config-local.yaml"
 
 # Build scheduler binary for dev and test
 .PHONY: build

--- a/conf/scheduler-config.yaml
+++ b/conf/scheduler-config.yaml
@@ -25,3 +25,5 @@ profiles:
       multiPoint:
         enabled:
         - name: YuniKornPlugin
+        disabled:
+        - name: DefaultPreemption

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -108,7 +108,7 @@ func (sp *YuniKornSchedulerPlugin) PreFilter(_ context.Context, state *framework
 				sp.context.RemovePodAllocation(string(pod.UID))
 				dispatcher.Dispatch(cache.NewRejectTaskEvent(app.GetApplicationID(), task.GetTaskID(),
 					fmt.Sprintf("task %s rejected by scheduler", task.GetTaskID())))
-				return framework.NewStatus(framework.Unschedulable, "Pod is not ready for scheduling")
+				return framework.NewStatus(framework.UnschedulableAndUnresolvable, "Pod is not ready for scheduling")
 			}
 
 			nodeID, ok := sp.context.GetPendingPodAllocation(string(pod.UID))
@@ -123,7 +123,7 @@ func (sp *YuniKornSchedulerPlugin) PreFilter(_ context.Context, state *framework
 		}
 	}
 
-	return framework.NewStatus(framework.Unschedulable, "Pod is not ready for scheduling")
+	return framework.NewStatus(framework.UnschedulableAndUnresolvable, "Pod is not ready for scheduling")
 }
 
 // PreFilterExtensions is unused
@@ -163,7 +163,7 @@ func (sp *YuniKornSchedulerPlugin) Filter(_ context.Context, _ *framework.CycleS
 		}
 	}
 
-	return framework.NewStatus(framework.Unschedulable, "Pod is not fit for node")
+	return framework.NewStatus(framework.UnschedulableAndUnresolvable, "Pod is not fit for node")
 }
 
 func (sp *YuniKornSchedulerPlugin) EventsToRegister() []framework.ClusterEvent {

--- a/scripts/plugin-conf-gen.sh
+++ b/scripts/plugin-conf-gen.sh
@@ -19,18 +19,10 @@
 #
 
 KCFG=$1
-DEST=$2
-cat > "${DEST}" <<EOL
-apiVersion: kubescheduler.config.k8s.io/v1beta3
-kind: KubeSchedulerConfiguration
+SRC=$2
+DEST=$3
+cp -f "${SRC}" "${DEST}"
+cat >> "${DEST}" <<EOL
 clientConnection:
   kubeconfig: ${KCFG}
-leaderElection:
-  leaderElect: false
-profiles:
-  - schedulerName: yunikorn
-    plugins:
-      multiPoint:
-        enabled:
-        - name: YuniKornPlugin
 EOL


### PR DESCRIPTION
### What is this PR for?
When running in plugin mode, return UnschedulableAndUnresolvable to prevent preemption of pods. Additionally, disable the default preemption plugin so that non-YuniKorn pods do not trigger preemption of YuniKorn pods.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1381

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
