### PR TITLE
[YUNIKORN-1647] Dynamic namespace support in admission controller

### DIFF
--- a/pkg/admission/admission_controller_test.go
+++ b/pkg/admission/admission_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -34,7 +33,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -268,7 +266,8 @@ func TestUpdateSchedulerName(t *testing.T) {
 
 func TestValidateConfigMapEmpty(t *testing.T) {
 	pcCache := createPriorityClassCacheForTest()
-	controller := InitAdmissionController(createConfig(), pcCache)
+	nsCache := createNamespaceClassCacheForTest()
+	controller := InitAdmissionController(createConfig(), pcCache, nsCache)
 	configmap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.ConfigMapName,
@@ -349,6 +348,7 @@ func prepareConfigMap(data string) *v1.ConfigMap {
 
 func prepareController(t *testing.T, url string, processNs string, bypassNs string, labelNs string, noLabelNs string, bypassAuth bool, trustControllers bool) *AdmissionController {
 	pcCache := createPriorityClassCacheForTest()
+	nsCache := createNamespaceClassCacheForTest()
 	if bypassNs == "" {
 		bypassNs = "^kube-system$"
 	}
@@ -364,7 +364,7 @@ func prepareController(t *testing.T, url string, processNs string, bypassNs stri
 		conf.AMAccessControlExternalUsers:     "^testExtUser$",
 		conf.AMAccessControlExternalGroups:    "^testExtGroup$",
 	})
-	return InitAdmissionController(config, pcCache)
+	return InitAdmissionController(config, pcCache, nsCache)
 }
 
 func serverMock(mode responseMode) *httptest.Server {
@@ -875,6 +875,20 @@ func TestShouldProcessNamespace(t *testing.T) {
 	assert.Check(t, !ac.shouldProcessNamespace("test"), "test namespace allowed when not on process list")
 	assert.Check(t, ac.shouldProcessNamespace("allow-this"), "allow-this namespace not allowed when on process list")
 	assert.Check(t, !ac.shouldProcessNamespace("allow-except-this"), "allow-except-this namespace allowed when on bypass list")
+
+	ac = prepareController(t, "", "^ns-no-annotation$", "^ns-regexp-deny$", "", "", false, true)
+	ac.nsCache.nameSpaces["ns-no-annotation"] = nsFlags{enableYuniKorn: -1, generateAppID: -1}
+	ac.nsCache.nameSpaces["ns-process-true"] = nsFlags{enableYuniKorn: 1, generateAppID: -1}
+	ac.nsCache.nameSpaces["ns-process-false"] = nsFlags{enableYuniKorn: 0, generateAppID: -1}
+	assert.Check(t, ac.shouldProcessNamespace("ns-no-annotation"), "no annotation namespace allowed")
+	assert.Check(t, ac.shouldProcessNamespace("ns-process-true"), "namespace process true")
+	assert.Check(t, !ac.shouldProcessNamespace("ns-process-false"), "namespace process false")
+	assert.Check(t, !ac.shouldProcessNamespace("unknown"), "namespace unknown not allowed")
+
+	// check regexp override
+	assert.Check(t, !ac.shouldProcessNamespace("ns-regexp-deny"), "namespace deny regexp not allowed")
+	ac.nsCache.nameSpaces["ns-regexp-deny"] = nsFlags{enableYuniKorn: 1, generateAppID: -1}
+	assert.Check(t, ac.shouldProcessNamespace("ns-regexp-deny"), "namespace override via annotation")
 }
 
 func TestShouldLabelNamespace(t *testing.T) {
@@ -886,6 +900,20 @@ func TestShouldLabelNamespace(t *testing.T) {
 	assert.Check(t, !ac.shouldLabelNamespace("test"), "test namespace allowed when not on label list")
 	assert.Check(t, ac.shouldLabelNamespace("allow-this"), "allow-this namespace not allowed when on label list")
 	assert.Check(t, !ac.shouldLabelNamespace("allow-except-this"), "allow-except-this namespace allowed when on no-label list")
+
+	ac = prepareController(t, "", "", "", "^ns-no-annotation$", "^ns-regexp-deny$", false, true)
+	ac.nsCache.nameSpaces["ns-no-annotation"] = nsFlags{enableYuniKorn: -1, generateAppID: -1}
+	ac.nsCache.nameSpaces["ns-generate-true"] = nsFlags{enableYuniKorn: -1, generateAppID: 1}
+	ac.nsCache.nameSpaces["ns-generate-false"] = nsFlags{enableYuniKorn: -1, generateAppID: 0}
+	assert.Check(t, ac.shouldLabelNamespace("ns-no-annotation"), "no annotation namespace allowed")
+	assert.Check(t, ac.shouldLabelNamespace("ns-generate-true"), "namespace generate true")
+	assert.Check(t, !ac.shouldLabelNamespace("ns-generate-false"), "namespace generate false")
+	assert.Check(t, !ac.shouldLabelNamespace("unknown"), "namespace unknown not allowed")
+
+	// check regexp override
+	assert.Check(t, !ac.shouldLabelNamespace("ns-regexp-deny"), "namespace deny regexp not allowed")
+	ac.nsCache.nameSpaces["ns-regexp-deny"] = nsFlags{enableYuniKorn: -1, generateAppID: 1}
+	assert.Check(t, ac.shouldLabelNamespace("ns-regexp-deny"), "namespace override via annotation")
 }
 
 func TestParseRegexes(t *testing.T) {
@@ -921,37 +949,43 @@ func TestParseRegexes(t *testing.T) {
 
 func TestInitAdmissionControllerRegexErrorHandling(t *testing.T) {
 	pcCache := createPriorityClassCacheForTest()
-	ac := InitAdmissionController(createConfig(), pcCache)
+	nsCache := createNamespaceClassCacheForTest()
+	ac := InitAdmissionController(createConfig(), pcCache, nil)
 	assert.Equal(t, 1, len(ac.conf.GetBypassNamespaces()))
 	assert.Equal(t, conf.DefaultFilteringBypassNamespaces, ac.conf.GetBypassNamespaces()[0].String(), "didn't set default bypassNamespaces")
 
-	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringProcessNamespaces: "("}), pcCache)
+	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringProcessNamespaces: "("}), pcCache, nsCache)
 	assert.Equal(t, 0, len(ac.conf.GetProcessNamespaces()), "didn't fail on bad processNamespaces list")
 
-	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringBypassNamespaces: "("}), pcCache)
+	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringBypassNamespaces: "("}), pcCache, nsCache)
 	assert.Equal(t, 1, len(ac.conf.GetBypassNamespaces()))
 	assert.Equal(t, conf.DefaultFilteringBypassNamespaces, ac.conf.GetBypassNamespaces()[0].String(), "didn't fail on bad bypassNamespaces list")
 
-	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringLabelNamespaces: "("}), pcCache)
+	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringLabelNamespaces: "("}), pcCache, nsCache)
 	assert.Equal(t, 0, len(ac.conf.GetLabelNamespaces()), "didn't fail on bad labelNamespaces list")
 
-	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringNoLabelNamespaces: "("}), pcCache)
+	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMFilteringNoLabelNamespaces: "("}), pcCache, nsCache)
 	assert.Equal(t, 0, len(ac.conf.GetNoLabelNamespaces()), "didn't fail on bad noLabelNamespaces list")
 
-	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMAccessControlSystemUsers: "("}), pcCache)
+	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMAccessControlSystemUsers: "("}), pcCache, nsCache)
 	assert.Equal(t, 1, len(ac.conf.GetSystemUsers()))
 	assert.Equal(t, conf.DefaultAccessControlSystemUsers, ac.conf.GetSystemUsers()[0].String(), "didn't fail on bad systemUsers list")
 
-	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMAccessControlExternalUsers: "("}), pcCache)
+	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMAccessControlExternalUsers: "("}), pcCache, nsCache)
 	assert.Equal(t, 0, len(ac.conf.GetExternalUsers()), "didn't fail on bad externalUsers list")
 
-	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMAccessControlExternalGroups: "("}), pcCache)
+	ac = InitAdmissionController(createConfigWithOverrides(map[string]string{conf.AMAccessControlExternalGroups: "("}), pcCache, nsCache)
 	assert.Equal(t, 0, len(ac.conf.GetExternalGroups()), "didn't fail on bad externalGroups list")
 }
 
 func createPriorityClassCacheForTest() *PriorityClassCache {
 	return &PriorityClassCache{
-		priorityClasses: make(map[string]*schedulingv1.PriorityClass),
-		lock:            sync.RWMutex{},
+		priorityClasses: make(map[string]bool),
+	}
+}
+
+func createNamespaceClassCacheForTest() *NamespaceCache {
+	return &NamespaceCache{
+		nameSpaces: make(map[string]nsFlags),
 	}
 }

--- a/pkg/admission/namespace_cache.go
+++ b/pkg/admission/namespace_cache.go
@@ -1,0 +1,162 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package admission
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	informersv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/yunikorn-k8shim/pkg/log"
+)
+
+type NamespaceCache struct {
+	nameSpaces map[string]nsFlags
+
+	sync.RWMutex
+}
+
+// nsFlags defines the two flags that can be set on the namespace.
+// It needs to support a tri-state value showing presence besides true/false.
+// -1: not present
+// 0: false
+// 1: true
+type nsFlags struct {
+	enableYuniKorn int
+	generateAppID  int
+}
+
+// NewNamespaceCache creates a new cache and registers the handler for the cache with the Informer.
+func NewNamespaceCache(namespaces informersv1.NamespaceInformer) *NamespaceCache {
+	nsc := &NamespaceCache{
+		nameSpaces: make(map[string]nsFlags),
+	}
+	if namespaces != nil {
+		namespaces.Informer().AddEventHandler(&namespaceUpdateHandler{cache: nsc})
+	}
+	return nsc
+}
+
+// enableYuniKorn returns the value for the enableYuniKorn flag (tri-state -1, 0 or 1) for the namespace.
+func (nsc *NamespaceCache) enableYuniKorn(name string) int {
+	nsc.RLock()
+	defer nsc.RUnlock()
+	flag, ok := nsc.nameSpaces[name]
+	if !ok {
+		return -1
+	}
+	return flag.enableYuniKorn
+}
+
+// generateAppID returns the value for the generateAppID flag (tri-state -1, 0 or 1) for the namespace.
+func (nsc *NamespaceCache) generateAppID(name string) int {
+	nsc.RLock()
+	defer nsc.RUnlock()
+	flag, ok := nsc.nameSpaces[name]
+	if !ok {
+		return -1
+	}
+	return flag.generateAppID
+}
+
+// namespaceExists for test only to see if the namespace has been added to the cache or not.
+func (nsc *NamespaceCache) namespaceExists(name string) bool {
+	nsc.RLock()
+	defer nsc.RUnlock()
+
+	_, ok := nsc.nameSpaces[name]
+	return ok
+}
+
+// namespaceUpdateHandler implements the K8s ResourceEventHandler interface for namespaces.
+type namespaceUpdateHandler struct {
+	cache *NamespaceCache
+}
+
+// OnAdd adds or replaces the namespace entry in the cache.
+// The cached value is only the resulting value of the annotation, not the whole namespace object.
+// An empty string for the Name is technically possible but should not occur.
+func (h *namespaceUpdateHandler) OnAdd(obj interface{}) {
+	ns := convert2Namespace(obj)
+	if ns == nil {
+		return
+	}
+
+	newFlags := getAnnotationValues(ns)
+	h.cache.Lock()
+	defer h.cache.Unlock()
+	h.cache.nameSpaces[ns.Name] = newFlags
+}
+
+// OnUpdate calls OnAdd for processing the namespace cache update.
+func (h *namespaceUpdateHandler) OnUpdate(_, newObj interface{}) {
+	h.OnAdd(newObj)
+}
+
+// OnDelete removes the namespace from the cache.
+func (h *namespaceUpdateHandler) OnDelete(obj interface{}) {
+	var ns *v1.Namespace
+	switch t := obj.(type) {
+	case *v1.Namespace:
+		ns = t
+	case cache.DeletedFinalStateUnknown:
+		ns = convert2Namespace(obj)
+	default:
+		log.Logger().Warn("unable to convert to Namespace")
+		return
+	}
+	if ns == nil {
+		return
+	}
+
+	h.cache.Lock()
+	defer h.cache.Unlock()
+	delete(h.cache.nameSpaces, ns.Name)
+}
+
+// getAnnotationValues retrieves the annotation from the namespace.
+// Converts the presence and content into a tri-state nsFlags object containing all nsFlags.
+func getAnnotationValues(ns *v1.Namespace) nsFlags {
+	if ns == nil {
+		return nsFlags{-1, -1}
+	}
+
+	return nsFlags{
+		enableYuniKorn: getAnnotationValue(ns.Annotations, constants.AnnotationEnableYuniKorn),
+		generateAppID:  getAnnotationValue(ns.Annotations, constants.AnnotationGenerateAppID),
+	}
+}
+
+// getAnnotationValue retrieves the value of name from the map and convert it to a tri-state.
+// Returns -1 if name is not present, 1 if the value is set to "true", 0 for all other cases.
+func getAnnotationValue(m map[string]string, name string) int {
+	strVal, ok := m[name]
+	if !ok {
+		return -1
+	}
+	switch strVal {
+	case constants.True:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/pkg/admission/namespace_cache.go
+++ b/pkg/admission/namespace_cache.go
@@ -60,6 +60,7 @@ func NewNamespaceCache(namespaces informersv1.NamespaceInformer) *NamespaceCache
 func (nsc *NamespaceCache) enableYuniKorn(name string) int {
 	nsc.RLock()
 	defer nsc.RUnlock()
+
 	flag, ok := nsc.nameSpaces[name]
 	if !ok {
 		return -1
@@ -71,6 +72,7 @@ func (nsc *NamespaceCache) enableYuniKorn(name string) int {
 func (nsc *NamespaceCache) generateAppID(name string) int {
 	nsc.RLock()
 	defer nsc.RUnlock()
+
 	flag, ok := nsc.nameSpaces[name]
 	if !ok {
 		return -1

--- a/pkg/admission/namespace_cache_test.go
+++ b/pkg/admission/namespace_cache_test.go
@@ -1,0 +1,196 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/apache/yunikorn-k8shim/pkg/client"
+	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
+)
+
+const testNS = "test-ns"
+
+func TestFlags(t *testing.T) {
+	cache := NewNamespaceCache(nil)
+	cache.nameSpaces["notset"] = nsFlags{
+		enableYuniKorn: -1,
+		generateAppID:  -1,
+	}
+	cache.nameSpaces["exist-unset"] = nsFlags{
+		enableYuniKorn: 0,
+		generateAppID:  0,
+	}
+	cache.nameSpaces["exist-set"] = nsFlags{
+		enableYuniKorn: 1,
+		generateAppID:  1,
+	}
+	cache.nameSpaces["generate-set"] = nsFlags{
+		enableYuniKorn: -1,
+		generateAppID:  1,
+	}
+
+	assert.Equal(t, -1, cache.enableYuniKorn(""), "not in cache")
+	assert.Equal(t, -1, cache.generateAppID(""), "not in cache")
+	assert.Equal(t, -1, cache.enableYuniKorn("notset"), "exist not set")
+	assert.Equal(t, -1, cache.generateAppID("notset"), "exist not set")
+	assert.Equal(t, 0, cache.enableYuniKorn("exist-unset"), "exist enable not set")
+	assert.Equal(t, 0, cache.generateAppID("exist-unset"), "exist generate not set")
+	assert.Equal(t, 1, cache.enableYuniKorn("exist-set"), "exist enable set")
+	assert.Equal(t, 1, cache.generateAppID("exist-set"), "exist generate set")
+	assert.Equal(t, -1, cache.enableYuniKorn("generate-set"), "only generate set")
+	assert.Equal(t, 1, cache.generateAppID("generate-set"), "generate should be set")
+}
+
+func TestNamespaceHandlers(t *testing.T) {
+	kubeClient := client.NewKubeClientMock(false)
+
+	informers := NewInformers(kubeClient, "default")
+	cache := NewNamespaceCache(informers.Namespace)
+	informers.Start()
+	defer informers.Stop()
+
+	// nothing in the cache
+	assert.Equal(t, -1, cache.enableYuniKorn(testNS), "cache should have been empty")
+
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testNS,
+			Annotations: map[string]string{"key": "value"},
+		},
+	}
+
+	nsInterface := kubeClient.GetClientSet().CoreV1().Namespaces()
+
+	// validate OnAdd
+	_, err := nsInterface.Create(context.Background(), ns, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	err = utils.WaitForCondition(func() bool {
+		return cache.namespaceExists(testNS)
+	}, 10*time.Millisecond, 5*time.Second)
+	assert.NilError(t, err)
+
+	assert.Equal(t, -1, cache.enableYuniKorn(testNS), "cache should have contained NS")
+
+	// validate OnUpdate
+	ns2 := ns.DeepCopy()
+	ns2.Annotations = map[string]string{constants.AnnotationEnableYuniKorn: "true",
+		constants.AnnotationGenerateAppID: "false"}
+
+	_, err = nsInterface.Update(context.Background(), ns2, metav1.UpdateOptions{})
+	assert.NilError(t, err)
+
+	err = utils.WaitForCondition(func() bool {
+		return cache.enableYuniKorn(testNS) > 0
+	}, 10*time.Millisecond, 5*time.Second)
+	assert.NilError(t, err)
+	assert.Equal(t, 0, cache.generateAppID(testNS), "generate should have been set to false")
+
+	ns2 = ns.DeepCopy()
+	ns2.Annotations = map[string]string{constants.AnnotationGenerateAppID: "true"}
+
+	_, err = nsInterface.Update(context.Background(), ns2, metav1.UpdateOptions{})
+	assert.NilError(t, err)
+
+	err = utils.WaitForCondition(func() bool {
+		return cache.generateAppID(testNS) > 0
+	}, 10*time.Millisecond, 5*time.Second)
+	assert.NilError(t, err)
+	assert.Equal(t, -1, cache.enableYuniKorn(testNS), "enable should have been cleared")
+
+	// validate OnDelete
+	err = nsInterface.Delete(context.Background(), ns.Name, metav1.DeleteOptions{})
+	assert.NilError(t, err)
+
+	err = utils.WaitForCondition(func() bool {
+		return !cache.namespaceExists(testNS)
+	}, 10*time.Millisecond, 5*time.Second)
+	assert.NilError(t, err, "ns not removed from cache")
+}
+
+func TestGetAnnotations(t *testing.T) {
+	tests := map[string]struct {
+		ns *v1.Namespace
+		f  nsFlags
+	}{
+		"nil ns": {
+			ns: nil,
+			f:  nsFlags{enableYuniKorn: -1, generateAppID: -1},
+		},
+		"empty annotations": {
+			ns: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNS,
+				},
+			},
+			f: nsFlags{enableYuniKorn: -1, generateAppID: -1},
+		},
+		"invalid values": {
+			ns: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNS,
+					Annotations: map[string]string{
+						constants.AnnotationGenerateAppID:  "",
+						constants.AnnotationEnableYuniKorn: "unknown",
+					},
+				},
+			},
+			f: nsFlags{enableYuniKorn: 0, generateAppID: 0},
+		},
+		"true values": {
+			ns: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNS,
+					Annotations: map[string]string{
+						constants.AnnotationEnableYuniKorn: "true",
+						constants.AnnotationGenerateAppID:  "true",
+					},
+				},
+			},
+			f: nsFlags{enableYuniKorn: 1, generateAppID: 1},
+		},
+		"distinct values": {
+			ns: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNS,
+					Annotations: map[string]string{
+						constants.AnnotationGenerateAppID:  "true",
+						constants.AnnotationEnableYuniKorn: "false",
+					},
+				},
+			},
+			f: nsFlags{enableYuniKorn: 0, generateAppID: 1},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := getAnnotationValues(test.ns)
+			assert.Equal(t, f.enableYuniKorn, test.f.enableYuniKorn, "enable value incorrect")
+			assert.Equal(t, f.generateAppID, test.f.generateAppID, "enable value incorrect")
+		})
+	}
+}

--- a/pkg/admission/priority_class_cache.go
+++ b/pkg/admission/priority_class_cache.go
@@ -49,6 +49,9 @@ func NewPriorityClassCache(priorityClasses informersv1.PriorityClassInformer) *P
 
 // isPreemptSelfAllowed returns the preemption value. Only returns false if configured.
 func (pcc *PriorityClassCache) isPreemptSelfAllowed(priorityClassName string) bool {
+	pcc.RLock()
+	defer pcc.RUnlock()
+
 	value, ok := pcc.priorityClasses[priorityClassName]
 	if !ok {
 		return true

--- a/pkg/admission/util.go
+++ b/pkg/admission/util.go
@@ -19,13 +19,17 @@
 package admission
 
 import (
+	"reflect"
+
+	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
+	"github.com/apache/yunikorn-k8shim/pkg/log"
 )
 
-func UpdatePodLabelForAdmissionController(pod *v1.Pod, namespace string) map[string]string {
+func updatePodLabel(pod *v1.Pod, namespace string) map[string]string {
 	existingLabels := pod.Labels
 	result := make(map[string]string)
 	for k, v := range existingLabels {
@@ -54,7 +58,7 @@ func UpdatePodLabelForAdmissionController(pod *v1.Pod, namespace string) map[str
 	return result
 }
 
-func UpdatePodAnnotationForAdmissionController(pod *v1.Pod, key string, value string) map[string]string {
+func updatePodAnnotation(pod *v1.Pod, key string, value string) map[string]string {
 	existingAnnotations := pod.Annotations
 	result := make(map[string]string)
 	for k, v := range existingAnnotations {
@@ -62,4 +66,12 @@ func UpdatePodAnnotationForAdmissionController(pod *v1.Pod, key string, value st
 	}
 	result[key] = value
 	return result
+}
+
+func convert2Namespace(obj interface{}) *v1.Namespace {
+	if nameSpace, ok := obj.(*v1.Namespace); ok {
+		return nameSpace
+	}
+	log.Logger().Warn("cannot convert to *v1.Namespace", zap.Stringer("type", reflect.TypeOf(obj)))
+	return nil
 }

--- a/pkg/admission/util_test.go
+++ b/pkg/admission/util_test.go
@@ -59,7 +59,7 @@ func TestUpdatePodLabelForAdmissionController(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	if result := UpdatePodLabelForAdmissionController(pod, "default"); result != nil {
+	if result := updatePodLabel(pod, "default"); result != nil {
 		assert.Equal(t, len(result), 4)
 		assert.Equal(t, result["random"], "random")
 		assert.Equal(t, result["queue"], "root.default")
@@ -90,7 +90,7 @@ func TestUpdatePodLabelForAdmissionController(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	if result := UpdatePodLabelForAdmissionController(pod, "default"); result != nil {
+	if result := updatePodLabel(pod, "default"); result != nil {
 		assert.Equal(t, len(result), 3)
 		assert.Equal(t, result["random"], "random")
 		assert.Equal(t, result["queue"], "root.default")
@@ -119,7 +119,7 @@ func TestUpdatePodLabelForAdmissionController(t *testing.T) {
 		Spec:   v1.PodSpec{},
 		Status: v1.PodStatus{},
 	}
-	if result := UpdatePodLabelForAdmissionController(pod, "default"); result != nil {
+	if result := updatePodLabel(pod, "default"); result != nil {
 		assert.Equal(t, len(result), 4)
 		assert.Equal(t, result["random"], "random")
 		assert.Equal(t, result["queue"], "root.abc")
@@ -144,7 +144,7 @@ func TestUpdatePodLabelForAdmissionController(t *testing.T) {
 		Spec:   v1.PodSpec{},
 		Status: v1.PodStatus{},
 	}
-	if result := UpdatePodLabelForAdmissionController(pod, "default"); result != nil {
+	if result := updatePodLabel(pod, "default"); result != nil {
 		assert.Equal(t, len(result), 3)
 		assert.Equal(t, result["queue"], "root.default")
 		assert.Equal(t, result["disableStateAware"], "true")
@@ -165,7 +165,7 @@ func TestUpdatePodLabelForAdmissionController(t *testing.T) {
 		Spec:   v1.PodSpec{},
 		Status: v1.PodStatus{},
 	}
-	if result := UpdatePodLabelForAdmissionController(pod, "default"); result != nil {
+	if result := updatePodLabel(pod, "default"); result != nil {
 		assert.Equal(t, len(result), 3)
 		assert.Equal(t, result["queue"], "root.default")
 		assert.Equal(t, result["disableStateAware"], "true")
@@ -183,7 +183,7 @@ func TestUpdatePodLabelForAdmissionController(t *testing.T) {
 		Spec:       v1.PodSpec{},
 		Status:     v1.PodStatus{},
 	}
-	if result := UpdatePodLabelForAdmissionController(pod, "default"); result != nil {
+	if result := updatePodLabel(pod, "default"); result != nil {
 		assert.Equal(t, len(result), 3)
 		assert.Equal(t, result["queue"], "root.default")
 		assert.Equal(t, result["disableStateAware"], "true")

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -86,8 +86,20 @@ const MemQuota = "yunikorn.apache.org/namespace.max.memory"
 // NamespaceQuota Namespace Quota
 const NamespaceQuota = "yunikorn.apache.org/namespace.quota"
 
-// Preemption
+// AnnotationAllowPreemption set on PriorityClass, opt out of preemption for pods with this priority class
 const AnnotationAllowPreemption = "yunikorn.apache.org/allow-preemption"
+
+// AnnotationGenerateAppID adds application ID to workloads in the namespace even if not set in the admission config.
+// Overrides the regexp behaviour if set, checked before the regexp is evaluated.
+// true: add an application ID label
+// false: do not add an application ID
+const AnnotationGenerateAppID = "yunikorn.apache.org/namespace.generateAppId"
+
+// AnnotationEnableYuniKorn sets the scheduler name to YuniKorn for workloads in the namespace even if not set in the admission config.
+// Overrides the regexp behaviour if set, checked before the regexp is evaluated.
+// true: set the scheduler name to YuniKorn
+// false: do not do anything
+const AnnotationEnableYuniKorn = "yunikorn.apache.org/namespace.enableYuniKorn"
 
 // Admission Controller pod label update constants
 const AutoGenAppPrefix = "yunikorn"


### PR DESCRIPTION
### What is this PR for?
Support annotations on a namespace to define processing behaviour in the admission controller. The annotations have preference over the regexp. If no annotations are found fall back on the regexp. If an annotation is found it defines the behaviour and overrides what is defined in the regexp.

Annotations to be supported on a namespace:
* yunikorn.apache.org/namespace.generateAppId
* yunikorn.apache.org/namespace.enableYuniKorn

Supported values for the annotation: true and false.

### What type of PR is it?
* [X] - Feature

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-1647

### How should this be tested?
Unit tests are added.
