### PR TITLE
[YUNIKORN-1609] Make api client timeouts configurable

### DIFF
--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -214,14 +214,14 @@ func (s *APIFactory) WaitForSync() error {
 		// skip this in test mode
 		return nil
 	}
-	return s.clients.WaitForSync(time.Second, 30*time.Second)
+	return s.clients.WaitForSync(time.Second, conf.GetSchedulerConf().ApiClientTimeout)
 }
 
 func (s *APIFactory) Start() {
 	// launch clients
 	if !s.IsTestingMode() {
 		s.clients.Run(s.stopChan)
-		if err := s.clients.WaitForSync(time.Second, 30*time.Second); err != nil {
+		if err := s.clients.WaitForSync(time.Second, conf.GetSchedulerConf().ApiClientTimeout); err != nil {
 			log.Logger().Warn("Failed to sync informers",
 				zap.Error(err))
 		}

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -52,6 +52,7 @@ func NewMockedAPIProvider(showError bool) *MockedAPIProvider {
 				KubeQPS:              0,
 				KubeBurst:            0,
 				Namespace:            "yunikorn",
+				ApiClientTimeout:     0,
 			},
 			KubeClient:            NewKubeClientMock(showError),
 			SchedulerAPI:          test.NewSchedulerAPIMock(),

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -63,6 +63,7 @@ const (
 	CMSvcDisableGangScheduling  = PrefixService + "disableGangScheduling"
 	CMSvcEnableConfigHotRefresh = PrefixService + "enableConfigHotRefresh"
 	CMSvcPlaceholderImage       = PrefixService + "placeholderImage"
+	CMSvcApiClientTimeout       = PrefixService + "apiClientTimeout"
 
 	// log
 	CMLogLevel = PrefixLog + "level"
@@ -86,6 +87,7 @@ const (
 	DefaultLogEncoding            = "console"
 	DefaultKubeQPS                = 1000
 	DefaultKubeBurst              = 1000
+	DefaultApiClientTimeout       = 30 * time.Second
 )
 
 var (
@@ -119,6 +121,7 @@ type SchedulerConf struct {
 	UserLabelKey           string        `json:"userLabelKey"`
 	PlaceHolderImage       string        `json:"placeHolderImage"`
 	Namespace              string        `json:"namespace"`
+	ApiClientTimeout       time.Duration `json:"apiClientTimeout"`
 	sync.RWMutex
 }
 
@@ -146,6 +149,7 @@ func (conf *SchedulerConf) Clone() *SchedulerConf {
 		UserLabelKey:           conf.UserLabelKey,
 		PlaceHolderImage:       conf.PlaceHolderImage,
 		Namespace:              conf.Namespace,
+		ApiClientTimeout:       conf.ApiClientTimeout,
 	}
 }
 
@@ -202,6 +206,7 @@ func handleNonReloadableConfig(old *SchedulerConf, new *SchedulerConf) {
 	checkNonReloadableString(CMSvcOperatorPlugins, &old.OperatorPlugins, &new.OperatorPlugins)
 	checkNonReloadableBool(CMSvcDisableGangScheduling, &old.DisableGangScheduling, &new.DisableGangScheduling)
 	checkNonReloadableString(CMSvcPlaceholderImage, &old.PlaceHolderImage, &new.PlaceHolderImage)
+	checkNonReloadableDuration(CMSvcApiClientTimeout, &old.ApiClientTimeout, &new.ApiClientTimeout)
 }
 
 const warningNonReloadable = "ignoring non-reloadable configuration change (restart required to update)"
@@ -331,6 +336,7 @@ func CreateDefaultConfig() *SchedulerConf {
 		DisableGangScheduling:  DefaultDisableGangScheduling,
 		UserLabelKey:           constants.DefaultUserLabel,
 		PlaceHolderImage:       constants.PlaceholderContainerImage,
+		ApiClientTimeout:       DefaultApiClientTimeout,
 	}
 }
 
@@ -355,6 +361,7 @@ func parseConfig(config map[string]string, prev *SchedulerConf) (*SchedulerConf,
 	parser.boolVar(&conf.DisableGangScheduling, CMSvcDisableGangScheduling)
 	parser.boolVar(&conf.EnableConfigHotRefresh, CMSvcEnableConfigHotRefresh)
 	parser.stringVar(&conf.PlaceHolderImage, CMSvcPlaceholderImage)
+	parser.durationVar(&conf.ApiClientTimeout, CMSvcApiClientTimeout)
 
 	// log
 	parser.intVar(&conf.LoggingLevel, CMLogLevel)

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -63,14 +63,14 @@ const (
 	CMSvcDisableGangScheduling  = PrefixService + "disableGangScheduling"
 	CMSvcEnableConfigHotRefresh = PrefixService + "enableConfigHotRefresh"
 	CMSvcPlaceholderImage       = PrefixService + "placeholderImage"
-	CMSvcApiClientTimeout       = PrefixService + "apiClientTimeout"
 
 	// log
 	CMLogLevel = PrefixLog + "level"
 
 	// kubernetes
-	CMKubeQPS   = PrefixKubernetes + "qps"
-	CMKubeBurst = PrefixKubernetes + "burst"
+	CMKubeQPS              = PrefixKubernetes + "qps"
+	CMKubeBurst            = PrefixKubernetes + "burst"
+	CMKubeApiClientTimeout = PrefixKubernetes + "apiClientTimeout"
 
 	// defaults
 	DefaultNamespace              = "default"
@@ -206,7 +206,7 @@ func handleNonReloadableConfig(old *SchedulerConf, new *SchedulerConf) {
 	checkNonReloadableString(CMSvcOperatorPlugins, &old.OperatorPlugins, &new.OperatorPlugins)
 	checkNonReloadableBool(CMSvcDisableGangScheduling, &old.DisableGangScheduling, &new.DisableGangScheduling)
 	checkNonReloadableString(CMSvcPlaceholderImage, &old.PlaceHolderImage, &new.PlaceHolderImage)
-	checkNonReloadableDuration(CMSvcApiClientTimeout, &old.ApiClientTimeout, &new.ApiClientTimeout)
+	checkNonReloadableDuration(CMKubeApiClientTimeout, &old.ApiClientTimeout, &new.ApiClientTimeout)
 }
 
 const warningNonReloadable = "ignoring non-reloadable configuration change (restart required to update)"
@@ -361,7 +361,7 @@ func parseConfig(config map[string]string, prev *SchedulerConf) (*SchedulerConf,
 	parser.boolVar(&conf.DisableGangScheduling, CMSvcDisableGangScheduling)
 	parser.boolVar(&conf.EnableConfigHotRefresh, CMSvcEnableConfigHotRefresh)
 	parser.stringVar(&conf.PlaceHolderImage, CMSvcPlaceholderImage)
-	parser.durationVar(&conf.ApiClientTimeout, CMSvcApiClientTimeout)
+	parser.durationVar(&conf.ApiClientTimeout, CMKubeApiClientTimeout)
 
 	// log
 	parser.intVar(&conf.LoggingLevel, CMLogLevel)

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -93,7 +93,7 @@ func TestParseConfigMap(t *testing.T) {
 		{CMLogLevel, "LoggingLevel", -1},
 		{CMKubeQPS, "KubeQPS", 2345},
 		{CMKubeBurst, "KubeBurst", 3456},
-		{CMSvcApiClientTimeout, "ApiClientTimeout", 30 * time.Second},
+		{CMKubeApiClientTimeout, "ApiClientTimeout", 30 * time.Second},
 	}
 
 	for _, tc := range testCases {
@@ -126,8 +126,8 @@ func TestUpdateConfigMapNonReloadable(t *testing.T) {
 		{CMLogLevel, "LoggingLevel", -1, true},
 		{CMKubeQPS, "KubeQPS", 2345, false},
 		{CMKubeBurst, "KubeBurst", 3456, false},
-		{CMSvcApiClientTimeout, "ApiClientTimeout", 30 * time.Second, false},
-		{CMSvcApiClientTimeout, "ApiClientTimeout", 30 * time.Second, false},
+		{CMKubeApiClientTimeout, "ApiClientTimeout", 30 * time.Second, false},
+		{CMKubeApiClientTimeout, "ApiClientTimeout", 30 * time.Second, false},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -71,6 +71,7 @@ func assertDefaults(t *testing.T, conf *SchedulerConf) {
 	assert.Equal(t, conf.KubeQPS, DefaultKubeQPS)
 	assert.Equal(t, conf.KubeBurst, DefaultKubeBurst)
 	assert.Equal(t, conf.UserLabelKey, constants.DefaultUserLabel)
+	assert.Equal(t, conf.ApiClientTimeout, DefaultApiClientTimeout)
 }
 
 func TestParseConfigMap(t *testing.T) {
@@ -92,6 +93,7 @@ func TestParseConfigMap(t *testing.T) {
 		{CMLogLevel, "LoggingLevel", -1},
 		{CMKubeQPS, "KubeQPS", 2345},
 		{CMKubeBurst, "KubeBurst", 3456},
+		{CMSvcApiClientTimeout, "ApiClientTimeout", 30 * time.Second},
 	}
 
 	for _, tc := range testCases {
@@ -124,6 +126,8 @@ func TestUpdateConfigMapNonReloadable(t *testing.T) {
 		{CMLogLevel, "LoggingLevel", -1, true},
 		{CMKubeQPS, "KubeQPS", 2345, false},
 		{CMKubeBurst, "KubeBurst", 3456, false},
+		{CMSvcApiClientTimeout, "ApiClientTimeout", 30 * time.Second, false},
+		{CMSvcApiClientTimeout, "ApiClientTimeout", 30 * time.Second, false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What is this PR for?

Right now there are 2 places in the scheduler with a 30 second timeout hard coded. It would be nice if those timeouts were user configurable. I was running into some issues in my cluster where 30 seconds was not enough.

Feel free to provide feedback, this is my first real change to yunikorn and I am more than happy to make improvements to my code.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
~~I have an update to the yunikorn-site coming as well. Just need to open a PR for it after I finish this one.~~ Docs pr here https://github.com/apache/yunikorn-site/pull/271

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1609

### How should this be tested?
I updated some unit tests to include my change. I also was able to test this change in my k8s cluster and it solved the issue for me.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
