### PR TITLE
[YUNIKORN-1597] Gang scheduling: application might not transition to Running after recovery

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -276,9 +276,19 @@ func (app *Application) GetAllocatedTasks() []*Task {
 	return app.getTasks(TaskStates().Allocated)
 }
 
+func (app *Application) GetBoundTasks() []*Task {
+	app.lock.RLock()
+	defer app.lock.RUnlock()
+	return app.getTasks(TaskStates().Bound)
+}
+
 func (app *Application) GetPlaceHolderTasks() []*Task {
 	app.lock.RLock()
 	defer app.lock.RUnlock()
+	return app.getPlaceHolderTasks()
+}
+
+func (app *Application) getPlaceHolderTasks() []*Task {
 	placeholders := make([]*Task, 0)
 	for _, task := range app.taskMap {
 		if task.placeholder {
@@ -519,6 +529,13 @@ func (app *Application) postAppAccepted() {
 }
 
 func (app *Application) onReserving() {
+	// happens after recovery - if placeholders already exist, we need to send
+	// an event to trigger Application state change in the core
+	if len(app.getPlaceHolderTasks()) > 0 {
+		ev := NewUpdateApplicationReservationEvent(app.applicationID)
+		dispatcher.Dispatch(ev)
+	}
+
 	go func() {
 		// while doing reserving
 		if err := getPlaceholderManager().createAppPlaceholders(app); err != nil {

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -544,7 +544,7 @@ func TestRecoverTask(t *testing.T) {
 	})
 	assert.Assert(t, task != nil)
 	assert.Equal(t, task.GetTaskID(), taskUID1)
-	assert.Equal(t, task.GetTaskState(), TaskStates().Allocated)
+	assert.Equal(t, task.GetTaskState(), TaskStates().Bound)
 
 	// add a tasks to the existing application
 	// this task was already completed with state: Succeed
@@ -588,7 +588,7 @@ func TestRecoverTask(t *testing.T) {
 	// make sure the recovered task is added to the app
 	app, exist := context.applications[appID]
 	assert.Equal(t, exist, true)
-	assert.Equal(t, len(app.getTasks(TaskStates().Allocated)), 1)
+	assert.Equal(t, len(app.getTasks(TaskStates().Bound)), 1)
 	assert.Equal(t, len(app.getTasks(TaskStates().Completed)), 2)
 	assert.Equal(t, len(app.getTasks(TaskStates().New)), 1)
 
@@ -599,7 +599,7 @@ func TestRecoverTask(t *testing.T) {
 		expectedPodName        string
 		expectedNodeName       string
 	}{
-		{taskUID1, TaskStates().Allocated, taskUID1, "pod1", fakeNodeName},
+		{taskUID1, TaskStates().Bound, taskUID1, "pod1", fakeNodeName},
 		{taskUID2, TaskStates().Completed, taskUID2, "pod2", fakeNodeName},
 		{taskUID3, TaskStates().Completed, taskUID3, "pod3", fakeNodeName},
 		{taskUID4, TaskStates().New, "", "pod4", ""},
@@ -661,7 +661,7 @@ func TestTaskReleaseAfterRecovery(t *testing.T) {
 
 	assert.Assert(t, task0 != nil)
 	assert.Equal(t, task0.GetTaskID(), pod1UID)
-	assert.Equal(t, task0.GetTaskState(), TaskStates().Allocated)
+	assert.Equal(t, task0.GetTaskState(), TaskStates().Bound)
 
 	task1 := context.AddTask(&interfaces.AddTaskRequest{
 		Metadata: interfaces.TaskMetadata{
@@ -673,12 +673,12 @@ func TestTaskReleaseAfterRecovery(t *testing.T) {
 
 	assert.Assert(t, task1 != nil)
 	assert.Equal(t, task1.GetTaskID(), pod2UID)
-	assert.Equal(t, task1.GetTaskState(), TaskStates().Allocated)
+	assert.Equal(t, task1.GetTaskState(), TaskStates().Bound)
 
 	// app should have 2 tasks recovered
 	app, exist := context.applications[appID]
 	assert.Equal(t, exist, true)
-	assert.Equal(t, len(app.GetAllocatedTasks()), 2)
+	assert.Equal(t, len(app.GetBoundTasks()), 2)
 
 	// release one of the tasks
 	context.NotifyTaskComplete(appID, pod2UID)
@@ -697,7 +697,7 @@ func TestTaskReleaseAfterRecovery(t *testing.T) {
 	// expect to see:
 	//  - task0 is still there
 	//  - task1 gets released
-	assert.Equal(t, t0.GetTaskState(), TaskStates().Allocated)
+	assert.Equal(t, t0.GetTaskState(), TaskStates().Bound)
 	assert.Equal(t, t1.GetTaskState(), TaskStates().Completed)
 }
 

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -213,12 +213,12 @@ func (task *Task) initialize() {
 
 	// task needs recovery means the task has already been
 	// scheduled by us with an allocation, instead of starting
-	// from New, directly set the task to Allocated.
+	// from New, directly set the task to Bound.
 	if utils.NeedRecovery(task.pod) {
 		task.allocationUUID = string(task.pod.UID)
 		task.nodeName = task.pod.Spec.NodeName
-		task.sm.SetState(TaskStates().Allocated)
-		log.Logger().Info("set task as Allocated",
+		task.sm.SetState(TaskStates().Bound)
+		log.Logger().Info("set task as Bound",
 			zap.String("appID", task.applicationID),
 			zap.String("taskID", task.taskID),
 			zap.String("allocationUUID", task.allocationUUID),


### PR DESCRIPTION
### What is this PR for?
If all remaining placeholders are in Running state after recovery, Yunikorn fails to advance the status of the application to Running.

No tests in this PR. It's very difficult to trigger this state in e2e tests and MockScheduler ignores the recovery entirely. Unit tests seem to be feasible as a follow-up.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1597

### How should this be tested?
Yunikorn needs code change.
1. a call to `panic()` in `Application.onReservationStateChange()` before calling the dispatcher.
2. However, there is at least one placeholder task in `Application.onReserving()` (new `if` block), set a boolean flag and don't call `panic()`.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
