### PR TITLE
[YUNIKORN-1642] Scheduler recovery failed due to listing operation timeout

### DIFF
--- a/pkg/cache/context_recovery.go
+++ b/pkg/cache/context_recovery.go
@@ -216,9 +216,7 @@ func waitAndListNodes(apiProvider client.APIProvider) ([]*corev1.Node, error) {
 
 	// need to wait for sync
 	// because the shared indexer doesn't sync its cache periodically
-	if err := apiProvider.WaitForSync(); err != nil {
-		return allNodes, err
-	}
+	apiProvider.WaitForSync()
 
 	// list all nodes in the cluster,
 	// retry for sometime if there is some errors

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -222,7 +222,7 @@ func (s *APIFactory) Start() {
 	if !s.IsTestingMode() {
 		s.clients.Run(s.stopChan)
 		if err := s.clients.WaitForSync(time.Second, conf.GetSchedulerConf().ApiClientTimeout); err != nil {
-			log.Logger().Fatal("Failed to sync informers",
+			log.Logger().Warn("Failed to sync informers",
 				zap.Error(err))
 		}
 	}

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -222,7 +222,7 @@ func (s *APIFactory) Start() {
 	if !s.IsTestingMode() {
 		s.clients.Run(s.stopChan)
 		if err := s.clients.WaitForSync(time.Second, conf.GetSchedulerConf().ApiClientTimeout); err != nil {
-			log.Logger().Warn("Failed to sync informers",
+			log.Logger().Fatal("Failed to sync informers",
 				zap.Error(err))
 		}
 	}

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -181,8 +181,8 @@ func (m *MockedAPIProvider) Stop() {
 	// no impl
 }
 
-func (m *MockedAPIProvider) WaitForSync() error {
-	return nil
+func (m *MockedAPIProvider) WaitForSync() {
+	// no impl
 }
 
 // MockedPersistentVolumeInformer implements PersistentVolumeInformer interface

--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -72,7 +72,7 @@ func (c *Clients) GetConf() *conf.SchedulerConf {
 }
 
 func (c *Clients) WaitForSync() {
-	timeNow := time.Now()
+	syncStartTime := time.Now()
 	counter := 0
 	for {
 		if c.NodeInformer.Informer().HasSynced() &&
@@ -89,13 +89,8 @@ func (c *Clients) WaitForSync() {
 		time.Sleep(time.Second)
 		counter++
 		if counter%10 == 0 {
-			if counter > 300 {
-				log.Logger().Warn("Still waiting for informers to sync, delay seems longer than usual...",
-					zap.Duration("timeElapsed", time.Since(timeNow).Round(time.Second)))
-			} else {
-				log.Logger().Info("Waiting for informers to sync",
-					zap.Duration("timeElapsed", time.Since(timeNow).Round(time.Second)))
-			}
+			log.Logger().Info("Waiting for informers to sync",
+				zap.Duration("timeElapsed", time.Since(syncStartTime).Round(time.Second)))
 		}
 	}
 }

--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -19,8 +19,9 @@
 package client
 
 import (
-	"go.uber.org/zap"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/apache/yunikorn-k8shim/pkg/client/informers/externalversions/yunikorn.apache.org/v1alpha1"
 


### PR DESCRIPTION
### What is this PR for?
The listing operation in the recovery phase: https://github.com/apache/yunikorn-k8shim/blob/c25ac60ffbc175c4966f917da21d184f34dea7b4/pkg/client/apifactory.go#L225. This could sometimes fail on some large clusters, the response time from API server is not guaranteed.  Since it is a WARN, it continues but the informers did not return anything. This confuses the scheduler that nothing needs to be recovered, and it goes ahead doing the scheduling. This causes subsequential scheduler failures. And eventually, nothing can be scheduled anymore.

This should be a FATAL error. So the scheduler can be restarted to retry recovering. 

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-1642

### Questions:
* [ ] - The licenses files need update. 
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
