### PR TITLE
[YUNIKORN-1622] K8shim: Race in allocate vs pod delete

### DIFF
--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -848,6 +848,10 @@ func TestTryReservePostRestart(t *testing.T) {
 			Containers: containers,
 		},
 	})
+	task0.allocationUUID = string(task0.pod.UID)
+	task0.nodeName = "fake-host"
+	task0.sm.SetState(TaskStates().Allocated)
+
 	task1 := NewTask("task01", app, context, &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
@@ -861,6 +865,7 @@ func TestTryReservePostRestart(t *testing.T) {
 			Containers: containers,
 		},
 	})
+
 	task2 := NewTask("task02", app, context, &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
@@ -874,7 +879,7 @@ func TestTryReservePostRestart(t *testing.T) {
 			Containers: containers,
 		},
 	})
-	task0.setAllocated("fake-host", string(task0.pod.UID))
+
 	app.addTask(task0)
 	app.addTask(task1)
 	app.addTask(task2)


### PR DESCRIPTION
### What is this PR for?
When a pod is allocated immediately set the allocation UUID and the node as part of the transition.
Make sure that the rejected to failed transition removes lingering asks. Set the node info in the task when it is returned by the core. Dedupe log messages on task transition.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1622

### How should this be tested?
No regressions in any test suite.
Fix itself is difficult to test as the issue is caused by a race in two go routines
