### PR TITLE
[YUNIKORN-1621] Removing duplicate replicaset e2e test of admin

### DIFF
--- a/test/e2e/admission_controller/admission_controller_test.go
+++ b/test/e2e/admission_controller/admission_controller_test.go
@@ -309,22 +309,6 @@ var _ = ginkgo.Describe("AdmissionController", func() {
 		runWorkloadTest("Job", create, delete, defaultPodTimeout)
 	})
 
-	ginkgo.It("Check that annotation is added to a ReplicaSet", func() {
-		create := func() (string, error) {
-			rs, err := kubeClient.CreateReplicaSet(&testReplicaSet, ns)
-			name := ""
-			if rs != nil {
-				name = rs.Name
-			}
-			return name, err
-		}
-		delete := func(name string) error {
-			return kubeClient.DeleteReplicaSet(name, ns)
-		}
-
-		runWorkloadTest("ReplicaSet", create, delete, defaultPodTimeout)
-	})
-
 	ginkgo.It("Check that annotation is added to a CronJob", func() {
 		create := func() (string, error) {
 			cj, err := kubeClient.CreateCronJob(&testCronJob, ns)


### PR DESCRIPTION
### What is this PR for?
There are duplicate code replicates cases in admin e2e test. 
[replicaset case1](https://github.com/apache/yunikorn-k8shim/blob/master/test/e2e/admission_controller/admission_controller_test.go#L280-L294)
[replicaset case2](https://github.com/apache/yunikorn-k8shim/blob/master/test/e2e/admission_controller/admission_controller_test.go#L328-L342)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1621

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
