### PR TITLE
[YUNIKORN-1675] Fix run / run_plugin Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,24 +198,19 @@ pseudo:
 .PHONY: run
 run: build
 	@echo "running scheduler locally"
-	cd ${DEV_BIN_DIR} && ./${BINARY} -kubeConfig=$(KUBECONFIG) -interval=1s \
-	-clusterId=mycluster -clusterVersion=${VERSION} -policyGroup=queues \
-	-logEncoding=console -logLevel=-1
+	cd ${DEV_BIN_DIR} && \
+	KUBECONFIG="$(KUBECONFIG)" ./${BINARY}
 
 .PHONY: run_plugin
 run_plugin: build_plugin
 	@echo "running scheduler plugin locally"
 	cd ${DEV_BIN_DIR} && \
-	  ./${PLUGIN_BINARY} \
-	    --address=0.0.0.0 \
-	    --leader-elect=false \
-	    --config=../../conf/scheduler-config-local.yaml \
-	    -v=2 \
-	    --yk-scheduler-name=yunikorn \
-	    --yk-kube-config=$(KUBECONFIG) \
-	    --yk-cluster-id=yk \
-	    --yk-scheduling-interval=1s \
-	    --yk-log-level=1
+	KUBECONFIG="$(KUBECONFIG)" \
+	./${PLUGIN_BINARY} \
+	--address=0.0.0.0 \
+	--leader-elect=false \
+	--config=../../conf/scheduler-config-local.yaml \
+	-v=2
 
 # Create output directories
 .PHONY: init


### PR DESCRIPTION
### What is this PR for?
Fixes the `run` and `run_plugin` Makefile targets which were broken with the ConfigV2 redesign.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1675

### How should this be tested?
No code changes, just developer Makefile targets

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
