### PR TITLE
[YUNIKORN-1550] pass k8s node labels as attributes not json

### DIFF
--- a/pkg/cache/node.go
+++ b/pkg/cache/node.go
@@ -36,7 +36,7 @@ import (
 type SchedulerNode struct {
 	name         string
 	uid          string
-	labels       string
+	labels       map[string]string
 	schedulable  bool
 	schedulerAPI api.SchedulerAPI
 	fsm          *fsm.FSM
@@ -50,7 +50,7 @@ type SchedulerNode struct {
 	lock *sync.RWMutex
 }
 
-func newSchedulerNode(nodeName string, nodeUID string, nodeLabels string,
+func newSchedulerNode(nodeName string, nodeUID string, nodeLabels map[string]string,
 	nodeResource *si.Resource, schedulerAPI api.SchedulerAPI, schedulable bool, ready bool) *SchedulerNode {
 	schedulerNode := &SchedulerNode{
 		name:         nodeName,

--- a/pkg/cache/node_graphviz_test.go
+++ b/pkg/cache/node_graphviz_test.go
@@ -39,7 +39,7 @@ func TestNodeFsmGraph(t *testing.T) {
 		AddResource(siCommon.Memory, 1).
 		AddResource(siCommon.CPU, 1).
 		Build()
-	node := newSchedulerNode("host001", "UID001", "{}", r1, api, false)
+	node := newSchedulerNode("host001", "UID001", map[string]string{}, r1, api, false)
 	graph := fsm.Visualize(node.fsm)
 
 	err := os.MkdirAll("../../_output/fsm", 0755)

--- a/pkg/cache/node_test.go
+++ b/pkg/cache/node_test.go
@@ -83,6 +83,9 @@ func NewTestSchedulerNode() *SchedulerNode {
 		AddResource(siCommon.Memory, 1).
 		AddResource(siCommon.CPU, 1).
 		Build()
-	node := newSchedulerNode("host001", "UID001", "{\"label1\":\"key1\",\"label2\":\"key2\"}", r1, api, false, true)
+	node := newSchedulerNode("host001", "UID001", map[string]string{
+		"key1": "label1",
+		"key2": "label2",
+	}, r1, api, false, true)
 	return node
 }

--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -19,7 +19,6 @@
 package cache
 
 import (
-	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -101,20 +100,13 @@ func (nc *schedulerNodes) addAndReportNode(node *v1.Node, reportNode bool) {
 
 	// add node to nodes map
 	if _, ok := nc.nodesMap[node.Name]; !ok {
-		var nodeLabels []byte
-		nodeLabels, err := json.Marshal(node.Labels) // A nil pointer encodes as the "null" JSON value.
-		if err != nil {
-			log.Logger().Error("failed to marshall node labels to json", zap.Error(err))
-			nodeLabels = make([]byte, 0)
-		}
-
 		log.Logger().Info("adding node to context",
 			zap.String("nodeName", node.Name),
-			zap.String("nodeLabels", string(nodeLabels)),
+			zap.String("nodeLabels", fmt.Sprintf("%v", node.Labels)),
 			zap.Bool("schedulable", !node.Spec.Unschedulable))
 
 		ready := hasReadyCondition(node)
-		newNode := newSchedulerNode(node.Name, string(node.UID), string(nodeLabels),
+		newNode := newSchedulerNode(node.Name, string(node.UID), node.Labels,
 			common.GetNodeResource(&node.Status), nc.proxy, !node.Spec.Unschedulable, ready)
 		nc.nodesMap[node.Name] = newNode
 	}

--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -102,7 +102,7 @@ func (nc *schedulerNodes) addAndReportNode(node *v1.Node, reportNode bool) {
 	if _, ok := nc.nodesMap[node.Name]; !ok {
 		log.Logger().Info("adding node to context",
 			zap.String("nodeName", node.Name),
-			zap.String("nodeLabels", fmt.Sprintf("%v", node.Labels)),
+			zap.Any("nodeLabels", node.Labels),
 			zap.Bool("schedulable", !node.Spec.Unschedulable))
 
 		ready := hasReadyCondition(node)

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -25,7 +25,6 @@ const False = "false"
 // Cluster
 const DefaultNodeAttributeHostNameKey = "si.io/hostname"
 const DefaultNodeAttributeRackNameKey = "si.io/rackname"
-const DefaultNodeAttributeNodeLabelsKey = "si.io/nodelabels"
 const DefaultRackName = "/rack-default"
 
 // Application

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -149,7 +149,7 @@ func CreateReleaseAllocationRequestForTask(appID, allocUUID, partition, terminat
 }
 
 // CreateUpdateRequestForNewNode builds a NodeRequest for new node addition and restoring existing node
-func CreateUpdateRequestForNewNode(nodeID string, nodeLabels string, capacity *si.Resource, occupied *si.Resource,
+func CreateUpdateRequestForNewNode(nodeID string, nodeLabels map[string]string, capacity *si.Resource, occupied *si.Resource,
 	existingAllocations []*si.Allocation, ready bool) si.NodeRequest {
 	// Use node's name as the NodeID, this is because when bind pod to node,
 	// name of node is required but uid is optional.
@@ -158,13 +158,17 @@ func CreateUpdateRequestForNewNode(nodeID string, nodeLabels string, capacity *s
 		SchedulableResource: capacity,
 		OccupiedResource:    occupied,
 		Attributes: map[string]string{
-			constants.DefaultNodeAttributeHostNameKey:   nodeID,
-			constants.DefaultNodeAttributeRackNameKey:   constants.DefaultRackName,
-			constants.DefaultNodeAttributeNodeLabelsKey: nodeLabels,
-			common.NodeReadyAttribute:                   strconv.FormatBool(ready),
+			constants.DefaultNodeAttributeHostNameKey: nodeID,
+			constants.DefaultNodeAttributeRackNameKey: constants.DefaultRackName,
+			common.NodeReadyAttribute:                 strconv.FormatBool(ready),
 		},
 		ExistingAllocations: existingAllocations,
 		Action:              si.NodeInfo_CREATE,
+	}
+
+	// Add nodeLabels key value to Attributes map
+	for k, v := range nodeLabels {
+		nodeInfo.Attributes[k] = v
 	}
 
 	nodes := make([]*si.NodeInfo, 1)

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 const nodeID = "node-01"
-const nodeLabels = "{\"label1\":\"key1\",\"label2\":\"key2\"}"
 
 func TestCreateReleaseAllocationRequest(t *testing.T) {
 	request := CreateReleaseAllocationRequestForTask("app01", "alloc01", "default", "STOPPED_BY_RM")
@@ -218,16 +217,23 @@ func TestCreateUpdateRequestForNewNode(t *testing.T) {
 	occupied := NewResourceBuilder().AddResource(common.Memory, 50).AddResource(common.CPU, 1).Build()
 	var existingAllocations []*si.Allocation
 	ready := true
+	nodeLabels := map[string]string{
+		"label1": "key1",
+		"label2": "key2",
+	}
 	request := CreateUpdateRequestForNewNode(nodeID, nodeLabels, capacity, occupied, existingAllocations, ready)
 	assert.Equal(t, len(request.Nodes), 1)
 	assert.Equal(t, request.Nodes[0].NodeID, nodeID)
 	assert.Equal(t, request.Nodes[0].SchedulableResource, capacity)
 	assert.Equal(t, request.Nodes[0].OccupiedResource, occupied)
-	assert.Equal(t, len(request.Nodes[0].Attributes), 4)
+	assert.Equal(t, len(request.Nodes[0].Attributes), 5)
 	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeHostNameKey], nodeID)
 	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeRackNameKey], constants.DefaultRackName)
-	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeNodeLabelsKey], nodeLabels)
 	assert.Equal(t, request.Nodes[0].Attributes[common.NodeReadyAttribute], strconv.FormatBool(ready))
+
+	// Make sure include nodeLabel
+	assert.Equal(t, request.Nodes[0].Attributes["label1"], "key1")
+	assert.Equal(t, request.Nodes[0].Attributes["label2"], "key2")
 }
 
 func TestCreateUpdateRequestForUpdatedNode(t *testing.T) {

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -86,7 +86,7 @@ func (fc *MockScheduler) updateConfig(queues string) error {
 	})
 }
 
-func (fc *MockScheduler) addNode(nodeName, nodeLabels string, memory, cpu int64) error {
+func (fc *MockScheduler) addNode(nodeName string, nodeLabels map[string]string, memory, cpu int64) error {
 	nodeResource := common.NewResourceBuilder().
 		AddResource(siCommon.Memory, memory).
 		AddResource(siCommon.CPU, cpu).

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -38,8 +38,6 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
-const nodeLabels = "{\"label1\":\"key1\",\"label2\":\"key2\"}"
-
 func TestApplicationScheduling(t *testing.T) {
 	configData := `
 partitions:
@@ -67,6 +65,10 @@ partitions:
 	cluster.waitForSchedulerState(t, SchedulerStates().Running)
 	err := cluster.updateConfig(configData)
 	assert.NilError(t, err, "update config failed")
+	nodeLabels := map[string]string{
+		"label1": "key1",
+		"label2": "key2",
+	}
 
 	// register nodes
 	err = cluster.addNode("test.host.01", nodeLabels, 100000000, 10)
@@ -117,6 +119,11 @@ partitions:
 	cluster.waitForSchedulerState(t, SchedulerStates().Running)
 	err := cluster.updateConfig(configData)
 	assert.NilError(t, err, "update config failed")
+
+	nodeLabels := map[string]string{
+		"label1": "key1",
+		"label2": "key2",
+	}
 
 	// register nodes
 	err = cluster.addNode("test.host.01", nodeLabels, 100000000, 10)
@@ -212,6 +219,10 @@ partitions:
 	err := cluster.updateConfig(configData)
 	assert.NilError(t, err, "update config failed")
 
+	nodeLabels := map[string]string{
+		"label1": "key1",
+		"label2": "key2",
+	}
 	// register nodes
 	err = cluster.addNode("test.host.01", nodeLabels, 100000000, 10)
 	assert.NilError(t, err, "add node failed")


### PR DESCRIPTION
### What is this PR for?
The k8shim in [YUNIKORN-1389](https://issues.apache.org/jira/browse/YUNIKORN-1389) was extended to pass on the K8s node labels to the core via the attributes. The K8s node labels are marshalled into a single json string. The string is added using a new key.

There are multiple issues with that. The overhead of un-marshalling it each time a label needs to be checked for existence is large. It also needs a two step check to find a label. First find the label in the attributes and then un-marshal the string and do another check for the real key & value needed.

We should add the labels from the K8s node as entries in the attributes map. Each label becomes and entry not json marshalling.

### What type of PR is it?
* [x] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1550
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
