### PR TITLE
[YUNIKORN-1535] Use scratch image as base in Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,8 +268,8 @@ sched_image: scheduler
 	@echo "building scheduler docker image"
 	@cp ${RELEASE_BIN_DIR}/${BINARY} ./deployments/image/configmap
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/configmap/Dockerfile
+	DOCKER_BUILDKIT=1 \
 	docker build ./deployments/image/configmap -t ${REGISTRY}/yunikorn:scheduler-${DOCKER_ARCH}-${VERSION} \
-	--build-arg TARGETPLATFORM="linux/${DOCKER_ARCH}" \
 	--platform "linux/${DOCKER_ARCH}" \
 	--label "yunikorn-core-revision=${CORE_SHA}" \
 	--label "yunikorn-scheduler-interface-revision=${SI_SHA}" \
@@ -287,8 +287,8 @@ plugin_image: plugin
 	@cp ${RELEASE_BIN_DIR}/${PLUGIN_BINARY} ./deployments/image/plugin
 	@cp conf/scheduler-config.yaml ./deployments/image/plugin/scheduler-config.yaml
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/plugin/Dockerfile
+	DOCKER_BUILDKIT=1 \
 	docker build ./deployments/image/plugin -t ${REGISTRY}/yunikorn:scheduler-plugin-${DOCKER_ARCH}-${VERSION} \
-	--build-arg TARGETPLATFORM="linux/${DOCKER_ARCH}" \
 	--platform "linux/${DOCKER_ARCH}" \
 	--label "yunikorn-core-revision=${CORE_SHA}" \
 	--label "yunikorn-scheduler-interface-revision=${SI_SHA}" \
@@ -315,8 +315,8 @@ admission: init
 adm_image: admission
 	@echo "building admission controller docker image"
 	@cp ${ADMISSION_CONTROLLER_BIN_DIR}/${POD_ADMISSION_CONTROLLER_BINARY} ./deployments/image/admission
+	DOCKER_BUILDKIT=1 \
 	docker build ./deployments/image/admission -t ${REGISTRY}/yunikorn:admission-${DOCKER_ARCH}-${VERSION} \
-	--build-arg TARGETPLATFORM="linux/${DOCKER_ARCH}" \
 	--platform "linux/${DOCKER_ARCH}" \
 	--label "yunikorn-core-revision=${CORE_SHA}" \
 	--label "yunikorn-scheduler-interface-revision=${SI_SHA}" \
@@ -348,8 +348,10 @@ simulation_image: simulation
 	@echo "building gang test docker images"
 	@cp ${GANG_BIN_DIR}/${GANG_CLIENT_BINARY} ./deployments/image/gang/gangclient
 	@cp ${GANG_BIN_DIR}/${GANG_SERVER_BINARY} ./deployments/image/gang/webserver
+	DOCKER_BUILDKIT=1 \
 	docker build ./deployments/image/gang/gangclient -t ${REGISTRY}/yunikorn:simulation-gang-worker-${VERSION} \
 	${QUIET} --build-arg ARCH=${DOCKER_ARCH}/
+	DOCKER_BUILDKIT=1 \
 	docker build ./deployments/image/gang/webserver -t ${REGISTRY}/yunikorn:simulation-gang-coordinator-${VERSION} \
 	${QUIET} --build-arg ARCH=${DOCKER_ARCH}/
 	@rm -f ./deployments/image/gang/gangclient/${GANG_CLIENT_BINARY}
@@ -363,6 +365,7 @@ image: sched_image plugin_image adm_image
 .PHONY: webtest_image
 webtest_image:
 	@echo "building web server image for automated e2e tests"
+	DOCKER_BUILDKIT=1 \
 	docker build ./deployments/image/webtest -t ${REGISTRY}/yunikorn:webtest-${DOCKER_ARCH}-${VERSION} \
 	--label "yunikorn-e2e-web-image" \
 	${QUIET} --build-arg ARCH=${DOCKER_ARCH}/

--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,8 @@ sched_image: scheduler
 	@cp ${RELEASE_BIN_DIR}/${BINARY} ./deployments/image/configmap
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/configmap/Dockerfile
 	docker build ./deployments/image/configmap -t ${REGISTRY}/yunikorn:scheduler-${DOCKER_ARCH}-${VERSION} \
+	--build-arg TARGETPLATFORM="linux/${DOCKER_ARCH}" \
+	--platform "linux/${DOCKER_ARCH}" \
 	--label "yunikorn-core-revision=${CORE_SHA}" \
 	--label "yunikorn-scheduler-interface-revision=${SI_SHA}" \
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
@@ -286,6 +288,8 @@ plugin_image: plugin
 	@cp conf/scheduler-config.yaml ./deployments/image/plugin/scheduler-config.yaml
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/plugin/Dockerfile
 	docker build ./deployments/image/plugin -t ${REGISTRY}/yunikorn:scheduler-plugin-${DOCKER_ARCH}-${VERSION} \
+	--build-arg TARGETPLATFORM="linux/${DOCKER_ARCH}" \
+	--platform "linux/${DOCKER_ARCH}" \
 	--label "yunikorn-core-revision=${CORE_SHA}" \
 	--label "yunikorn-scheduler-interface-revision=${SI_SHA}" \
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
@@ -312,6 +316,8 @@ adm_image: admission
 	@echo "building admission controller docker image"
 	@cp ${ADMISSION_CONTROLLER_BIN_DIR}/${POD_ADMISSION_CONTROLLER_BINARY} ./deployments/image/admission
 	docker build ./deployments/image/admission -t ${REGISTRY}/yunikorn:admission-${DOCKER_ARCH}-${VERSION} \
+	--build-arg TARGETPLATFORM="linux/${DOCKER_ARCH}" \
+	--platform "linux/${DOCKER_ARCH}" \
 	--label "yunikorn-core-revision=${CORE_SHA}" \
 	--label "yunikorn-scheduler-interface-revision=${SI_SHA}" \
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ sched_image: scheduler
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
-	${QUIET} --build-arg ARCH=${DOCKER_ARCH}/
+	${QUIET}
 	@mv -f ./deployments/image/configmap/Dockerfile.bkp ./deployments/image/configmap/Dockerfile
 	@rm -f ./deployments/image/configmap/${BINARY}
 
@@ -291,7 +291,7 @@ plugin_image: plugin
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
-	${QUIET} --build-arg ARCH=${DOCKER_ARCH}/
+	${QUIET}
 	@mv -f ./deployments/image/plugin/Dockerfile.bkp ./deployments/image/plugin/Dockerfile
 	@rm -f ./deployments/image/plugin/${PLUGIN_BINARY}
 	@rm -f ./deployments/image/plugin/scheduler-config.yaml
@@ -317,7 +317,7 @@ adm_image: admission
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
-	${QUIET} --build-arg ARCH=${DOCKER_ARCH}/
+	${QUIET}
 	@rm -f ./deployments/image/admission/${POD_ADMISSION_CONTROLLER_BINARY}
 
 # Build gang web server and client binary in a production ready version

--- a/deployments/image/admission/Dockerfile
+++ b/deployments/image/admission/Dockerfile
@@ -14,7 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM scratch
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM scratch
 COPY --chown=0:0 scheduler-admission-controller /
 USER 4444:4444
 ENTRYPOINT [ "/scheduler-admission-controller" ]

--- a/deployments/image/admission/Dockerfile
+++ b/deployments/image/admission/Dockerfile
@@ -14,7 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG TARGETPLATFORM
 FROM --platform=$TARGETPLATFORM scratch
 COPY --chown=0:0 scheduler-admission-controller /
 USER 4444:4444

--- a/deployments/image/admission/Dockerfile
+++ b/deployments/image/admission/Dockerfile
@@ -14,22 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-ARG ARCH=
-FROM ${ARCH}alpine:latest
-
-# Home location for all data and configs
-ENV HOME=/opt/yunikorn
-
-# Always run everything as yunikorn
-RUN mkdir -p $HOME && \
-    addgroup -S -g 4444 yunikorn && \
-    adduser -S -h $HOME -G yunikorn -u 4444 yunikorn -s /bin/sh && \
-    chown -R 4444:0 $HOME && \
-    chmod -R g=u $HOME
-
-COPY --chown=4444:0 scheduler-admission-controller $HOME/bin/
-
-WORKDIR $HOME
-USER yunikorn
-ENTRYPOINT $HOME/bin/scheduler-admission-controller
+FROM scratch
+COPY --chown=0:0 scheduler-admission-controller /
+USER 4444:4444
+ENTRYPOINT [ "/scheduler-admission-controller" ]

--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -14,22 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-ARG ARCH=
-FROM ${ARCH}alpine:latest
-
-# Home location for all data and executables
-ENV HOME=/opt/yunikorn
-
-# Always run everything as yunikorn
-RUN mkdir -p $HOME && \
-    addgroup -S -g 4444 yunikorn && \
-    adduser -S -h $HOME -G yunikorn -u 4444 yunikorn -s /bin/sh && \
-    chown -R 4444:0 $HOME && \
-    chmod -R g=u $HOME
-
-COPY --chown=4444:0 k8s_yunikorn_scheduler $HOME/bin/
-
-WORKDIR $HOME
-USER yunikorn
-ENTRYPOINT $HOME/bin/k8s_yunikorn_scheduler
+FROM scratch
+COPY --chown=0:0 k8s_yunikorn_scheduler /
+USER 4444:4444
+ENTRYPOINT [ "/k8s_yunikorn_scheduler" ]

--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -14,7 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM scratch
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM scratch
 COPY --chown=0:0 k8s_yunikorn_scheduler /
 USER 4444:4444
 ENTRYPOINT [ "/k8s_yunikorn_scheduler" ]

--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -14,7 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG TARGETPLATFORM
 FROM --platform=$TARGETPLATFORM scratch
 COPY --chown=0:0 k8s_yunikorn_scheduler /
 USER 4444:4444

--- a/deployments/image/plugin/Dockerfile
+++ b/deployments/image/plugin/Dockerfile
@@ -14,7 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG TARGETPLATFORM
 FROM --platform=$TARGETPLATFORM scratch
 COPY --chown=0:0 kube-scheduler scheduler-config.yaml /
 USER 4444:4444

--- a/deployments/image/plugin/Dockerfile
+++ b/deployments/image/plugin/Dockerfile
@@ -14,22 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-ARG ARCH=
-FROM ${ARCH}alpine:latest
-
-# Home location for all data and executables
-ENV HOME=/opt/yunikorn
-
-RUN mkdir -p $HOME && \
-    addgroup -S -g 4444 yunikorn && \
-    adduser -S -h $HOME -G yunikorn -u 4444 yunikorn -s /bin/sh && \
-    chown -R 4444:0 $HOME && \
-    chmod -R g=u $HOME
-
-COPY --chown=4444:0 scheduler-config.yaml $HOME/
-COPY --chown=4444:0 kube-scheduler $HOME/bin/
-
-WORKDIR $HOME
-USER yunikorn
-ENTRYPOINT [ "/opt/yunikorn/bin/kube-scheduler", "--bind-address=0.0.0.0", "--config=/opt/yunikorn/scheduler-config.yaml" ]
+FROM scratch
+COPY --chown=0:0 kube-scheduler scheduler-config.yaml /
+USER 4444:4444
+ENTRYPOINT [ "/kube-scheduler", "--bind-address=0.0.0.0", "--config=/scheduler-config.yaml" ]

--- a/deployments/image/plugin/Dockerfile
+++ b/deployments/image/plugin/Dockerfile
@@ -14,7 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM scratch
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM scratch
 COPY --chown=0:0 kube-scheduler scheduler-config.yaml /
 USER 4444:4444
 ENTRYPOINT [ "/kube-scheduler", "--bind-address=0.0.0.0", "--config=/scheduler-config.yaml" ]


### PR DESCRIPTION
### What is this PR for?
In the interests of security, use a scratch image for Docker images where we deploy a single Go binary.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1535

### How should this be tested?
Existing e2e tests cover this.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
