### PR TITLE
[YUNIKORN-1370] Read admission controller config from configmaps

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -333,7 +333,7 @@ func (ctx *Context) deleteConfigMaps(obj interface{}) {
 	case cache.DeletedFinalStateUnknown:
 		configmap = utils.Convert2ConfigMap(obj)
 	default:
-		log.Logger().Debug("unable to convert to configmap")
+		log.Logger().Warn("unable to convert to configmap")
 		return
 	}
 

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date))
 
-	configMaps, err := client.LoadBootstrapConfigMaps()
+	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {
 		log.Logger().Fatal("Unable to bootstrap configuration", zap.Error(err))
 	}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -78,5 +78,7 @@ func initLogger() {
 }
 
 func GetZapConfigs() *zap.Config {
+	// force init
+	_ = Logger()
 	return zapConfigs
 }

--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
@@ -25,9 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -39,21 +37,24 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
+	schedulerconf "github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 	"github.com/apache/yunikorn-k8shim/pkg/plugin/admissioncontrollers/webhook/annotation"
+	"github.com/apache/yunikorn-k8shim/pkg/plugin/admissioncontrollers/webhook/conf"
 	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 )
 
 const (
-	autoGenAppPrefix             = "yunikorn"
-	autoGenAppSuffix             = "autogen"
-	enableConfigHotRefreshEnvVar = "ENABLE_CONFIG_HOT_REFRESH"
-	yunikornPod                  = "yunikorn"
-	defaultQueue                 = "root.default"
-	configHotFreshResponse       = "ConfigHotRefresh is disabled. Please use the REST API to update the configuration, or enable configHotRefresh. "
-	admissionReviewAPIVersion    = "admission.k8s.io/v1"
-	admissionReviewKind          = "AdmissionReview"
-	userInfoAnnotation           = siCommon.DomainYuniKorn + "user.info"
+	autoGenAppPrefix                = "yunikorn"
+	autoGenAppSuffix                = "autogen"
+	yunikornPod                     = "yunikorn"
+	defaultQueue                    = "root.default"
+	admissionReviewAPIVersion       = "admission.k8s.io/v1"
+	admissionReviewKind             = "AdmissionReview"
+	userInfoAnnotation              = siCommon.DomainYuniKorn + "user.info"
+	schedulerValidateConfURLPattern = "http://%s/ws/v1/validate-conf"
+	mutateURL                       = "/mutate"
+	validateConfURL                 = "/validate-conf"
 )
 
 var (
@@ -63,14 +64,8 @@ var (
 )
 
 type admissionController struct {
-	configName               string
-	schedulerValidateConfURL string
-	bypassAuth               bool
-	processNamespaces        []*regexp.Regexp
-	bypassNamespaces         []*regexp.Regexp
-	labelNamespaces          []*regexp.Regexp
-	noLabelNamespaces        []*regexp.Regexp
-	annotationHandler        *annotation.UserGroupAnnotationHandler
+	conf              *conf.AdmissionControllerConf
+	annotationHandler *annotation.UserGroupAnnotationHandler
 }
 
 type patchOperation struct {
@@ -84,92 +79,14 @@ type ValidateConfResponse struct {
 	Reason  string `json:"reason"`
 }
 
-func initAdmissionController(configName string,
-	schedulerValidateConfURL string,
-	processNamespaces string,
-	bypassNamespaces string,
-	labelNamespaces string,
-	noLabelNamespaces string,
-	bypassAuth bool,
-	trustControllers bool,
-	systemUsers string,
-	externalUsers string,
-	externalGroups string) (*admissionController, error) {
-	processRegexes, err := parseRegexes(processNamespaces)
-	if err != nil {
-		return nil, err
-	}
-	bypassRegexes, err := parseRegexes(bypassNamespaces)
-	if err != nil {
-		return nil, err
-	}
-	labelRegexes, err := parseRegexes(labelNamespaces)
-	if err != nil {
-		return nil, err
-	}
-	noLabelRegexes, err := parseRegexes(noLabelNamespaces)
-	if err != nil {
-		return nil, err
+func initAdmissionController(conf *conf.AdmissionControllerConf) *admissionController {
+	hook := &admissionController{
+		conf:              conf,
+		annotationHandler: annotation.NewUserGroupAnnotationHandler(conf),
 	}
 
-	var systemUsersRegexes []*regexp.Regexp
-	if systemUsers != "" {
-		regexps, err := parseRegexes(systemUsers)
-		if err != nil {
-			return nil, err
-		}
-		systemUsersRegexes = regexps
-	}
-
-	var externalUsersRegexes []*regexp.Regexp
-	if externalUsers != "" {
-		regexps, err := parseRegexes(externalUsers)
-		if err != nil {
-			return nil, err
-		}
-		externalUsersRegexes = regexps
-	}
-
-	var externalGroupsRegexes []*regexp.Regexp
-	if externalGroups != "" {
-		regexps, err := parseRegexes(externalGroups)
-		if err != nil {
-			return nil, err
-		}
-		externalGroupsRegexes = regexps
-	}
-
-	annotationHandler := &annotation.UserGroupAnnotationHandler{
-		TrustControllers: trustControllers,
-		SystemUsers:      systemUsersRegexes,
-		ExternalGroups:   externalGroupsRegexes,
-		ExternalUsers:    externalUsersRegexes,
-	}
-
-	hook := admissionController{
-		configName:               configName,
-		schedulerValidateConfURL: schedulerValidateConfURL,
-		bypassAuth:               bypassAuth,
-		processNamespaces:        processRegexes,
-		bypassNamespaces:         bypassRegexes,
-		labelNamespaces:          labelRegexes,
-		noLabelNamespaces:        noLabelRegexes,
-		annotationHandler:        annotationHandler,
-	}
-
-	log.Logger().Info("Initialized YuniKorn Admission Controller",
-		zap.String("processNs", processNamespaces),
-		zap.String("bypassNs", bypassNamespaces),
-		zap.String("labelNs", labelNamespaces),
-		zap.String("noLabelNs", noLabelNamespaces),
-		zap.Bool("bypassAuth", bypassAuth),
-		zap.Bool("trustControllers", trustControllers),
-		zap.String("systemUsers", systemUsers),
-		zap.String("externalUsers", externalUsers),
-		zap.String("externalGroups", externalGroups),
-	)
-
-	return &hook, nil
+	log.Logger().Info("Initialized YuniKorn Admission Controller")
+	return hook
 }
 
 func parseRegexes(patterns string) ([]*regexp.Regexp, error) {
@@ -306,7 +223,7 @@ func (c *admissionController) processWorkload(req *admissionv1.AdmissionRequest)
 }
 
 func (c *admissionController) checkUserInfoAnnotation(getAnnotation func() (string, bool), userName string, groups []string, uid string) *admissionv1.AdmissionResponse {
-	if annotation, ok := getAnnotation(); ok && !c.bypassAuth {
+	if annotation, ok := getAnnotation(); ok && !c.conf.GetBypassAuth() {
 		if allowed := c.annotationHandler.IsAnnotationAllowed(userName, groups); !allowed {
 			errMsg := fmt.Sprintf("user %s with groups [%s] is not allowed to set user annotation", userName,
 				strings.Join(groups, ","))
@@ -383,20 +300,6 @@ func updateLabels(namespace string, pod *v1.Pod, patch []patchOperation) []patch
 	return patch
 }
 
-func isConfigMapUpdateAllowed(userInfo string) bool {
-	hotRefreshEnabled := os.Getenv(enableConfigHotRefreshEnvVar)
-	allowed, err := strconv.ParseBool(hotRefreshEnabled)
-	if err != nil {
-		log.Logger().Error("Failed to parse ENABLE_CONFIG_HOT_REFRESH value",
-			zap.String("ENABLE_CONFIG_HOT_REFRESH", hotRefreshEnabled))
-		return false
-	}
-	if allowed || strings.Contains(userInfo, "yunikorn-admin") {
-		return true
-	}
-	return false
-}
-
 func (c *admissionController) validateConf(req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	if req == nil {
 		log.Logger().Warn("empty request received")
@@ -404,14 +307,16 @@ func (c *admissionController) validateConf(req *admissionv1.AdmissionRequest) *a
 	}
 
 	uid := string(req.UID)
-	if !isConfigMapUpdateAllowed(req.UserInfo.Username) {
-		return admissionResponseBuilder(uid, false, configHotFreshResponse, nil)
-	}
 
 	var requestKind = req.Kind.Kind
 	if requestKind != "ConfigMap" {
 		log.Logger().Warn("request kind is not configmap", zap.String("requestKind", requestKind))
 		return admissionResponseBuilder(uid, true, "", nil)
+	}
+
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = "default"
 	}
 
 	var configmap v1.ConfigMap
@@ -421,7 +326,7 @@ func (c *admissionController) validateConf(req *admissionv1.AdmissionRequest) *a
 	}
 
 	// validate new/updated config map
-	if err := c.validateConfigMap(&configmap); err != nil {
+	if err := c.validateConfigMap(namespace, &configmap); err != nil {
 		log.Logger().Error("failed to validate yunikorn configs", zap.Error(err))
 		return admissionResponseBuilder(uid, false, err.Error(), nil)
 	}
@@ -430,10 +335,11 @@ func (c *admissionController) validateConf(req *admissionv1.AdmissionRequest) *a
 }
 
 func (c *admissionController) namespaceMatchesProcessList(namespace string) bool {
-	if len(c.processNamespaces) == 0 {
+	processNamespaces := c.conf.GetProcessNamespaces()
+	if len(processNamespaces) == 0 {
 		return true
 	}
-	for _, re := range c.processNamespaces {
+	for _, re := range processNamespaces {
 		if re.MatchString(namespace) {
 			return true
 		}
@@ -442,7 +348,8 @@ func (c *admissionController) namespaceMatchesProcessList(namespace string) bool
 }
 
 func (c *admissionController) namespaceMatchesBypassList(namespace string) bool {
-	for _, re := range c.bypassNamespaces {
+	bypassNamespaces := c.conf.GetBypassNamespaces()
+	for _, re := range bypassNamespaces {
 		if re.MatchString(namespace) {
 			return true
 		}
@@ -451,10 +358,11 @@ func (c *admissionController) namespaceMatchesBypassList(namespace string) bool 
 }
 
 func (c *admissionController) namespaceMatchesLabelList(namespace string) bool {
-	if len(c.labelNamespaces) == 0 {
+	labelNamespaces := c.conf.GetLabelNamespaces()
+	if len(labelNamespaces) == 0 {
 		return true
 	}
-	for _, re := range c.labelNamespaces {
+	for _, re := range labelNamespaces {
 		if re.MatchString(namespace) {
 			return true
 		}
@@ -463,7 +371,8 @@ func (c *admissionController) namespaceMatchesLabelList(namespace string) bool {
 }
 
 func (c *admissionController) namespaceMatchesNoLabelList(namespace string) bool {
-	for _, re := range c.noLabelNamespaces {
+	noLabelNamespaces := c.conf.GetNoLabelNamespaces()
+	for _, re := range noLabelNamespaces {
 		if re.MatchString(namespace) {
 			return true
 		}
@@ -479,47 +388,64 @@ func (c *admissionController) shouldLabelNamespace(namespace string) bool {
 	return c.namespaceMatchesLabelList(namespace) && !c.namespaceMatchesNoLabelList(namespace)
 }
 
-func (c *admissionController) validateConfigMap(cm *v1.ConfigMap) error {
-	if cm.Name == constants.ConfigMapName {
-		if content, ok := cm.Data[c.configName]; ok {
-			checksum := fmt.Sprintf("%X", sha256.Sum256([]byte(content)))
-			log.Logger().Info("Validating YuniKorn configuration", zap.String("checksum", checksum))
-			log.Logger().Debug("Configmap data", zap.ByteString("content", []byte(content)))
-			response, err := http.Post(c.schedulerValidateConfURL, "application/json", bytes.NewBuffer([]byte(content)))
-			if err != nil {
-				log.Logger().Error("YuniKorn scheduler is unreachable, assuming configmap is valid", zap.Error(err))
-				return nil
-			}
-			defer response.Body.Close()
-			if response.StatusCode < 200 || response.StatusCode > 299 {
-				log.Logger().Error("YuniKorn scheduler responded with unexpected status, assuming configmap is valid",
-					zap.Int("status", response.StatusCode))
-				return nil
-			}
-			responseBytes, err := io.ReadAll(response.Body)
-			if err != nil {
-				log.Logger().Error("Unable to read response from YuniKorn scheduler, assuming configmap is valid", zap.Error(err))
-				return nil
-			}
-			var responseData ValidateConfResponse
-			if err := json.Unmarshal(responseBytes, &responseData); err != nil {
-				log.Logger().Error("Unable to parse response from YuniKorn scheduler, assuming configmap is valid", zap.Error(err))
-				return nil
-			}
-			if !responseData.Allowed {
-				err = fmt.Errorf(responseData.Reason)
-				log.Logger().Error("Configmap validation failed, aborting", zap.Error(err))
-				return err
-			}
-		} else {
-			err := fmt.Errorf("required config '%s' not found in this configmap", c.configName)
-			log.Logger().Error("Unable to parse YuniKorn configmap", zap.Error(err))
-			return err
-		}
-		log.Logger().Info("Successfully validated YuniKorn configuration")
-	} else {
-		log.Logger().Debug("Configmap does not belong to YuniKorn", zap.String("Name", cm.Name))
+func (c *admissionController) validateConfigMap(namespace string, cm *v1.ConfigMap) error {
+	if namespace != c.conf.GetNamespace() {
+		log.Logger().Debug("Configmap does not belong to YuniKorn", zap.String("namespace", namespace), zap.String("Name", cm.Name))
+		return nil
 	}
+
+	configMaps := c.conf.GetConfigMaps()
+	switch cm.Name {
+	case constants.DefaultConfigMapName:
+		configMaps[0] = cm
+	case constants.ConfigMapName:
+		configMaps[1] = cm
+	default:
+		log.Logger().Debug("Configmap does not belong to YuniKorn", zap.String("namespace", namespace), zap.String("Name", cm.Name))
+		return nil
+	}
+
+	configs := schedulerconf.FlattenConfigMaps(configMaps)
+	policyGroup := conf.GetPendingPolicyGroup(configs)
+	confKey := fmt.Sprintf("%s.yaml", policyGroup)
+
+	content, ok := configs[confKey]
+	if !ok {
+		log.Logger().Info("Configmap missing policygroup config, using default", zap.String("entry", confKey))
+		content = ""
+	}
+
+	checksum := fmt.Sprintf("%X", sha256.Sum256([]byte(content)))
+	log.Logger().Info("Validating YuniKorn configuration", zap.String("checksum", checksum))
+	log.Logger().Debug("Configmap data", zap.ByteString("content", []byte(content)))
+	response, err := http.Post(fmt.Sprintf(schedulerValidateConfURLPattern, c.conf.GetSchedulerServiceAddress()), "application/json", bytes.NewBuffer([]byte(content)))
+	if err != nil {
+		log.Logger().Error("YuniKorn scheduler is unreachable, assuming configmap is valid", zap.Error(err))
+		return nil
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		log.Logger().Error("YuniKorn scheduler responded with unexpected status, assuming configmap is valid",
+			zap.Int("status", response.StatusCode))
+		return nil
+	}
+	responseBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Logger().Error("Unable to read response from YuniKorn scheduler, assuming configmap is valid", zap.Error(err))
+		return nil
+	}
+	var responseData ValidateConfResponse
+	if err = json.Unmarshal(responseBytes, &responseData); err != nil {
+		log.Logger().Error("Unable to parse response from YuniKorn scheduler, assuming configmap is valid", zap.Error(err))
+		return nil
+	}
+	if !responseData.Allowed {
+		err = fmt.Errorf(responseData.Reason)
+		log.Logger().Error("Configmap validation failed, aborting", zap.Error(err))
+		return err
+	}
+
+	log.Logger().Info("Successfully validated YuniKorn configuration")
 	return nil
 }
 

--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
@@ -23,9 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -37,8 +35,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/apache/yunikorn-k8shim/pkg/plugin/admissioncontrollers/webhook/conf"
+
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
-	"github.com/apache/yunikorn-k8shim/pkg/conf"
 )
 
 type responseMode int
@@ -264,23 +263,16 @@ func TestUpdateSchedulerName(t *testing.T) {
 	}
 }
 
-func TestValidateConfigMap(t *testing.T) {
-	configName := fmt.Sprintf("%s.yaml", conf.DefaultPolicyGroup)
-	controller, err := initAdmissionController(configName, "", "", "", "", "", false, true, "", "", "")
-	if err != nil {
-		t.Fatal("failed to init admission controller", err)
-	}
+func TestValidateConfigMapEmpty(t *testing.T) {
+	controller := initAdmissionController(createConfig())
 	configmap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.ConfigMapName,
 		},
 		Data: make(map[string]string),
 	}
-	// specified config "queues.yaml" not found
-	err = controller.validateConfigMap(configmap)
-	assert.Assert(t, err != nil, "expecting error when specified config is not found")
-	assert.Equal(t, err.Error(), "required config 'queues.yaml' not found in this configmap")
-	// skip further validations which depends on the webservice of yunikorn-core
+	err := controller.validateConfigMap("yunikorn", configmap)
+	assert.NilError(t, err, "unexpected error with missing config")
 }
 
 const ConfigData = `
@@ -303,21 +295,22 @@ func TestValidateConfigMapValidConfig(t *testing.T) {
 	srv := serverMock(Success)
 	defer srv.Close()
 	// both server and url pattern contains http://, so we need to delete one
-	controller := prepareController(t, strings.Replace(srv.URL, "http://", "", 1), "", "", "", "")
-	err := controller.validateConfigMap(configmap)
+	controller := prepareController(t, strings.Replace(srv.URL, "http://", "", 1), "", "", "", "", false, true)
+	err := controller.validateConfigMap("yunikorn", configmap)
 	assert.NilError(t, err, "No error expected")
 }
 
 /**
 Test for the case when the POST request is successful, but the config change is not allowed.
 */
-func TestValidateConfigMapInValidConfig(t *testing.T) {
+func TestValidateConfigMapInvalidConfig(t *testing.T) {
 	configmap := prepareConfigMap(ConfigData)
 	srv := serverMock(Failure)
 	defer srv.Close()
 	// both server and url pattern contains http://, so we need to delete one
-	controller := prepareController(t, strings.Replace(srv.URL, "http://", "", 1), "", "", "", "")
-	err := controller.validateConfigMap(configmap)
+	controller := prepareController(t, strings.Replace(srv.URL, "http://", "", 1), "", "", "", "", false, true)
+	err := controller.validateConfigMap("default", configmap)
+	assert.Assert(t, err != nil, "error not found")
 	assert.Equal(t, "Invalid config", err.Error(),
 		"Other error returned than the expected one")
 }
@@ -330,8 +323,8 @@ func TestValidateConfigMapWrongRequest(t *testing.T) {
 	srv := serverMock(Failure)
 	defer srv.Close()
 	// the url is wrong, so the POST request will fail, and success will be assumed
-	controller := prepareController(t, srv.URL, "", "", "", "")
-	err := controller.validateConfigMap(configmap)
+	controller := prepareController(t, srv.URL, "", "", "", "", false, true)
+	err := controller.validateConfigMap("yunikorn", configmap)
 	assert.NilError(t, err, "No error expected")
 }
 
@@ -343,8 +336,8 @@ func TestValidateConfigMapServerError(t *testing.T) {
 	srv := serverMock(Error)
 	defer srv.Close()
 	// both server and url pattern contains http://, so we need to delete one
-	controller := prepareController(t, strings.Replace(srv.URL, "http://", "", 1), "", "", "", "")
-	err := controller.validateConfigMap(configmap)
+	controller := prepareController(t, strings.Replace(srv.URL, "http://", "", 1), "", "", "", "", false, true)
+	err := controller.validateConfigMap("yunikorn", configmap)
 	assert.NilError(t, err, "No error expected")
 }
 
@@ -358,21 +351,23 @@ func prepareConfigMap(data string) *v1.ConfigMap {
 	return configmap
 }
 
-func prepareController(t *testing.T, url string, processNs string, bypassNs string, labelNs string, noLabelNs string) *admissionController {
-	configName := fmt.Sprintf("%s.yaml", conf.DefaultPolicyGroup)
+func prepareController(t *testing.T, url string, processNs string, bypassNs string, labelNs string, noLabelNs string, bypassAuth bool, trustControllers bool) *admissionController {
 	if bypassNs == "" {
 		bypassNs = "^kube-system$"
 	}
-	controller, err := initAdmissionController(
-		configName,
-		fmt.Sprintf(schedulerValidateConfURLPattern, url),
-		processNs, bypassNs, labelNs, noLabelNs,
-		false, true,
-		"system:serviceaccount:kube-system:job-controller", "testExtUser", "testExtGroup")
-	if err != nil {
-		t.Fatal("failed to prepare controller", err)
-	}
-	return controller
+	config := createConfigWithOverrides(map[string]string{
+		conf.AMWebHookSchedulerServiceAddress: url,
+		conf.AMFilteringProcessNamespaces:     processNs,
+		conf.AMFilteringBypassNamespaces:      bypassNs,
+		conf.AMFilteringLabelNamespaces:       labelNs,
+		conf.AMFilteringNoLabelNamespaces:     noLabelNs,
+		conf.AMAccessControlBypassAuth:        fmt.Sprintf("%t", bypassAuth),
+		conf.AMAccessControlTrustControllers:  fmt.Sprintf("%t", trustControllers),
+		conf.AMAccessControlSystemUsers:       "system:serviceaccount:kube-system:job-controller",
+		conf.AMAccessControlExternalUsers:     "testExtUser",
+		conf.AMAccessControlExternalGroups:    "testExtGroup",
+	})
+	return initAdmissionController(config)
 }
 
 func serverMock(mode responseMode) *httptest.Server {
@@ -427,27 +422,6 @@ func TestGenerateAppID(t *testing.T) {
 	assert.Equal(t, len(appID), 63)
 }
 
-func TestIsConfigMapUpdateAllowed(t *testing.T) {
-	testCases := []struct {
-		name             string
-		allowed          bool
-		userInfo         string
-		enableHotRefresh bool
-	}{
-		{"Hot refresh enabled, yunikorn user", true, "default:yunikorn-admin", true},
-		{"Hot refresh enabled, non yunikorn user", true, "default:some-user", true},
-		{"Hot refresh disabled, non yunikorn user", false, "default:some-user", false},
-		{"Hot refresh disabled, yunikorn user", true, "default:yunikorn-admin", false},
-	}
-	for _, tc := range testCases {
-		os.Setenv(enableConfigHotRefreshEnvVar, strconv.FormatBool(tc.enableHotRefresh))
-		t.Run(tc.name, func(t *testing.T) {
-			allowed := isConfigMapUpdateAllowed(tc.userInfo)
-			assert.Equal(t, tc.allowed, allowed, "")
-		})
-	}
-}
-
 func TestMutate(t *testing.T) {
 	var ac *admissionController
 	var pod v1.Pod
@@ -456,8 +430,7 @@ func TestMutate(t *testing.T) {
 	var podJSON []byte
 	var err error
 
-	ac = prepareController(t, "", "", "^kube-system$,^bypass$", "", "^nolabel$")
-	ac.bypassAuth = true
+	ac = prepareController(t, "", "", "^kube-system$,^bypass$", "", "^nolabel$", true, true)
 
 	// nil request
 	resp = ac.mutate(nil)
@@ -560,7 +533,7 @@ func TestMutate(t *testing.T) {
 }
 
 func TestExternalAuthentication(t *testing.T) {
-	ac := prepareController(t, "", "", "^kube-system$,^bypass$", "", "^nolabel$")
+	ac := prepareController(t, "", "", "^kube-system$,^bypass$", "", "^nolabel$", false, true)
 
 	// validation fails, submitter user is not whitelisted
 	pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{
@@ -678,7 +651,7 @@ func labels(t *testing.T, patch []byte) map[string]interface{} {
 }
 
 func TestShouldProcessNamespace(t *testing.T) {
-	ac := prepareController(t, "", "", "^kube-system$,^pre-,-post$", "", "")
+	ac := prepareController(t, "", "", "^kube-system$,^pre-,-post$", "", "", false, true)
 	assert.Check(t, ac.shouldProcessNamespace("test"), "test namespace not allowed")
 	assert.Check(t, !ac.shouldProcessNamespace("kube-system"), "kube-system namespace allowed")
 	assert.Check(t, ac.shouldProcessNamespace("x-kube-system"), "x-kube-system namespace not allowed")
@@ -686,18 +659,18 @@ func TestShouldProcessNamespace(t *testing.T) {
 	assert.Check(t, !ac.shouldProcessNamespace("pre-ns"), "pre-ns namespace allowed")
 	assert.Check(t, !ac.shouldProcessNamespace("ns-post"), "ns-post namespace allowed")
 
-	ac = prepareController(t, "", "^allow-", "^allow-except-", "", "")
+	ac = prepareController(t, "", "^allow-", "^allow-except-", "", "", false, true)
 	assert.Check(t, !ac.shouldProcessNamespace("test"), "test namespace allowed when not on process list")
 	assert.Check(t, ac.shouldProcessNamespace("allow-this"), "allow-this namespace not allowed when on process list")
 	assert.Check(t, !ac.shouldProcessNamespace("allow-except-this"), "allow-except-this namespace allowed when on bypass list")
 }
 
 func TestShouldLabelNamespace(t *testing.T) {
-	ac := prepareController(t, "", "", "", "", "^skip$")
+	ac := prepareController(t, "", "", "", "", "^skip$", false, true)
 	assert.Check(t, ac.shouldLabelNamespace("test"), "test namespace not allowed")
 	assert.Check(t, !ac.shouldLabelNamespace("skip"), "skip namespace allowed when on no-label list")
 
-	ac = prepareController(t, "", "", "", "^allow-", "^allow-except-")
+	ac = prepareController(t, "", "", "", "^allow-", "^allow-except-", false, true)
 	assert.Check(t, !ac.shouldLabelNamespace("test"), "test namespace allowed when not on label list")
 	assert.Check(t, ac.shouldLabelNamespace("allow-this"), "allow-this namespace not allowed when on label list")
 	assert.Check(t, !ac.shouldLabelNamespace("allow-except-this"), "allow-except-this namespace allowed when on no-label list")
@@ -735,99 +708,30 @@ func TestParseRegexes(t *testing.T) {
 }
 
 func TestInitAdmissionControllerRegexErrorHandling(t *testing.T) {
-	var err error
+	ac := initAdmissionController(createConfig())
+	assert.Equal(t, 1, len(ac.conf.GetBypassNamespaces()))
+	assert.Equal(t, conf.DefaultFilteringBypassNamespaces, ac.conf.GetBypassNamespaces()[0].String(), "didn't set default bypassNamespaces")
 
-	_, err = initAdmissionController("", "", "", "", "", "", false, true, "", "", "")
-	assert.NilError(t, err, "error returned from simple init")
+	ac = initAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringProcessNamespaces: "("}))
+	assert.Equal(t, 0, len(ac.conf.GetProcessNamespaces()), "didn't fail on bad processNamespaces list")
 
-	_, err = initAdmissionController("", "", "(", "", "", "", false, true, "", "", "")
-	assert.ErrorContains(t, err, "error parsing regexp", "didn't fail on bad processNamespaces list")
+	ac = initAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringBypassNamespaces: "("}))
+	assert.Equal(t, 1, len(ac.conf.GetBypassNamespaces()))
+	assert.Equal(t, conf.DefaultFilteringBypassNamespaces, ac.conf.GetBypassNamespaces()[0].String(), "didn't fail on bad bypassNamespaces list")
 
-	_, err = initAdmissionController("", "", "", "(", "", "", false, true, "", "", "")
-	assert.ErrorContains(t, err, "error parsing regexp", "didn't fail on bad bypassNamespaces list")
+	ac = initAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringLabelNamespaces: "("}))
+	assert.Equal(t, 0, len(ac.conf.GetLabelNamespaces()), "didn't fail on bad labelNamespaces list")
 
-	_, err = initAdmissionController("", "", "", "", "(", "", false, true, "", "", "")
-	assert.ErrorContains(t, err, "error parsing regexp", "didn't fail on bad labelNamespaces list")
+	ac = initAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringNoLabelNamespaces: "("}))
+	assert.Equal(t, 0, len(ac.conf.GetNoLabelNamespaces()), "didn't fail on bad noLabelNamespaces list")
 
-	_, err = initAdmissionController("", "", "", "", "", "(", false, true, "", "", "")
-	assert.ErrorContains(t, err, "error parsing regexp", "didn't fail on bad noLabelNamespaces list")
+	ac = initAdmissionController(createConfigWithOverrides(map[string]string{conf.AMAccessControlSystemUsers: "("}))
+	assert.Equal(t, 1, len(ac.conf.GetSystemUsers()))
+	assert.Equal(t, conf.DefaultAccessControlSystemUsers, ac.conf.GetSystemUsers()[0].String(), "didn't fail on bad systemUsers list")
 
-	_, err = initAdmissionController("", "", "", "", "", "", false, true, "(", "", "")
-	assert.ErrorContains(t, err, "error parsing regexp", "didn't fail on bad systemUsers list")
+	ac = initAdmissionController(createConfigWithOverrides(map[string]string{conf.AMAccessControlExternalUsers: "("}))
+	assert.Equal(t, 0, len(ac.conf.GetExternalUsers()), "didn't fail on bad externalUsers list")
 
-	_, err = initAdmissionController("", "", "", "", "", "", false, true, "", "(", "")
-	assert.ErrorContains(t, err, "error parsing regexp", "didn't fail on bad externalUsers list")
-
-	_, err = initAdmissionController("", "", "", "", "", "", false, true, "", "", "(")
-	assert.ErrorContains(t, err, "error parsing regexp", "didn't fail on bad externalGroups list")
-}
-
-func TestEnvSettings(t *testing.T) {
-	originalEnv := getEnvSettings()
-	defer func() {
-		os.Setenv(admissionControllerNamespace, originalEnv.namespace)
-		os.Setenv(admissionControllerService, originalEnv.serviceName)
-		os.Setenv(admissionControllerProcessNamespaces, originalEnv.processNamespaces)
-		os.Setenv(admissionControllerBypassNamespaces, originalEnv.bypassNamespaces)
-		os.Setenv(admissionControllerLabelNamespaces, originalEnv.labelNamespaces)
-		os.Setenv(admissionControllerNoLabelNamespaces, originalEnv.noLabelNamespaces)
-		os.Setenv(admissionControllerBypassAuth, strconv.FormatBool(originalEnv.bypassAuth))
-		os.Setenv(admissionControllerSystemUsers, originalEnv.systemUsers)
-		os.Setenv(admissionControllerExternalUsers, originalEnv.externalUsers)
-		os.Setenv(admissionControllerExternalGroups, originalEnv.externalGroups)
-		os.Setenv(admissionControllerTrustControllers, strconv.FormatBool(originalEnv.trustControllers))
-	}()
-
-	// test valid settings
-	os.Setenv(admissionControllerNamespace, "testNamespace")
-	os.Setenv(admissionControllerService, "testYunikornService")
-	os.Setenv(admissionControllerProcessNamespaces, "testProcessNamespaces")
-	os.Setenv(admissionControllerBypassNamespaces, "testBypassNamespaces")
-	os.Setenv(admissionControllerLabelNamespaces, "testLabelNamespaces")
-	os.Setenv(admissionControllerNoLabelNamespaces, "testNolabelNamespaces")
-	os.Setenv(admissionControllerBypassAuth, "false")
-	os.Setenv(admissionControllerSystemUsers, "systemuser")
-	os.Setenv(admissionControllerExternalUsers, "yunikorn")
-	os.Setenv(admissionControllerExternalGroups, "devs")
-	os.Setenv(admissionControllerTrustControllers, "true")
-	env := getEnvSettings()
-	assert.Equal(t, env.namespace, "testNamespace")
-	assert.Equal(t, env.serviceName, "testYunikornService")
-	assert.Equal(t, env.processNamespaces, "testProcessNamespaces")
-	assert.Equal(t, env.bypassNamespaces, "testBypassNamespaces")
-	assert.Equal(t, env.labelNamespaces, "testLabelNamespaces")
-	assert.Equal(t, env.noLabelNamespaces, "testNolabelNamespaces")
-	assert.Equal(t, env.bypassAuth, false)
-	assert.Equal(t, env.systemUsers, "systemuser")
-	assert.Equal(t, env.externalUsers, "yunikorn")
-	assert.Equal(t, env.externalGroups, "devs")
-	assert.Equal(t, env.trustControllers, true)
-
-	// test missing settings
-	os.Unsetenv(admissionControllerProcessNamespaces)
-	os.Unsetenv(admissionControllerBypassNamespaces)
-	os.Unsetenv(admissionControllerLabelNamespaces)
-	os.Unsetenv(admissionControllerNoLabelNamespaces)
-	os.Unsetenv(admissionControllerBypassAuth)
-	os.Unsetenv(admissionControllerSystemUsers)
-	os.Unsetenv(admissionControllerExternalUsers)
-	os.Unsetenv(admissionControllerExternalGroups)
-	os.Unsetenv(admissionControllerTrustControllers)
-	env = getEnvSettings()
-	assert.Equal(t, env.processNamespaces, "")
-	assert.Equal(t, env.bypassNamespaces, defaultBypassNamespaces)
-	assert.Equal(t, env.labelNamespaces, "")
-	assert.Equal(t, env.noLabelNamespaces, "")
-	assert.Equal(t, env.bypassAuth, defaultBypassAuth)
-	assert.Equal(t, env.systemUsers, defaultSystemUsers)
-	assert.Equal(t, env.externalUsers, "")
-	assert.Equal(t, env.externalGroups, "")
-	assert.Equal(t, env.trustControllers, defaultTrustControllers)
-
-	// test faulty settings for boolean values
-	os.Setenv(admissionControllerBypassAuth, "xyz")
-	os.Setenv(admissionControllerTrustControllers, "xyz")
-	env = getEnvSettings()
-	assert.Equal(t, env.bypassAuth, defaultBypassAuth)
-	assert.Equal(t, env.trustControllers, defaultTrustControllers)
+	ac = initAdmissionController(createConfigWithOverrides(map[string]string{conf.AMAccessControlExternalGroups: "("}))
+	assert.Equal(t, 0, len(ac.conf.GetExternalGroups()), "didn't fail on bad externalGroups list")
 }

--- a/pkg/plugin/admissioncontrollers/webhook/conf/am_conf.go
+++ b/pkg/plugin/admissioncontrollers/webhook/conf/am_conf.go
@@ -1,0 +1,477 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package conf
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	informersv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/apache/yunikorn-k8shim/pkg/client"
+	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
+	schedulerconf "github.com/apache/yunikorn-k8shim/pkg/conf"
+	"github.com/apache/yunikorn-k8shim/pkg/log"
+)
+
+const (
+	AdmissionControllerPrefix = "admissionController."
+	WebHookPrefix             = AdmissionControllerPrefix + "webHook."
+	FilteringPrefix           = AdmissionControllerPrefix + "filtering."
+	AccessControlPrefix       = AdmissionControllerPrefix + "accessControl."
+
+	// webhook configuration
+	AMWebHookAMServiceName           = WebHookPrefix + "amServiceName"
+	AMWebHookSchedulerServiceAddress = WebHookPrefix + "schedulerServiceAddress"
+
+	// filtering configuration
+	AMFilteringProcessNamespaces = FilteringPrefix + "processNamespaces"
+	AMFilteringBypassNamespaces  = FilteringPrefix + "bypassNamespaces"
+	AMFilteringLabelNamespaces   = FilteringPrefix + "labelNamespaces"
+	AMFilteringNoLabelNamespaces = FilteringPrefix + "noLabelNamespaces"
+
+	// access control configuration
+	AMAccessControlBypassAuth       = AccessControlPrefix + "bypassAuth"
+	AMAccessControlTrustControllers = AccessControlPrefix + "trustControllers"
+	AMAccessControlSystemUsers      = AccessControlPrefix + "systemUsers"
+	AMAccessControlExternalUsers    = AccessControlPrefix + "externalUsers"
+	AMAccessControlExternalGroups   = AccessControlPrefix + "externalGroups"
+)
+
+const (
+	// deprecated env vars
+	deprecatedEnvEnableConfigHotRefresh  = "ENABLE_CONFIG_HOT_REFRESH"
+	deprecatedEnvPolicyGroup             = "POLICY_GROUP"
+	deprecatedEnvService                 = "ADMISSION_CONTROLLER_SERVICE"
+	deprecatedEnvSchedulerServiceAddress = "SCHEDULER_SERVICE_ADDRESS"
+	deprecatedEnvProcessNamespaces       = "ADMISSION_CONTROLLER_PROCESS_NAMESPACES"
+	deprecatedEnvBypassNamespaces        = "ADMISSION_CONTROLLER_BYPASS_NAMESPACES"
+	deprecatedEnvLabelNamespaces         = "ADMISSION_CONTROLLER_LABEL_NAMESPACES"
+	deprecatedEnvNoLabelNamespaces       = "ADMISSION_CONTROLLER_NO_LABEL_NAMESPACES"
+	deprecatedEnvBypassAuth              = "ADMISSION_CONTROLLER_BYPASS_AUTH"
+	deprecatedEnvTrustControllers        = "ADMISSION_CONTROLLER_TRUST_CONTROLLERS"
+	deprecatedEnvSystemUsers             = "ADMISSION_CONTROLLER_SYSTEM_USERS"
+	deprecatedEnvExternalUsers           = "ADMISSION_CONTROLLER_EXTERNAL_USERS"
+	deprecatedEnvExternalGroups          = "ADMISSION_CONTROLLER_EXTERNAL_GROUPS"
+	deprecatedEnvNamespace               = "ADMISSION_CONTROLLER_NAMESPACE"
+)
+
+const (
+	// webhook defaults
+	DefaultWebHookAmServiceName           = "yunikorn-admission-controller-service"
+	DefaultWebHookSchedulerServiceAddress = "yunikorn-service:9080"
+
+	// filtering defaults
+	DefaultFilteringProcessNamespaces = ""
+	DefaultFilteringBypassNamespaces  = "^kube-system$"
+	DefaultFilteringLabelNamespaces   = ""
+	DefaultFilteringNoLabelNamespaces = ""
+
+	// access control defaults
+	DefaultAccessControlBypassAuth       = false
+	DefaultAccessControlTrustControllers = true
+	DefaultAccessControlSystemUsers      = "system:serviceaccount:kube-system:*"
+	DefaultAccessControlExternalUsers    = ""
+	DefaultAccessControlExternalGroups   = ""
+)
+
+func GetAdmissionControllerNamespace() string {
+	if value, ok := os.LookupEnv(schedulerconf.EnvNamespace); ok {
+		return value
+	}
+	if value, ok := os.LookupEnv(deprecatedEnvNamespace); ok {
+		return value
+	}
+	return schedulerconf.DefaultNamespace
+}
+
+type AdmissionControllerConf struct {
+	namespace  string
+	kubeConfig string
+
+	// mutable values require locking
+	enableConfigHotRefresh  bool
+	policyGroup             string
+	amServiceName           string
+	schedulerServiceAddress string
+	processNamespaces       []*regexp.Regexp
+	bypassNamespaces        []*regexp.Regexp
+	labelNamespaces         []*regexp.Regexp
+	noLabelNamespaces       []*regexp.Regexp
+	bypassAuth              bool
+	trustControllers        bool
+	systemUsers             []*regexp.Regexp
+	externalUsers           []*regexp.Regexp
+	externalGroups          []*regexp.Regexp
+	configMaps              []*v1.ConfigMap
+
+	configMapInformer informersv1.ConfigMapInformer
+	stopChan          chan struct{}
+	lock              sync.RWMutex
+}
+
+func NewAdmissionControllerConf(configMaps []*v1.ConfigMap) *AdmissionControllerConf {
+	acc := &AdmissionControllerConf{
+		namespace:  GetAdmissionControllerNamespace(),
+		kubeConfig: schedulerconf.GetDefaultKubeConfigPath(),
+	}
+	acc.updateConfigMaps(configMaps, true)
+	return acc
+}
+
+func (acc *AdmissionControllerConf) StartInformers(kubeClient client.KubeClient) {
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient.GetClientSet(), 0, informers.WithNamespace(acc.namespace))
+	acc.stopChan = make(chan struct{})
+	informerFactory.Start(acc.stopChan)
+	acc.configMapInformer = informerFactory.Core().V1().ConfigMaps()
+	acc.configMapInformer.Informer().AddEventHandler(&configMapUpdateHandler{conf: acc})
+	go acc.configMapInformer.Informer().Run(acc.stopChan)
+	if err := acc.waitForSync(time.Second, 30*time.Second); err != nil {
+		log.Logger().Warn("Failed to sync informers", zap.Error(err))
+	}
+}
+
+func (acc *AdmissionControllerConf) StopInformers() {
+	if acc.stopChan != nil {
+		close(acc.stopChan)
+	}
+}
+
+func (acc *AdmissionControllerConf) GetNamespace() string {
+	return acc.namespace
+}
+
+func (acc *AdmissionControllerConf) GetKubeConfig() string {
+	return acc.kubeConfig
+}
+
+func (acc *AdmissionControllerConf) GetEnableConfigHotRefresh() bool {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.enableConfigHotRefresh
+}
+
+func (acc *AdmissionControllerConf) GetPolicyGroup() string {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.policyGroup
+}
+
+func GetPendingPolicyGroup(configs map[string]string) string {
+	return parseConfigString(configs, schedulerconf.CMSvcPolicyGroup, schedulerconf.DefaultPolicyGroup, deprecatedEnvPolicyGroup)
+}
+
+func (acc *AdmissionControllerConf) GetAmServiceName() string {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.amServiceName
+}
+
+func (acc *AdmissionControllerConf) GetSchedulerServiceAddress() string {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.schedulerServiceAddress
+}
+
+func (acc *AdmissionControllerConf) GetProcessNamespaces() []*regexp.Regexp {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.processNamespaces
+}
+
+func (acc *AdmissionControllerConf) GetBypassNamespaces() []*regexp.Regexp {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.bypassNamespaces
+}
+
+func (acc *AdmissionControllerConf) GetLabelNamespaces() []*regexp.Regexp {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.labelNamespaces
+}
+
+func (acc *AdmissionControllerConf) GetNoLabelNamespaces() []*regexp.Regexp {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.noLabelNamespaces
+}
+
+func (acc *AdmissionControllerConf) GetBypassAuth() bool {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.bypassAuth
+}
+
+func (acc *AdmissionControllerConf) GetTrustControllers() bool {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.trustControllers
+}
+
+func (acc *AdmissionControllerConf) GetSystemUsers() []*regexp.Regexp {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.systemUsers
+}
+
+func (acc *AdmissionControllerConf) GetExternalUsers() []*regexp.Regexp {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.externalUsers
+}
+
+func (acc *AdmissionControllerConf) GetExternalGroups() []*regexp.Regexp {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.externalGroups
+}
+
+func (acc *AdmissionControllerConf) waitForSync(interval time.Duration, timeout time.Duration) error {
+	return utils.WaitForCondition(func() bool {
+		return acc.configMapInformer.Informer().HasSynced()
+	}, interval, timeout)
+}
+
+type configMapUpdateHandler struct {
+	conf *AdmissionControllerConf
+}
+
+func (h *configMapUpdateHandler) OnAdd(obj interface{}) {
+	cm := utils.Convert2ConfigMap(obj)
+	if idx, ok := h.configMapIndex(cm); ok {
+		h.conf.configUpdated(idx, cm)
+	}
+}
+
+func (h *configMapUpdateHandler) OnUpdate(_, newObj interface{}) {
+	cm := utils.Convert2ConfigMap(newObj)
+	if idx, ok := h.configMapIndex(cm); ok {
+		h.conf.configUpdated(idx, cm)
+	}
+}
+
+func (h *configMapUpdateHandler) OnDelete(obj interface{}) {
+	var cm *v1.ConfigMap
+	switch t := obj.(type) {
+	case *v1.ConfigMap:
+		cm = t
+	case cache.DeletedFinalStateUnknown:
+		cm = utils.Convert2ConfigMap(obj)
+	default:
+		log.Logger().Warn("unable to convert to configmap")
+		return
+	}
+	if idx, ok := h.configMapIndex(cm); ok {
+		h.conf.configUpdated(idx, nil)
+	}
+}
+
+func (h *configMapUpdateHandler) configMapIndex(configMap *v1.ConfigMap) (int, bool) {
+	if configMap == nil {
+		return -1, false
+	}
+	if configMap.Namespace != h.conf.namespace {
+		return -1, false
+	}
+	switch configMap.Name {
+	case constants.DefaultConfigMapName:
+		return 0, true
+	case constants.ConfigMapName:
+		return 1, true
+	default:
+		return -1, false
+	}
+}
+
+func (acc *AdmissionControllerConf) configUpdated(index int, configMap *v1.ConfigMap) {
+	configMaps := acc.GetConfigMaps()
+	configMaps[index] = configMap
+	acc.updateConfigMaps(configMaps, false)
+}
+
+func (acc *AdmissionControllerConf) GetConfigMaps() []*v1.ConfigMap {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+
+	result := make([]*v1.ConfigMap, 0)
+	result = append(result, acc.configMaps...)
+	return result
+}
+
+func (acc *AdmissionControllerConf) updateConfigMaps(configMaps []*v1.ConfigMap, initial bool) {
+	acc.lock.Lock()
+	defer acc.lock.Unlock()
+
+	// check for enable config hot refresh
+	if !initial && !acc.enableConfigHotRefresh {
+		log.Logger().Warn("Config hot-refresh is disabled, ignoring configuration update")
+		return
+	}
+
+	acc.configMaps = configMaps
+	configs := schedulerconf.FlattenConfigMaps(configMaps)
+
+	// hot refresh
+	acc.enableConfigHotRefresh = parseConfigBool(configs, schedulerconf.CMSvcEnableConfigHotRefresh, schedulerconf.DefaultEnableConfigHotRefresh, deprecatedEnvEnableConfigHotRefresh)
+
+	// logging
+	logLevel := parseConfigInt(configs, schedulerconf.CMLogLevel, schedulerconf.DefaultLoggingLevel, "")
+	log.GetZapConfigs().Level.SetLevel(zapcore.Level(logLevel))
+
+	// scheduler
+	acc.policyGroup = parseConfigString(configs, schedulerconf.CMSvcPolicyGroup, schedulerconf.DefaultPolicyGroup, deprecatedEnvPolicyGroup)
+
+	// webhook
+	acc.amServiceName = parseConfigString(configs, AMWebHookAMServiceName, DefaultWebHookAmServiceName, deprecatedEnvService)
+	acc.schedulerServiceAddress = parseConfigString(configs, AMWebHookSchedulerServiceAddress, DefaultWebHookSchedulerServiceAddress, deprecatedEnvSchedulerServiceAddress)
+
+	// filtering
+	acc.processNamespaces = parseConfigRegexps(configs, AMFilteringProcessNamespaces, DefaultFilteringProcessNamespaces, deprecatedEnvProcessNamespaces)
+	acc.bypassNamespaces = parseConfigRegexps(configs, AMFilteringBypassNamespaces, DefaultFilteringBypassNamespaces, deprecatedEnvBypassNamespaces)
+	acc.labelNamespaces = parseConfigRegexps(configs, AMFilteringLabelNamespaces, DefaultFilteringLabelNamespaces, deprecatedEnvLabelNamespaces)
+	acc.noLabelNamespaces = parseConfigRegexps(configs, AMFilteringNoLabelNamespaces, DefaultFilteringNoLabelNamespaces, deprecatedEnvNoLabelNamespaces)
+
+	// access control
+	acc.bypassAuth = parseConfigBool(configs, AMAccessControlBypassAuth, DefaultAccessControlBypassAuth, deprecatedEnvBypassAuth)
+	acc.trustControllers = parseConfigBool(configs, AMAccessControlTrustControllers, DefaultAccessControlTrustControllers, deprecatedEnvTrustControllers)
+	acc.systemUsers = parseConfigRegexps(configs, AMAccessControlSystemUsers, DefaultAccessControlSystemUsers, deprecatedEnvSystemUsers)
+	acc.externalUsers = parseConfigRegexps(configs, AMAccessControlExternalUsers, DefaultAccessControlExternalUsers, deprecatedEnvExternalUsers)
+	acc.externalGroups = parseConfigRegexps(configs, AMAccessControlExternalGroups, DefaultAccessControlExternalGroups, deprecatedEnvExternalGroups)
+
+	acc.dumpConfigurationInternal()
+}
+
+func (acc *AdmissionControllerConf) DumpConfiguration() {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	acc.dumpConfigurationInternal()
+}
+
+func (acc *AdmissionControllerConf) dumpConfigurationInternal() {
+	log.Logger().Info("Loaded admission controller configuration",
+		zap.String("namespace", acc.namespace),
+		zap.String("kubeConfig", acc.kubeConfig),
+		zap.String("policyGroup", acc.policyGroup),
+		zap.String("amServiceName", acc.amServiceName),
+		zap.String("schedulerServiceAddress", acc.schedulerServiceAddress),
+		zap.Strings("processNamespaces", regexpsString(acc.processNamespaces)),
+		zap.Strings("bypassNamespaces", regexpsString(acc.bypassNamespaces)),
+		zap.Strings("labelNamespaces", regexpsString(acc.labelNamespaces)),
+		zap.Strings("noLabelNamespaces", regexpsString(acc.noLabelNamespaces)),
+		zap.Bool("bypassAuth", acc.bypassAuth),
+		zap.Bool("trustControllers", acc.trustControllers),
+		zap.Strings("systemUsers", regexpsString(acc.systemUsers)),
+		zap.Strings("externalUsers", regexpsString(acc.externalUsers)),
+		zap.Strings("externalGroups", regexpsString(acc.externalGroups)))
+}
+
+func regexpsString(regexes []*regexp.Regexp) []string {
+	result := make([]string, 0)
+	for _, regex := range regexes {
+		result = append(result, regex.String())
+	}
+	return result
+}
+
+func parseConfigRegexps(config map[string]string, key string, defaultValue string, env string) []*regexp.Regexp {
+	value := parseConfigString(config, key, defaultValue, env)
+	result, err := parseRegexes(value)
+	if err != nil {
+		log.Logger().Error(fmt.Sprintf("Unable to parse regex values '%s' for configuration '%s', using default value '%s'",
+			value, key, defaultValue), zap.Error(err))
+		result, err = parseRegexes(defaultValue)
+		if err != nil {
+			log.Logger().Fatal("BUG: can't parse default regex pattern", zap.Error(err))
+		}
+	}
+	return result
+}
+
+func parseConfigBool(config map[string]string, key string, defaultValue bool, env string) bool {
+	value := parseConfigString(config, key, fmt.Sprintf("%t", defaultValue), env)
+	result, err := strconv.ParseBool(value)
+	if err != nil {
+		log.Logger().Error(fmt.Sprintf("Unable to parse bool value '%s' for configuration '%s', using default value '%t'",
+			value, key, defaultValue), zap.Error(err))
+		result = defaultValue
+	}
+	return result
+}
+
+func parseConfigInt(config map[string]string, key string, defaultValue int, env string) int {
+	value := parseConfigString(config, key, fmt.Sprintf("%d", defaultValue), env)
+	result, err := strconv.ParseInt(value, 10, 31)
+	if err != nil {
+		log.Logger().Error(fmt.Sprintf("Unable to parse int value '%s' for configuration '%s', using default value '%d'",
+			value, key, defaultValue), zap.Error(err))
+		return defaultValue
+	}
+	return int(result)
+}
+
+func parseConfigString(config map[string]string, key string, defaultValue string, env string) string {
+	result := defaultValue
+	var envValue, confValue string
+	var envOk, confOk bool
+
+	if env != "" {
+		envValue, envOk = os.LookupEnv(env)
+		if envOk {
+			result = envValue
+		}
+	}
+	confValue, confOk = config[key]
+	if confOk {
+		result = confValue
+	}
+	if confOk && envOk && confValue != envValue {
+		log.Logger().Warn(fmt.Sprintf("Deprecated environment variable '%s' found with inconsistent value. Provided: '%s', used: '%s'",
+			env, envValue, confValue))
+	}
+	return result
+}
+
+func parseRegexes(patterns string) ([]*regexp.Regexp, error) {
+	result := make([]*regexp.Regexp, 0)
+	for _, pattern := range strings.Split(patterns, ",") {
+		pattern = strings.TrimSpace(pattern)
+		if len(pattern) == 0 {
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			log.Logger().Error("Unable to compile regular expression", zap.String("pattern", pattern), zap.Error(err))
+			return nil, err
+		}
+		result = append(result, re)
+	}
+	return result, nil
+}

--- a/pkg/plugin/admissioncontrollers/webhook/conf/am_conf_test.go
+++ b/pkg/plugin/admissioncontrollers/webhook/conf/am_conf_test.go
@@ -1,0 +1,198 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package conf
+
+import (
+	"os"
+	"testing"
+
+	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
+
+	schedulerconf "github.com/apache/yunikorn-k8shim/pkg/conf"
+)
+
+func resetEnv() {
+	os.Unsetenv(schedulerconf.EnvNamespace)
+	os.Unsetenv(deprecatedEnvPolicyGroup)
+	os.Unsetenv(deprecatedEnvService)
+	os.Unsetenv(deprecatedEnvSchedulerServiceAddress)
+	os.Unsetenv(deprecatedEnvProcessNamespaces)
+	os.Unsetenv(deprecatedEnvBypassNamespaces)
+	os.Unsetenv(deprecatedEnvLabelNamespaces)
+	os.Unsetenv(deprecatedEnvNoLabelNamespaces)
+	os.Unsetenv(deprecatedEnvBypassAuth)
+	os.Unsetenv(deprecatedEnvTrustControllers)
+	os.Unsetenv(deprecatedEnvSystemUsers)
+	os.Unsetenv(deprecatedEnvExternalUsers)
+	os.Unsetenv(deprecatedEnvExternalGroups)
+}
+
+func TestConfigMapVars(t *testing.T) {
+	// ensure environment doesn't influence results
+	resetEnv()
+
+	// test valid settings
+	conf := NewAdmissionControllerConf([]*v1.ConfigMap{nil, {Data: map[string]string{
+		schedulerconf.CMSvcPolicyGroup:   "testPolicyGroup",
+		AMWebHookAMServiceName:           "testYunikornService",
+		AMWebHookSchedulerServiceAddress: "testAddress",
+		AMFilteringProcessNamespaces:     "testProcessNamespaces",
+		AMFilteringBypassNamespaces:      "testBypassNamespaces",
+		AMFilteringLabelNamespaces:       "testLabelNamespaces",
+		AMFilteringNoLabelNamespaces:     "testNolabelNamespaces",
+		AMAccessControlBypassAuth:        "true",
+		AMAccessControlSystemUsers:       "systemuser",
+		AMAccessControlExternalUsers:     "yunikorn",
+		AMAccessControlExternalGroups:    "devs",
+		AMAccessControlTrustControllers:  "false",
+	}}})
+	assert.Equal(t, conf.GetPolicyGroup(), "testPolicyGroup")
+	assert.Equal(t, conf.GetAmServiceName(), "testYunikornService")
+	assert.Equal(t, conf.GetSchedulerServiceAddress(), "testAddress")
+	assert.Equal(t, conf.GetProcessNamespaces()[0].String(), "testProcessNamespaces")
+	assert.Equal(t, conf.GetBypassNamespaces()[0].String(), "testBypassNamespaces")
+	assert.Equal(t, conf.GetLabelNamespaces()[0].String(), "testLabelNamespaces")
+	assert.Equal(t, conf.GetNoLabelNamespaces()[0].String(), "testNolabelNamespaces")
+	assert.Equal(t, conf.GetBypassAuth(), true)
+	assert.Equal(t, conf.GetSystemUsers()[0].String(), "systemuser")
+	assert.Equal(t, conf.GetExternalUsers()[0].String(), "yunikorn")
+	assert.Equal(t, conf.GetExternalGroups()[0].String(), "devs")
+	assert.Equal(t, conf.GetTrustControllers(), false)
+
+	// test missing settings
+	conf = NewAdmissionControllerConf([]*v1.ConfigMap{nil, nil})
+	assert.Equal(t, conf.GetPolicyGroup(), schedulerconf.DefaultPolicyGroup)
+	assert.Equal(t, conf.GetNamespace(), schedulerconf.DefaultNamespace)
+	assert.Equal(t, conf.GetAmServiceName(), DefaultWebHookAmServiceName)
+	assert.Equal(t, conf.GetSchedulerServiceAddress(), DefaultWebHookSchedulerServiceAddress)
+	assert.Equal(t, 0, len(conf.GetProcessNamespaces()))
+	assert.Equal(t, conf.GetBypassNamespaces()[0].String(), DefaultFilteringBypassNamespaces)
+	assert.Equal(t, 0, len(conf.GetLabelNamespaces()))
+	assert.Equal(t, 0, len(conf.GetNoLabelNamespaces()))
+	assert.Equal(t, conf.GetBypassAuth(), DefaultAccessControlBypassAuth)
+	assert.Equal(t, conf.GetSystemUsers()[0].String(), DefaultAccessControlSystemUsers)
+	assert.Equal(t, 0, len(conf.GetExternalUsers()))
+	assert.Equal(t, 0, len(conf.GetExternalGroups()))
+	assert.Equal(t, conf.GetTrustControllers(), DefaultAccessControlTrustControllers)
+
+	// test faulty settings for boolean values
+	conf = NewAdmissionControllerConf([]*v1.ConfigMap{nil, {Data: map[string]string{
+		AMAccessControlBypassAuth:       "xyz",
+		AMAccessControlTrustControllers: "xyz",
+	}}})
+	assert.Equal(t, conf.GetBypassAuth(), DefaultAccessControlBypassAuth)
+	assert.Equal(t, conf.GetTrustControllers(), DefaultAccessControlTrustControllers)
+
+	// test disable / enable of config hot refresh
+	conf = NewAdmissionControllerConf([]*v1.ConfigMap{nil, nil})
+
+	// test set (hot refresh enabled)
+	conf.updateConfigMaps([]*v1.ConfigMap{nil, {
+		Data: map[string]string{
+			schedulerconf.CMSvcPolicyGroup: "testPolicyGroup",
+		},
+	}}, false)
+	assert.Equal(t, conf.GetPolicyGroup(), "testPolicyGroup")
+
+	// update performed at the same time as disabling hot refresh should still work
+	conf.updateConfigMaps([]*v1.ConfigMap{nil, {
+		Data: map[string]string{
+			schedulerconf.CMSvcEnableConfigHotRefresh: "false",
+			schedulerconf.CMSvcPolicyGroup:            "testPolicyGroup2",
+		},
+	}}, false)
+	assert.Equal(t, conf.GetPolicyGroup(), "testPolicyGroup2")
+
+	// update performed even when resetting hot refresh should not work
+	conf.updateConfigMaps([]*v1.ConfigMap{nil, {
+		Data: map[string]string{
+			schedulerconf.CMSvcEnableConfigHotRefresh: "true",
+			schedulerconf.CMSvcPolicyGroup:            "testPolicyGroup3",
+		},
+	}}, false)
+
+	// update again should also not change, as hot-refresh is one-way disable
+	assert.Equal(t, conf.GetPolicyGroup(), "testPolicyGroup2")
+	conf.updateConfigMaps([]*v1.ConfigMap{nil, {
+		Data: map[string]string{
+			schedulerconf.CMSvcEnableConfigHotRefresh: "true",
+			schedulerconf.CMSvcPolicyGroup:            "testPolicyGroup4",
+		},
+	}}, false)
+	assert.Equal(t, conf.GetPolicyGroup(), "testPolicyGroup2")
+}
+
+func TestEnvironmentVars(t *testing.T) {
+	resetEnv()
+	defer resetEnv()
+
+	// test valid settings
+	os.Setenv(schedulerconf.EnvNamespace, "testNamespace")
+	os.Setenv(deprecatedEnvService, "testYunikornService")
+	os.Setenv(deprecatedEnvSchedulerServiceAddress, "testAddress")
+	os.Setenv(deprecatedEnvProcessNamespaces, "testProcessNamespaces")
+	os.Setenv(deprecatedEnvBypassNamespaces, "testBypassNamespaces")
+	os.Setenv(deprecatedEnvLabelNamespaces, "testLabelNamespaces")
+	os.Setenv(deprecatedEnvNoLabelNamespaces, "testNolabelNamespaces")
+	os.Setenv(deprecatedEnvBypassAuth, "true")
+	os.Setenv(deprecatedEnvSystemUsers, "systemuser")
+	os.Setenv(deprecatedEnvExternalUsers, "yunikorn")
+	os.Setenv(deprecatedEnvExternalGroups, "devs")
+	os.Setenv(deprecatedEnvTrustControllers, "false")
+
+	conf := NewAdmissionControllerConf([]*v1.ConfigMap{nil, nil})
+	assert.Equal(t, conf.GetNamespace(), "testNamespace")
+	assert.Equal(t, conf.GetAmServiceName(), "testYunikornService")
+	assert.Equal(t, conf.GetSchedulerServiceAddress(), "testAddress")
+	assert.Equal(t, conf.GetProcessNamespaces()[0].String(), "testProcessNamespaces")
+	assert.Equal(t, conf.GetBypassNamespaces()[0].String(), "testBypassNamespaces")
+	assert.Equal(t, conf.GetLabelNamespaces()[0].String(), "testLabelNamespaces")
+	assert.Equal(t, conf.GetNoLabelNamespaces()[0].String(), "testNolabelNamespaces")
+	assert.Equal(t, conf.GetBypassAuth(), true)
+	assert.Equal(t, conf.GetSystemUsers()[0].String(), "systemuser")
+	assert.Equal(t, conf.GetExternalUsers()[0].String(), "yunikorn")
+	assert.Equal(t, conf.GetExternalGroups()[0].String(), "devs")
+	assert.Equal(t, conf.GetTrustControllers(), false)
+
+	// test missing settings
+	resetEnv()
+	conf = NewAdmissionControllerConf([]*v1.ConfigMap{nil, nil})
+	assert.Equal(t, conf.GetNamespace(), schedulerconf.DefaultNamespace)
+	assert.Equal(t, conf.GetAmServiceName(), DefaultWebHookAmServiceName)
+	assert.Equal(t, conf.GetSchedulerServiceAddress(), DefaultWebHookSchedulerServiceAddress)
+	assert.Equal(t, 0, len(conf.GetProcessNamespaces()))
+	assert.Equal(t, conf.GetBypassNamespaces()[0].String(), DefaultFilteringBypassNamespaces)
+	assert.Equal(t, 0, len(conf.GetLabelNamespaces()))
+	assert.Equal(t, 0, len(conf.GetNoLabelNamespaces()))
+	assert.Equal(t, conf.GetBypassAuth(), DefaultAccessControlBypassAuth)
+	assert.Equal(t, conf.GetSystemUsers()[0].String(), DefaultAccessControlSystemUsers)
+	assert.Equal(t, 0, len(conf.GetExternalUsers()))
+	assert.Equal(t, 0, len(conf.GetExternalGroups()))
+	assert.Equal(t, conf.GetTrustControllers(), DefaultAccessControlTrustControllers)
+
+	// test faulty settings for boolean values
+	resetEnv()
+	os.Setenv(deprecatedEnvBypassAuth, "xyz")
+	os.Setenv(deprecatedEnvTrustControllers, "xyz")
+
+	conf = NewAdmissionControllerConf([]*v1.ConfigMap{nil, nil})
+	assert.Equal(t, conf.GetBypassAuth(), DefaultAccessControlBypassAuth)
+	assert.Equal(t, conf.GetTrustControllers(), DefaultAccessControlTrustControllers)
+}

--- a/pkg/plugin/admissioncontrollers/webhook/util_test.go
+++ b/pkg/plugin/admissioncontrollers/webhook/util_test.go
@@ -16,28 +16,18 @@
  limitations under the License.
 */
 
-package client
+package main
 
 import (
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
-	"github.com/apache/yunikorn-k8shim/pkg/conf"
+	"github.com/apache/yunikorn-k8shim/pkg/plugin/admissioncontrollers/webhook/conf"
 )
 
-func LoadBootstrapConfigMaps(namespace string) ([]*v1.ConfigMap, error) {
-	// we need a bootstrap client so that we can read the initial version of the configmap
-	kubeClient := NewBootstrapKubeClient(conf.GetDefaultKubeConfigPath())
+func createConfig() *conf.AdmissionControllerConf {
+	return conf.NewAdmissionControllerConf([]*v1.ConfigMap{nil, nil})
+}
 
-	defaults, err := kubeClient.GetConfigMap(namespace, constants.DefaultConfigMapName)
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := kubeClient.GetConfigMap(namespace, constants.ConfigMapName)
-	if err != nil {
-		return nil, err
-	}
-
-	return []*v1.ConfigMap{defaults, config}, nil
+func createConfigWithOverrides(overrides map[string]string) *conf.AdmissionControllerConf {
+	return conf.NewAdmissionControllerConf([]*v1.ConfigMap{nil, {Data: overrides}})
 }

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -207,7 +207,7 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
 	log.Logger().Info("Build info", zap.String("version", conf.BuildVersion), zap.String("date", conf.BuildDate))
 
-	configMaps, err := client.LoadBootstrapConfigMaps()
+	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {
 		log.Logger().Fatal("Unable to bootstrap configuration", zap.Error(err))
 	}

--- a/test/e2e/admission_controller/admission_controller_suite_test.go
+++ b/test/e2e/admission_controller/admission_controller_suite_test.go
@@ -69,6 +69,8 @@ var _ = BeforeSuite(func() {
 	kubeClient = k8s.KubeCtl{}
 	Expect(kubeClient.SetClient()).To(BeNil())
 
+	yunikorn.EnsureYuniKornConfigsPresent()
+
 	By("Port-forward the scheduler pod")
 	err := kubeClient.PortForwardYkSchedulerPod()
 	Ω(err).NotTo(HaveOccurred())

--- a/test/e2e/admission_controller/admission_controller_test.go
+++ b/test/e2e/admission_controller/admission_controller_test.go
@@ -81,13 +81,26 @@ var _ = ginkgo.Describe("AdmissionController", func() {
 		gomega.Ω(res.Allowed).Should(gomega.BeEquivalentTo(false))
 	})
 
+	ginkgo.It("Configure the scheduler with an empty configmap", func() {
+		emptyConfigMap := v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.ConfigMapName,
+				Namespace: configmanager.YuniKornTestConfig.YkNamespace,
+			},
+			Data: make(map[string]string),
+		}
+		cm, err := kubeClient.UpdateConfigMap(&emptyConfigMap, configmanager.YuniKornTestConfig.YkNamespace)
+		gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+		gomega.Ω(cm).ShouldNot(gomega.BeNil())
+	})
+
 	ginkgo.It("Configure the scheduler with invalid configmap", func() {
 		invalidConfigMap := v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      constants.ConfigMapName,
 				Namespace: configmanager.YuniKornTestConfig.YkNamespace,
 			},
-			Data: make(map[string]string),
+			Data: map[string]string{"queues.yaml": "invalid"},
 		}
 		invalidCm, err := kubeClient.UpdateConfigMap(&invalidConfigMap, configmanager.YuniKornTestConfig.YkNamespace)
 		gomega.Ω(err).Should(gomega.HaveOccurred())

--- a/test/e2e/app/app_test.go
+++ b/test/e2e/app/app_test.go
@@ -43,6 +43,8 @@ var _ = ginkgo.Describe("App", func() {
 		kClient = k8s.KubeCtl{}
 		gomega.Ω(kClient.SetClient()).To(gomega.BeNil())
 
+		yunikorn.EnsureYuniKornConfigsPresent()
+
 		ginkgo.By("Port-forward the scheduler pod")
 		err := kClient.PortForwardYkSchedulerPod()
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/basic_scheduling/basic_scheduling_test.go
+++ b/test/e2e/basic_scheduling/basic_scheduling_test.go
@@ -50,6 +50,8 @@ var _ = ginkgo.Describe("", func() {
 		// Initializing rest client
 		restClient = yunikorn.RClient{}
 
+		yunikorn.EnsureYuniKornConfigsPresent()
+
 		By("Port-forward the scheduler pod")
 		err := kClient.PortForwardYkSchedulerPod()
 		Ω(err).NotTo(HaveOccurred())

--- a/test/e2e/framework/helpers/k8s/k8s_utils.go
+++ b/test/e2e/framework/helpers/k8s/k8s_utils.go
@@ -376,6 +376,17 @@ func (k *KubeCtl) CreateConfigMap(cMap *v1.ConfigMap, namespace string) (*v1.Con
 	return k.clientSet.CoreV1().ConfigMaps(namespace).Create(context.TODO(), cMap, metav1.CreateOptions{})
 }
 
+func (k *KubeCtl) ConfigMapExists(name string, namespace string) (bool, error) {
+	_, err := k.clientSet.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func (k *KubeCtl) GetConfigMap(name string, namespace string) (*v1.ConfigMap, error) {
 	return k.clientSet.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }

--- a/test/e2e/framework/helpers/yunikorn/yk_utils.go
+++ b/test/e2e/framework/helpers/yunikorn/yk_utils.go
@@ -21,6 +21,13 @@ package yunikorn
 import (
 	"fmt"
 
+	"github.com/apache/yunikorn-core/pkg/common/configs"
+	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
+
+	//	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/configmanager"
 )
 
@@ -52,4 +59,16 @@ func GetYKHost() string {
 
 func GetYKScheme() string {
 	return configmanager.YuniKornTestConfig.YkScheme
+}
+
+func CreateDefaultConfigMap() *v1.ConfigMap {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.ConfigMapName,
+			Namespace: configmanager.YuniKornTestConfig.YkNamespace,
+		},
+		Data: make(map[string]string),
+	}
+	cm.Data[configmanager.DefaultPolicyGroup] = configs.DefaultSchedulerConfig
+	return cm
 }

--- a/test/e2e/predicates/predicates_suite_test.go
+++ b/test/e2e/predicates/predicates_suite_test.go
@@ -46,6 +46,7 @@ var annotation string
 
 var _ = BeforeSuite(func() {
 	annotation = "ann-" + common.RandSeq(10)
+	yunikorn.EnsureYuniKornConfigsPresent()
 	yunikorn.UpdateConfigMapWrapper(oldConfigMap, "fifo", annotation)
 })
 

--- a/test/e2e/queue_quota_mgmt/queue_quota_mgmt_suite_test.go
+++ b/test/e2e/queue_quota_mgmt/queue_quota_mgmt_suite_test.go
@@ -43,6 +43,7 @@ var oldConfigMap = new(v1.ConfigMap)
 var annotation = "ann-" + common.RandSeq(10)
 
 var _ = BeforeSuite(func() {
+	yunikorn.EnsureYuniKornConfigsPresent()
 	yunikorn.UpdateConfigMapWrapper(oldConfigMap, "", annotation)
 })
 

--- a/test/e2e/recovery_and_restart/recovery_and_restart_test.go
+++ b/test/e2e/recovery_and_restart/recovery_and_restart_test.go
@@ -61,6 +61,8 @@ var _ = ginkgo.Describe("", func() {
 		// Initializing rest client
 		restClient = yunikorn.RClient{}
 
+		yunikorn.EnsureYuniKornConfigsPresent()
+
 		ginkgo.By("Enable basic scheduling config over config maps")
 		var c, err = kClient.GetConfigMaps(configmanager.YuniKornTestConfig.YkNamespace,
 			configmanager.DefaultYuniKornConfigMap)

--- a/test/e2e/simple_preemptor/simple_preemptor_test.go
+++ b/test/e2e/simple_preemptor/simple_preemptor_test.go
@@ -59,6 +59,8 @@ var _ = ginkgo.Describe("SimplePreemptor", func() {
 		restClient = yunikorn.RClient{}
 		Ω(restClient).NotTo(gomega.BeNil())
 
+		yunikorn.EnsureYuniKornConfigsPresent()
+
 		ginkgo.By("Port-forward the scheduler pod")
 		var err = kClient.PortForwardYkSchedulerPod()
 		Ω(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/state_aware_app_scheduling/state_aware_app_scheduling_suite_test.go
+++ b/test/e2e/state_aware_app_scheduling/state_aware_app_scheduling_suite_test.go
@@ -44,6 +44,7 @@ var annotation string
 
 var _ = BeforeSuite(func() {
 	annotation = "ann-" + common.RandSeq(10)
+	yunikorn.EnsureYuniKornConfigsPresent()
 	yunikorn.UpdateConfigMapWrapper(oldConfigMap, "stateaware", annotation)
 })
 


### PR DESCRIPTION
### What is this PR for?
Updates the admission controller to read its configuration from configmaps instead of environment variables. Additionally, config reloading is supported.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1370

### How should this be tested?
New unit tests added, updated e2e test to allow empty configmap to validate.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
