### PR TITLE
[YUNIKORN-1404] e2e: don't delete individual pods when jobs are submitted

### DIFF
--- a/test/e2e/framework/helpers/k8s/k8s_utils.go
+++ b/test/e2e/framework/helpers/k8s/k8s_utils.go
@@ -31,6 +31,8 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -57,6 +59,17 @@ import (
 )
 
 const portForwardPort = 9080
+
+type WorkloadType string
+
+const (
+	Deployment  = "Deployment"
+	StatefulSet = "StatefulSet"
+	DaemonSet   = "DaemonSet"
+	ReplicaSet  = "ReplicaSet"
+	Job         = "Job"
+	CronJob     = "CronJob"
+)
 
 var fw *portforward.PortForwarder
 var lock = &sync.Mutex{}
@@ -1189,4 +1202,37 @@ func (k *KubeCtl) UntaintNode(name, key string) error {
 	node.Spec.Taints = newTaints
 	_, err = k.clientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 	return err
+}
+
+func (k *KubeCtl) DeleteWorkloadAndPods(objectName string, wlType WorkloadType, namespace string) {
+	ginkgo.By("Delete " + objectName + ", type is " + string(wlType) + " in namespace " + namespace)
+	var err error
+	switch wlType {
+	case Deployment:
+		err = k.DeleteDeployment(objectName, namespace)
+	case StatefulSet:
+		err = k.DeleteStatefulSet(objectName, namespace)
+	case ReplicaSet:
+		err = k.DeleteReplicaSet(objectName, namespace)
+	case DaemonSet:
+		err = k.DeleteDaemonSet(objectName, namespace)
+	case Job:
+		err = k.DeleteJob(objectName, namespace)
+	case CronJob:
+		err = k.DeleteCronJob(objectName, namespace)
+	default:
+		fmt.Fprintf(ginkgo.GinkgoWriter, "Unknown type %s, just deleting pods\n", string(wlType))
+	}
+	gomega.Ω(err).ShouldNot(gomega.HaveOccurred(), "Could not delete "+objectName)
+
+	pods, err := k.GetPods(namespace)
+	gomega.Ω(err).ShouldNot(gomega.HaveOccurred(), "Could not get pods from namespace "+namespace)
+	fmt.Fprintf(ginkgo.GinkgoWriter, "Forcibly deleting remaining pods in namespace %s\n", namespace)
+	for _, pod := range pods.Items {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "Deleting %s\n", pod.Name)
+		_ = k.DeletePod(pod.Name, namespace) //nolint:errcheck
+	}
+
+	err = k.WaitForPodCount(namespace, 0, 10*time.Second)
+	gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
 }

--- a/test/e2e/recovery_and_restart/recovery_and_restart_suite_test.go
+++ b/test/e2e/recovery_and_restart/recovery_and_restart_suite_test.go
@@ -19,9 +19,11 @@
 package recoveryandrestart_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/onsi/gomega"
 
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/configmanager"
@@ -32,6 +34,14 @@ func init() {
 }
 
 func TestRecoveryAndRestart(t *testing.T) {
+	ginkgo.ReportAfterSuite("TestRecoveryAndRestart", func(report ginkgo.Report) {
+		err := reporters.GenerateJUnitReportWithConfig(
+			report,
+			filepath.Join(configmanager.YuniKornTestConfig.LogDir, "TEST-recovery_and_restart_junit.xml"),
+			reporters.JunitReportConfig{OmitSpecLabels: true},
+		)
+		Ω(err).NotTo(gomega.HaveOccurred())
+	})
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "RecoveryAndRestart Suite")
 }

--- a/test/e2e/recovery_and_restart/recovery_and_restart_test.go
+++ b/test/e2e/recovery_and_restart/recovery_and_restart_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/configmanager"
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/common"
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/k8s"
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/yunikorn"
@@ -99,17 +100,25 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
+	ginkgo.By("Tear down namespace: " + dev)
+	err := kClient.TearDownNamespace(dev)
+	Ω(err).NotTo(gomega.HaveOccurred())
+
 	// call the healthCheck api to check scheduler health
 	ginkgo.By("Check Yunikorn's health")
-	checks, err := yunikorn.GetFailedHealthChecks()
-	Ω(err).NotTo(gomega.HaveOccurred())
+	checks, err2 := yunikorn.GetFailedHealthChecks()
+	Ω(err2).NotTo(gomega.HaveOccurred())
 	Ω(checks).To(gomega.Equal(""), checks)
 
-	ginkgo.By("Tear down namespace: " + dev)
-	err = kClient.TearDownNamespace(dev)
-	Ω(err).NotTo(gomega.HaveOccurred())
-
-	yunikorn.RestoreConfigMapWrapper(oldConfigMap, annotation)
+	ginkgo.By("Restoring the old config maps")
+	var c, err1 = kClient.GetConfigMaps(configmanager.YuniKornTestConfig.YkNamespace,
+		configmanager.DefaultYuniKornConfigMap)
+	Ω(err1).NotTo(gomega.HaveOccurred())
+	Ω(c).NotTo(gomega.BeNil())
+	c.Data = oldConfigMap.Data
+	var e, err3 = kClient.UpdateConfigMap(c, configmanager.YuniKornTestConfig.YkNamespace)
+	Ω(err3).NotTo(gomega.HaveOccurred())
+	Ω(e).NotTo(gomega.BeNil())
 })
 
 var _ = ginkgo.Describe("", func() {
@@ -154,8 +163,10 @@ var _ = ginkgo.Describe("", func() {
 		job1 := k8s.InitTestJob(appID1, parallelism, parallelism, pod1)
 		_, createErr := kClient.CreateJob(job1, dev)
 		Ω(createErr).NotTo(gomega.HaveOccurred())
+		defer kClient.DeleteWorkloadAndPods(job1.Name, k8s.Job, dev)
 		job2 := k8s.InitTestJob(appID2, parallelism, parallelism, pod2)
 		_, createErr2 := kClient.CreateJob(job2, dev)
+		defer kClient.DeleteWorkloadAndPods(job2.Name, k8s.Job, dev)
 		Ω(createErr2).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Restart the scheduler pod immediately")
@@ -175,29 +186,6 @@ var _ = ginkgo.Describe("", func() {
 		Ω(err).NotTo(gomega.HaveOccurred())
 		err = kClient.WaitForJobPodsRunning(dev, job2.Name, parallelism, 60*time.Second)
 		Ω(err).NotTo(gomega.HaveOccurred())
-
-		ginkgo.By("Deleting sleep jobs")
-		err = kClient.DeleteJob(job1.Name, dev)
-		Ω(err).NotTo(gomega.HaveOccurred())
-		err = kClient.DeleteJob(job2.Name, dev)
-		Ω(err).NotTo(gomega.HaveOccurred())
-
-		ginkgo.By("Deleting sleep pods")
-		sleep1Pods, err2 := kClient.ListPods(dev, "applicationId="+sleepPodConfig1.AppID)
-		Ω(err2).NotTo(gomega.HaveOccurred())
-		sleep2Pods, err3 := kClient.ListPods(dev, "applicationId="+sleepPodConfig2.AppID)
-		Ω(err3).NotTo(gomega.HaveOccurred())
-
-		sleepPods := make([]v1.Pod, 0)
-		sleepPods = append(sleepPods, sleep1Pods.Items...)
-		sleepPods = append(sleepPods, sleep2Pods.Items...)
-
-		for _, pod := range sleepPods {
-			podName := pod.GetName()
-			err := kClient.DeletePod(podName, dev)
-			Ω(err).NotTo(gomega.HaveOccurred())
-			fmt.Fprintf(ginkgo.GinkgoWriter, "Deleted pod %s\n", podName)
-		}
 	})
 
 	ginkgo.It("Verify_GangScheduling_TwoGangs_Restart_YK", func() {
@@ -217,6 +205,7 @@ var _ = ginkgo.Describe("", func() {
 		job := k8s.InitTestJob(appID, parallelism, parallelism, pod)
 		_, err := kClient.CreateJob(job, dev)
 		Ω(err).NotTo(gomega.HaveOccurred())
+		defer kClient.DeleteWorkloadAndPods(job.Name, k8s.Job, dev)
 
 		ginkgo.By("Waiting job pods to be created")
 		createErr := kClient.WaitForJobPodsCreated(dev, job.Name, parallelism, 30*time.Second)


### PR DESCRIPTION
### What is this PR for?
Don't just clean up individual pods when jobs are submitted, instead, delete the job then delete any pods in the namespace which are still there. This ensure proper cleanup.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1404

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
