### PR TITLE
YUNIKORN-1564 Constants for node attributes are not consistent in scheduler interface and shim

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -23,8 +23,6 @@ const True = "true"
 const False = "false"
 
 // Cluster
-const DefaultNodeAttributeHostNameKey = "si.io/hostname"
-const DefaultNodeAttributeRackNameKey = "si.io/rackname"
 const DefaultNodeAttributeNodeLabelsKey = "si.io/nodelabels"
 const DefaultRackName = "/rack-default"
 

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -158,8 +158,8 @@ func CreateUpdateRequestForNewNode(nodeID string, nodeLabels string, capacity *s
 		SchedulableResource: capacity,
 		OccupiedResource:    occupied,
 		Attributes: map[string]string{
-			constants.DefaultNodeAttributeHostNameKey:   nodeID,
-			constants.DefaultNodeAttributeRackNameKey:   constants.DefaultRackName,
+			common.HostName: nodeID,
+			common.RackName: constants.DefaultRackName,
 			constants.DefaultNodeAttributeNodeLabelsKey: nodeLabels,
 			common.NodeReadyAttribute:                   strconv.FormatBool(ready),
 		},

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -224,8 +224,8 @@ func TestCreateUpdateRequestForNewNode(t *testing.T) {
 	assert.Equal(t, request.Nodes[0].SchedulableResource, capacity)
 	assert.Equal(t, request.Nodes[0].OccupiedResource, occupied)
 	assert.Equal(t, len(request.Nodes[0].Attributes), 4)
-	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeHostNameKey], nodeID)
-	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeRackNameKey], constants.DefaultRackName)
+	assert.Equal(t, request.Nodes[0].Attributes[common.HostName], nodeID)
+	assert.Equal(t, request.Nodes[0].Attributes[common.RackName], constants.DefaultRackName)
 	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeNodeLabelsKey], nodeLabels)
 	assert.Equal(t, request.Nodes[0].Attributes[common.NodeReadyAttribute], strconv.FormatBool(ready))
 }


### PR DESCRIPTION
### What is this PR for?
Before we do more changes to remove nodename noderack in node attribute, and then add noderack to nodeinfo, also change in Scheduler Interface and webapp in https://issues.apache.org/jira/browse/YUNIKORN-1560 

We first fix the consistence with interface and shim, then i will do above things.

And don't change the nodelabels field, because we will address new nodelabels pass instead of the json now in another jira:
https://issues.apache.org/jira/browse/YUNIKORN-1550

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1564
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
