### PR TITLE
[YUNIKORN-1547] Use Pending instead of QuotaApproved status for ready to schedule

### DIFF
--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -443,7 +443,7 @@ func (task *Task) postTaskBound() {
 		if _, err := task.UpdateTaskPod(podCopy, func(pod *v1.Pod) {
 			pod.Status = v1.PodStatus{
 				Phase:   podCopy.Status.Phase,
-				Reason:  "QuotaApproved",
+				Reason:  "Pending",
 				Message: "pod fits into the queue quota and it is ready for scheduling",
 			}
 


### PR DESCRIPTION
### What is this PR for?
The plugin mode currently uses a custom pod status of QuotaApproved, which can cause some issues with third-party tooling. Instead, we should use Pending.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1547

### How should this be tested?
E2e tests continue to run.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
