### PR TITLE
[YUNIKORN-1627] Admission controller triggers infinite recreation of ReplicaSet objects

### DIFF
--- a/pkg/admission/metadata/extract.go
+++ b/pkg/admission/metadata/extract.go
@@ -20,7 +20,6 @@ package metadata
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -108,11 +107,11 @@ func fromReplicaSet(req *admissionv1.AdmissionRequest) (*extractResult, error) {
 	if len(replicaSet.OwnerReferences) > 0 {
 		for _, ownerReference := range replicaSet.OwnerReferences {
 			if ownerReference.Kind == Deployment {
-				//For ReplicaSets, if the ownerReference is set to a Deployment,
+				// For ReplicaSets, if the ownerReference is set to a Deployment,
 				// it should be sufficient to check for that and assume that the Deployment itself has passed in the appropriate user information
 				// due to the admission controller having mutated the Deployment.
-				return nil, errors.New(fmt.Sprintf("ReplicaSet %s already has Deployment ownerReference: %s, "+
-					"skip the mute action for this ReplicaSet.", replicaSet.Name, ownerReference.Name))
+				return nil, fmt.Errorf("ReplicaSet %s already has Deployment ownerReference: %s, "+
+					"skip the mute action for this ReplicaSet.", replicaSet.Name, ownerReference.Name)
 			}
 		}
 	}


### PR DESCRIPTION
### What is this PR for?
[YUNIKORN-1338](https://issues.apache.org/jira/browse/YUNIKORN-1338) added support in the admission controller for mutating workload objects other than Pods for the purposes of user tracking (and eventual enforcement). This functionality works as designed.

However, in the case where a ReplicaSet is managed by a Deployment, the changes to the ReplicaSet pod template trigger the associated Deployment to recreate the ReplicaSet without the changes, which the admission controller then updates, triggering another ReplicaSet, etc. ad infinitum. 

The workaround for now is to set the following in the yunikorn-configs ConfigMap, which disables the functionality:

admissionController.accessControl.bypassAuth: "true"
The real fix needs to take into account any ownerReference in a workload which points to another workload type that we manage. This definitely includes ReplicaSet -> Deployment, but could include other workload relationships (more investigation needed on this).

For ReplicaSets, if the ownerReference is set to a Deployment, it should be sufficient to check for that and assume that the Deployment itself has passed in the appropriate user information due to the admission controller having mutated the Deployment.

### What type of PR is it?
* [x] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1627
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
