### PR TITLE
[YUNIKORN-1578][shim] Use zap.Stringer instead of calling String on object

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -411,7 +411,7 @@ func (app *Application) scheduleTasks(taskScheduleCondition func(t *Task) bool) 
 
 func (app *Application) handleSubmitApplicationEvent() {
 	log.Logger().Info("handle app submission",
-		zap.String("app", app.String()),
+		zap.Stringer("app", app),
 		zap.String("clusterID", conf.GetSchedulerConf().ClusterID))
 	err := app.schedulerAPI.UpdateApplication(
 		&si.ApplicationRequest{
@@ -442,7 +442,7 @@ func (app *Application) handleSubmitApplicationEvent() {
 
 func (app *Application) handleRecoverApplicationEvent() {
 	log.Logger().Info("handle app recovering",
-		zap.String("app", app.String()),
+		zap.Stringer("app", app),
 		zap.String("clusterID", conf.GetSchedulerConf().ClusterID))
 	err := app.schedulerAPI.UpdateApplication(
 		&si.ApplicationRequest{
@@ -673,7 +673,7 @@ func (app *Application) publishPlaceholderTimeoutEvents(task *Task) {
 	if app.originatingTask != nil && task.IsPlaceholder() && task.terminationType == si.TerminationType_name[int32(si.TerminationType_TIMEOUT)] {
 		log.Logger().Debug("trying to send placeholder timeout events to the original pod from application",
 			zap.String("appID", app.applicationID),
-			zap.String("app request originating pod", app.originatingTask.GetTaskPod().String()),
+			zap.Stringer("app request originating pod", app.originatingTask.GetTaskPod()),
 			zap.String("taskID", task.taskID),
 			zap.String("terminationType", task.terminationType))
 		events.GetRecorder().Eventf(app.originatingTask.GetTaskPod().DeepCopy(), nil, v1.EventTypeWarning, "Placeholder timed out",

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -916,7 +916,7 @@ func (ctx *Context) PublishEvents(eventRecords []*si.EventRecord) {
 					log.Logger().Warn("task event is not published because task is not found",
 						zap.String("appID", appID),
 						zap.String("taskID", taskID),
-						zap.String("event", record.String()))
+						zap.Stringer("event", record))
 				}
 			case si.EventRecord_NODE:
 				nodeID := record.ObjectID
@@ -924,21 +924,21 @@ func (ctx *Context) PublishEvents(eventRecords []*si.EventRecord) {
 				if nodeInfo == nil {
 					log.Logger().Warn("node event is not published because nodeInfo is not found",
 						zap.String("nodeID", nodeID),
-						zap.String("event", record.String()))
+						zap.Stringer("event", record))
 					continue
 				}
 				node := nodeInfo.Node()
 				if node == nil {
 					log.Logger().Warn("node event is not published because node is not found",
 						zap.String("nodeID", nodeID),
-						zap.String("event", record.String()))
+						zap.Stringer("event", record))
 					continue
 				}
 				events.GetRecorder().Eventf(node.DeepCopy(), nil,
 					v1.EventTypeNormal, record.Reason, record.Reason, record.Message)
 			default:
 				log.Logger().Warn("Unsupported event type, currently only supports to publish request event records",
-					zap.String("type", record.Type.String()))
+					zap.Stringer("type", record.Type))
 			}
 		}
 	}
@@ -1009,7 +1009,7 @@ func (ctx *Context) HandleContainerStateUpdate(request *si.UpdateContainerSchedu
 			}
 		default:
 			log.Logger().Warn("no handler for container scheduling state",
-				zap.String("state", request.State.String()))
+				zap.Stringer("state", request.State))
 		}
 	}
 }

--- a/pkg/cache/node.go
+++ b/pkg/cache/node.go
@@ -89,12 +89,12 @@ func (n *SchedulerNode) updateOccupiedResource(resource *si.Resource, opt update
 	case AddOccupiedResource:
 		log.Logger().Info("add node occupied resource",
 			zap.String("nodeID", n.name),
-			zap.String("occupied", resource.String()))
+			zap.Stringer("occupied", resource))
 		n.occupied = common.Add(n.occupied, resource)
 	case SubOccupiedResource:
 		log.Logger().Info("subtract node occupied resource",
 			zap.String("nodeID", n.name),
-			zap.String("occupied", resource.String()))
+			zap.Stringer("occupied", resource))
 		n.occupied = common.Sub(n.occupied, resource)
 	default:
 		// noop
@@ -107,7 +107,7 @@ func (n *SchedulerNode) setCapacity(capacity *si.Resource) {
 	defer n.lock.Unlock()
 	log.Logger().Debug("set node capacity",
 		zap.String("nodeID", n.name),
-		zap.String("capacity", capacity.String()))
+		zap.Stringer("capacity", capacity))
 	n.capacity = capacity
 }
 

--- a/pkg/cache/placeholder_manager.go
+++ b/pkg/cache/placeholder_manager.go
@@ -101,7 +101,7 @@ func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
 				return err
 			}
 			log.Logger().Info("placeholder created",
-				zap.String("placeholder", placeholder.String()))
+				zap.Stringer("placeholder", placeholder))
 		}
 	}
 

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -315,7 +315,7 @@ func (task *Task) handleSubmitTaskEvent() {
 		task.pod,
 		task.originator,
 		preemptionPolicy)
-	log.Logger().Debug("send update request", zap.String("request", rr.String()))
+	log.Logger().Debug("send update request", zap.Stringer("request", &rr))
 	if err := task.context.apiProvider.GetAPIs().SchedulerAPI.UpdateAllocation(&rr); err != nil {
 		log.Logger().Debug("failed to send scheduling request to scheduler", zap.Error(err))
 		return

--- a/pkg/callback/scheduler_callback.go
+++ b/pkg/callback/scheduler_callback.go
@@ -46,7 +46,7 @@ func NewAsyncRMCallback(ctx *cache.Context) *AsyncRMCallback {
 
 func (callback *AsyncRMCallback) UpdateAllocation(response *si.AllocationResponse) error {
 	log.Logger().Debug("UpdateAllocation callback received",
-		zap.String("UpdateAllocationResponse", response.String()))
+		zap.Stringer("UpdateAllocationResponse", response))
 	// handle new allocations
 	for _, alloc := range response.New {
 		// got allocation for pod, bind pod to the scheduled node
@@ -106,7 +106,7 @@ func (callback *AsyncRMCallback) UpdateAllocation(response *si.AllocationRespons
 
 func (callback *AsyncRMCallback) UpdateApplication(response *si.ApplicationResponse) error {
 	log.Logger().Debug("UpdateApplication callback received",
-		zap.String("UpdateApplicationResponse", response.String()))
+		zap.Stringer("UpdateApplicationResponse", response))
 
 	// handle new accepted apps
 	for _, app := range response.Accepted {
@@ -163,7 +163,7 @@ func (callback *AsyncRMCallback) UpdateApplication(response *si.ApplicationRespo
 
 func (callback *AsyncRMCallback) UpdateNode(response *si.NodeResponse) error {
 	log.Logger().Debug("UpdateNode callback received",
-		zap.String("UpdateNodeResponse", response.String()))
+		zap.Stringer("UpdateNodeResponse", response))
 	// handle new accepted nodes
 	for _, node := range response.Accepted {
 		log.Logger().Debug("callback: response to accepted node",

--- a/pkg/client/kubeclient.go
+++ b/pkg/client/kubeclient.go
@@ -246,6 +246,6 @@ func (nc SchedulerKubeClient) UpdateStatus(pod *v1.Pod) (*v1.Pod, error) {
 	log.Logger().Info("Successfully updated pod status",
 		zap.String("namespace", pod.Namespace),
 		zap.String("podName", pod.Name),
-		zap.String("newStatus", pod.Status.String()))
+		zap.Stringer("newStatus", &pod.Status))
 	return updatedPod, nil
 }


### PR DESCRIPTION
### What is this PR for?
Throughout the code we have lots of places where we use the following call structure:

zap.String("text here", object.String()) 

This causes the object.String() call to happen before we even consider if it needs to be logged. Zap has a lazy way of doing this that removes the call to create the string  until it is needed, after the level checks etc. The above call becomes:

zap.Stringer("text here", object) 

Affect core and k8shim


### What type of PR is it
* [x] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1578

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
