### PR TITLE
[YUNIKORN-1542] Use ensure and restore config wrappers across all tes…

### DIFF
--- a/test/e2e/app/app_test.go
+++ b/test/e2e/app/app_test.go
@@ -37,13 +37,17 @@ var appClient *crdclientset.Clientset
 // var appCRDDef string
 var appCRD *v1alpha1.Application
 var dev = "apptest"
+var annotation = "ann-" + common.RandSeq(10)
+var oldConfigMap = new(v1.ConfigMap)
 
 var _ = ginkgo.BeforeSuite(func() {
 	// Initializing kubectl client and create test namespace
 	kClient = k8s.KubeCtl{}
 	gomega.Ω(kClient.SetClient()).To(gomega.BeNil())
 
+	annotation = "ann-" + common.RandSeq(10)
 	yunikorn.EnsureYuniKornConfigsPresent()
+	yunikorn.UpdateConfigMapWrapper(oldConfigMap, "", annotation)
 
 	ginkgo.By("Port-forward the scheduler pod")
 	err := kClient.PortForwardYkSchedulerPod()
@@ -100,6 +104,8 @@ var _ = ginkgo.BeforeSuite(func() {
 })
 
 var _ = ginkgo.AfterSuite(func() {
+	yunikorn.RestoreConfigMapWrapper(oldConfigMap, annotation)
+
 	ginkgo.By("Deleting application CRD")
 	err := yunikorn.DeleteApplication(appClient, dev, "example")
 	gomega.Ω(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/priority_scheduling/priority_scheduling_suite_test.go
+++ b/test/e2e/priority_scheduling/priority_scheduling_suite_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/configmanager"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/common"
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/k8s"
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/yunikorn"
 )
@@ -80,12 +81,17 @@ var normalPriorityClass = schedulingv1.PriorityClass{
 	PreemptionPolicy: &preemptPolicyNever,
 }
 
+var annotation = "ann-" + common.RandSeq(10)
+var oldConfigMap = new(v1.ConfigMap)
+
 var _ = ginkgo.BeforeSuite(func() {
 	var err error
 	kubeClient = k8s.KubeCtl{}
 	Expect(kubeClient.SetClient()).To(BeNil())
 
+	annotation = "ann-" + common.RandSeq(10)
 	yunikorn.EnsureYuniKornConfigsPresent()
+	yunikorn.UpdateConfigMapWrapper(oldConfigMap, "", annotation)
 
 	By(fmt.Sprintf("Creating priority class %s", lowPriorityClass.Name))
 	_, err = kubeClient.CreatePriorityClass(&lowPriorityClass)
@@ -116,6 +122,8 @@ var _ = ginkgo.AfterSuite(func() {
 	By(fmt.Sprintf("Removing priority class %s", lowPriorityClass.Name))
 	err = kubeClient.DeletePriorityClass(lowPriorityClass.Name)
 	Ω(err).ShouldNot(HaveOccurred())
+
+	yunikorn.RestoreConfigMapWrapper(oldConfigMap, annotation)
 })
 
 var By = ginkgo.By

--- a/test/e2e/simple_preemptor/simple_preemptor_test.go
+++ b/test/e2e/simple_preemptor/simple_preemptor_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	tests "github.com/apache/yunikorn-k8shim/test/e2e"
-	"github.com/apache/yunikorn-k8shim/test/e2e/framework/configmanager"
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/common"
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/k8s"
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/yunikorn"
@@ -40,8 +39,9 @@ import (
 var kClient k8s.KubeCtl
 var restClient yunikorn.RClient
 var ns *v1.Namespace
-var oldConfigMap *v1.ConfigMap
 var dev = "dev" + common.RandSeq(5)
+var oldConfigMap = new(v1.ConfigMap)
+var annotation = "ann-" + common.RandSeq(10)
 
 // Nodes
 var Worker1 = "yk8s-worker"
@@ -59,30 +59,13 @@ var _ = ginkgo.BeforeSuite(func() {
 	restClient = yunikorn.RClient{}
 	Ω(restClient).NotTo(gomega.BeNil())
 
+	annotation = "ann-" + common.RandSeq(10)
 	yunikorn.EnsureYuniKornConfigsPresent()
+	yunikorn.UpdateConfigMapWrapper(oldConfigMap, "", annotation)
 
 	ginkgo.By("Port-forward the scheduler pod")
 	var err = kClient.PortForwardYkSchedulerPod()
 	Ω(err).NotTo(gomega.HaveOccurred())
-
-	ginkgo.By("Enable basic scheduling config over config maps")
-	var c, configErr = kClient.GetConfigMaps(configmanager.YuniKornTestConfig.YkNamespace,
-		configmanager.DefaultYuniKornConfigMap)
-	Ω(configErr).NotTo(gomega.HaveOccurred())
-	Ω(c).NotTo(gomega.BeNil())
-
-	oldConfigMap = c.DeepCopy()
-	Ω(c).Should(gomega.BeEquivalentTo(oldConfigMap))
-
-	// Define basic configMap
-	sc := common.CreateBasicConfigMap()
-	configStr, yamlErr := common.ToYAML(sc)
-	Ω(yamlErr).NotTo(gomega.HaveOccurred())
-
-	c.Data[configmanager.DefaultPolicyGroup] = configStr
-	var d, err3 = kClient.UpdateConfigMap(c, configmanager.YuniKornTestConfig.YkNamespace)
-	Ω(err3).NotTo(gomega.HaveOccurred())
-	Ω(d).NotTo(gomega.BeNil())
 
 	ginkgo.By("create development namespace")
 	ns, err = kClient.CreateNamespace(dev, nil)
@@ -139,15 +122,7 @@ var _ = ginkgo.AfterSuite(func() {
 	err = kClient.TearDownNamespace(ns.Name)
 	Ω(err).NotTo(gomega.HaveOccurred())
 
-	ginkgo.By("Restoring the old config maps")
-	var c, err1 = kClient.GetConfigMaps(configmanager.YuniKornTestConfig.YkNamespace,
-		configmanager.DefaultYuniKornConfigMap)
-	Ω(err1).NotTo(gomega.HaveOccurred())
-	Ω(c).NotTo(gomega.BeNil())
-	c.Data = oldConfigMap.Data
-	var e, err3 = kClient.UpdateConfigMap(c, configmanager.YuniKornTestConfig.YkNamespace)
-	Ω(err3).NotTo(gomega.HaveOccurred())
-	Ω(e).NotTo(gomega.BeNil())
+	yunikorn.RestoreConfigMapWrapper(oldConfigMap, annotation)
 })
 
 var _ = ginkgo.Describe("SimplePreemptor", func() {


### PR DESCRIPTION
### What is this PR for?
add `EnsureYuniKornConfigsPresent()` & `RestoreConfigMapWrapper()` to following test suites:
- admission_controller
- app
- priority_scheduling
- recovery_and_restart
- simple_preemptor

And make "ensure and restore config" wrappers accross all test suites

### What type of PR is it?
* [x] - Sub-task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1542/

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
