### PR TITLE
[YUNIKORN-1704] Allow application FSM transition from Recovering to Rejected

### DIFF
--- a/pkg/cache/application_state.go
+++ b/pkg/cache/application_state.go
@@ -478,7 +478,7 @@ func newAppState() *fsm.FSM { //nolint:funlen
 			},
 			{
 				Name: RejectApplication.String(),
-				Src:  []string{states.Submitted},
+				Src:  []string{states.Submitted, states.Recovering},
 				Dst:  states.Rejected,
 			},
 			{


### PR DESCRIPTION
The application state machine in the shim does not allow Rejected as a transition from the Recovering state, resulting in the application being stuck in Recovering.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1704

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
