### PR TITLE
[YUNIKORN-1555] Filter out terminated pods during recovery

### DIFF
--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
 	"go.uber.org/zap"
 
 	"github.com/apache/yunikorn-k8shim/pkg/appmgmt/general"
@@ -63,8 +64,10 @@ func (svc *AppManagementService) recoverApps() (map[string]interfaces.ManagedApp
 			})
 
 			for _, pod := range pods {
-				app := svc.podEventHandler.HandleEvent(general.AddPod, general.Recovery, pod)
-				recoveringApps[app.GetApplicationID()] = app
+				if utils.NeedRecovery(pod) {
+					app := svc.podEventHandler.HandleEvent(general.AddPod, general.Recovery, pod)
+					recoveringApps[app.GetApplicationID()] = app
+				}
 			}
 			log.Logger().Info("Recovery finished")
 			svc.podEventHandler.RecoveryDone()

--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -23,12 +23,12 @@ import (
 	"sort"
 	"time"
 
-	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
 	"go.uber.org/zap"
 
 	"github.com/apache/yunikorn-k8shim/pkg/appmgmt/general"
 	"github.com/apache/yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/yunikorn-k8shim/pkg/cache"
+	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 )
 

--- a/pkg/appmgmt/appmgmt_recovery_test.go
+++ b/pkg/appmgmt/appmgmt_recovery_test.go
@@ -277,10 +277,10 @@ func (ma *mockedAppManager) Stop() {
 func (ma *mockedAppManager) ListPods() ([]*v1.Pod, error) {
 	pods := make([]*v1.Pod, 8)
 	pods[0] = newPodHelper("pod1", "task01", "app01", time.Unix(100, 0), v1.PodRunning)
-	pods[1] = newPodHelper("pod2", "task02", "app01", time.Unix(500, 0), v1.PodRunning)
+	pods[1] = newPodHelper("pod2", "task02", "app01", time.Unix(500, 0), v1.PodPending)
 	pods[2] = newPodHelper("pod3", "task03", "app01", time.Unix(200, 0), v1.PodSucceeded)
 	pods[3] = newPodHelper("pod4", "task04", "app02", time.Unix(400, 0), v1.PodRunning)
-	pods[4] = newPodHelper("pod5", "task05", "app02", time.Unix(300, 0), v1.PodRunning)
+	pods[4] = newPodHelper("pod5", "task05", "app02", time.Unix(300, 0), v1.PodPending)
 	pods[5] = newPodHelper("pod6", "task06", "app02", time.Unix(600, 0), v1.PodFailed)
 
 	// these pods and apps should never be recovered

--- a/pkg/appmgmt/appmgmt_recovery_test.go
+++ b/pkg/appmgmt/appmgmt_recovery_test.go
@@ -197,6 +197,40 @@ func TestAppStatesDuringRecovery(t *testing.T) {
 	assert.Equal(t, app02.GetApplicationState(), cache.ApplicationStates().Accepted)
 }
 
+func TestPodRecovery(t *testing.T) {
+	conf.GetSchedulerConf().OperatorPlugins = "mocked-app-manager"
+	amProtocol := cache.NewMockedAMProtocol()
+	apiProvider := client.NewMockedAPIProvider(false)
+	taskRequests := make([]*interfaces.AddTaskRequest, 0)
+	amProtocol.UseAddTaskFn(func(request *interfaces.AddTaskRequest) {
+		taskRequests = append(taskRequests, request)
+	})
+	amService := NewAMService(amProtocol, apiProvider)
+	amService.register(&mockedAppManager{})
+
+	apps, err := amService.recoverApps()
+	assert.NilError(t, err)
+	assert.Equal(t, 4, len(taskRequests))
+	assert.Equal(t, 2, len(apps))
+
+	expected := map[string]map[string]bool{
+		"app01": {
+			"task01": true,
+			"task02": true,
+		},
+		"app02": {
+			"task04": true,
+			"task05": true,
+		},
+	}
+
+	for _, tr := range taskRequests {
+		check, ok := expected[tr.Metadata.ApplicationID]
+		assert.Assert(t, ok, "app should not be recovered: "+tr.Metadata.ApplicationID)
+		assert.Assert(t, check[tr.Metadata.TaskID], "task should not be recovered: "+tr.Metadata.TaskID)
+	}
+}
+
 func TestPodsSortedDuringRecovery(t *testing.T) {
 	conf.GetSchedulerConf().OperatorPlugins = "mocked-app-manager"
 	amProtocol := cache.NewMockedAMProtocol()
@@ -241,11 +275,17 @@ func (ma *mockedAppManager) Stop() {
 }
 
 func (ma *mockedAppManager) ListPods() ([]*v1.Pod, error) {
-	pods := make([]*v1.Pod, 4)
-	pods[0] = newPodHelper("pod1", "task01", "app01", time.Unix(100, 0))
-	pods[1] = newPodHelper("pod2", "task02", "app01", time.Unix(500, 0))
-	pods[2] = newPodHelper("pod3", "task03", "app02", time.Unix(200, 0))
-	pods[3] = newPodHelper("pod4", "task04", "app02", time.Unix(300, 0))
+	pods := make([]*v1.Pod, 8)
+	pods[0] = newPodHelper("pod1", "task01", "app01", time.Unix(100, 0), v1.PodRunning)
+	pods[1] = newPodHelper("pod2", "task02", "app01", time.Unix(500, 0), v1.PodRunning)
+	pods[2] = newPodHelper("pod3", "task03", "app01", time.Unix(200, 0), v1.PodSucceeded)
+	pods[3] = newPodHelper("pod4", "task04", "app02", time.Unix(400, 0), v1.PodRunning)
+	pods[4] = newPodHelper("pod5", "task05", "app02", time.Unix(300, 0), v1.PodRunning)
+	pods[5] = newPodHelper("pod6", "task06", "app02", time.Unix(600, 0), v1.PodFailed)
+
+	// these pods and apps should never be recovered
+	pods[6] = newPodHelper("pod7", "task07", "app03", time.Unix(300, 0), v1.PodFailed)
+	pods[7] = newPodHelper("pod8", "task08", "app04", time.Unix(300, 0), v1.PodSucceeded)
 
 	return pods, nil
 }
@@ -254,7 +294,7 @@ func (ma *mockedAppManager) GetExistingAllocation(pod *v1.Pod) *si.Allocation {
 	return nil
 }
 
-func newPodHelper(name, podUID, appID string, creationTimeStamp time.Time) *v1.Pod {
+func newPodHelper(name, podUID, appID string, creationTimeStamp time.Time, phase v1.PodPhase) *v1.Pod {
 	return &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
@@ -274,7 +314,7 @@ func newPodHelper(name, podUID, appID string, creationTimeStamp time.Time) *v1.P
 			SchedulerName: constants.SchedulerName,
 		},
 		Status: v1.PodStatus{
-			Phase: v1.PodRunning,
+			Phase: phase,
 		},
 	}
 }

--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -227,7 +227,7 @@ func (os *Manager) ListPods() ([]*v1.Pod, error) {
 		log.Logger().Debug("Looking at pod for recovery candidates", zap.String("podNamespace", pod.Namespace), zap.String("podName", pod.Name))
 		// general filter passes, and pod is assigned
 		// this means the pod is already scheduled by scheduler for an existing app
-		if utils.GetApplicationIDFromPod(pod) != "" && utils.IsAssignedPod(pod) {
+		if utils.GetApplicationIDFromPod(pod) != "" && utils.IsAssignedPod(pod) && !utils.IsPodTerminated(pod) {
 			if meta, ok := getAppMetadata(pod, true); ok {
 				podsRecovered++
 				pods = append(pods, pod)

--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -227,7 +227,7 @@ func (os *Manager) ListPods() ([]*v1.Pod, error) {
 		log.Logger().Debug("Looking at pod for recovery candidates", zap.String("podNamespace", pod.Namespace), zap.String("podName", pod.Name))
 		// general filter passes, and pod is assigned
 		// this means the pod is already scheduled by scheduler for an existing app
-		if utils.GetApplicationIDFromPod(pod) != "" && utils.IsAssignedPod(pod) && !utils.IsPodTerminated(pod) {
+		if utils.GetApplicationIDFromPod(pod) != "" && utils.IsAssignedPod(pod) {
 			if meta, ok := getAppMetadata(pod, true); ok {
 				podsRecovered++
 				pods = append(pods, pod)


### PR DESCRIPTION
### What is this PR for?
Excludes pods in a terminal state (Succeeded, Failed) during scheduler recovery. Applications may otherwise be recovered as "New" and remain there in scenarios where the application has completed and pods are awaiting garbage collection. 

This should not affect recovery behavior for applications with pods in non-terminal states as the application metadata will be recovered according to existing logic.   

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
[YUNIKORN-1555](https://issues.apache.org/jira/browse/YUNIKORN-1555)

### How should this be tested?
e2e

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
