### PR TITLE
[YUNIKORN-1526] support K8s pod overhead

### DIFF
--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -79,6 +79,21 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 		checkInitContainerRequest(pod, podResource)
 	}
 
+	// K8s pod EnableOverHead from:
+	// alpha: v1.16
+	// beta: v1.18
+	// Enables PodOverhead, for accounting pod overheads which are specific to a given RuntimeClass
+
+	// If Overhead is being utilized, add to the total requests for the pod
+	if pod.Spec.Overhead != nil {
+		podOverHeadResource := getResource(pod.Spec.Overhead)
+		podResource = Add(podResource, podOverHeadResource)
+		// Logging the overall pod size and pod overhead
+		log.Logger().Debug("We have calculated the overall pod size which includes the pod overhead",
+			zap.String("Pod overall size", podResource.String()),
+			zap.String("Pod overhead size", podOverHeadResource.String()))
+	}
+
 	return podResource
 }
 

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -89,7 +89,8 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 		podOverHeadResource := getResource(pod.Spec.Overhead)
 		podResource = Add(podResource, podOverHeadResource)
 		// Logging the overall pod size and pod overhead
-		log.Logger().Debug("We have calculated the overall pod size which includes the pod overhead",
+		log.Logger().Debug("Pod overhead specified, overall pod size adjusted",
+			zap.String("taskID", string(pod.UID)),
 			zap.String("Pod overall size", podResource.String()),
 			zap.String("Pod overhead size", podOverHeadResource.String()))
 	}

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -91,8 +91,8 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 		// Logging the overall pod size and pod overhead
 		log.Logger().Debug("Pod overhead specified, overall pod size adjusted",
 			zap.String("taskID", string(pod.UID)),
-			zap.String("Pod overall size", podResource.String()),
-			zap.String("Pod overhead size", podOverHeadResource.String()))
+			zap.Stringer("overallSize", podResource),
+			zap.Stringer("overheadSize", podOverHeadResource))
 	}
 
 	return podResource

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -191,6 +191,19 @@ func TestParsePodResource(t *testing.T) {
 	assert.Equal(t, res.Resources[siCommon.CPU].GetValue(), int64(3000))
 	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
 
+	// Add pod OverHead, only support CPU and Memory
+	overHeadResources := make(map[v1.ResourceName]resource.Quantity)
+	overHeadResources[v1.ResourceMemory] = resource.MustParse("500M")
+	overHeadResources[v1.ResourceCPU] = resource.MustParse("1")
+	// pod
+	pod.Spec.Overhead = overHeadResources
+
+	// verify we get aggregated resource from containers
+	res = GetPodResource(pod)
+	assert.Equal(t, res.Resources[siCommon.Memory].GetValue(), int64(2024*1000*1000))
+	assert.Equal(t, res.Resources[siCommon.CPU].GetValue(), int64(4000))
+	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
+
 	// test initcontainer and container resouce compare
 	initContainers := make([]v1.Container, 0)
 	initc1Resources := make(map[v1.ResourceName]resource.Quantity)

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -191,18 +191,19 @@ func TestParsePodResource(t *testing.T) {
 	assert.Equal(t, res.Resources[siCommon.CPU].GetValue(), int64(3000))
 	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
 
-	// Add pod OverHead, only support CPU and Memory
+	// Add pod OverHead
 	overHeadResources := make(map[v1.ResourceName]resource.Quantity)
 	overHeadResources[v1.ResourceMemory] = resource.MustParse("500M")
 	overHeadResources[v1.ResourceCPU] = resource.MustParse("1")
-	// pod
+	overHeadResources[v1.ResourceName("nvidia.com/gpu")] = resource.MustParse("1")
+	// Set pod OverHead
 	pod.Spec.Overhead = overHeadResources
 
 	// verify we get aggregated resource from containers
 	res = GetPodResource(pod)
 	assert.Equal(t, res.Resources[siCommon.Memory].GetValue(), int64(2024*1000*1000))
 	assert.Equal(t, res.Resources[siCommon.CPU].GetValue(), int64(4000))
-	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
+	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(6))
 
 	// test initcontainer and container resouce compare
 	initContainers := make([]v1.Container, 0)


### PR DESCRIPTION
### What is this PR for?
With K8s 1.24 a pod can now provide an overhead in the pod spec: pod.Spec.Overhead. The pod overhead allows specifying an overhead based on the runtime set on the pod. For certain runtimes this overhead can be large.  See this [KEP for details](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/688-pod-overhead).

The scheduler should take into account this overhead if set on a pod. We currently calculate the size of the pod based on the containers but do not take the overhead into account. That needs to change.

We need to take the overhead into account as part of scheduling and quota calculations: include the pod.Spec.Overhead resources in the size of the pod before sending it to the core. Overhead only support cpu and memory and is added to the requests. The plugin framework (node related checks) calculates the pod size each time it is called (overhead!) and includes the overhead. The callback for the predicates must take that into account and not be broken by that implementation.

Adding clearly how we have calculated the overall pod size in the logging is a requirement.

Note from @wilfred-s :
The field is optional and will not be set in any pod, unless the cluster has been setup with it, even if you run 1.24 or later.
It is not a user managed field it is set by an admission controller. You cannot set the field on a pod when you create the pod. The field has been part of the offical pod spec since 1.16, and marked as a beta field since 1.18. It was only moved to GA in 1.24.
We need to handle it as an optional field. Even for a release that has the feature as GA the field can be a nil 


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1526
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
