### PR TITLE
[YUNIKORN-1707] Ignore pods in non-labeled namespaces

### DIFF
--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -126,13 +126,7 @@ func (os *Manager) filterPods(obj interface{}) bool {
 	switch obj.(type) {
 	case *v1.Pod:
 		pod := obj.(*v1.Pod)
-		if utils.GeneralPodFilter(pod) {
-			// only application ID is required
-			if _, err := utils.GetApplicationIDFromPod(pod); err == nil {
-				return true
-			}
-		}
-		return false
+		return utils.GetApplicationIDFromPod(pod) != ""
 	default:
 		return false
 	}
@@ -236,7 +230,7 @@ func (os *Manager) ListPods() ([]*v1.Pod, error) {
 		log.Logger().Debug("Looking at pod for recovery candidates", zap.String("podNamespace", pod.Namespace), zap.String("podName", pod.Name))
 		// general filter passes, and pod is assigned
 		// this means the pod is already scheduled by scheduler for an existing app
-		if utils.GeneralPodFilter(pod) && utils.IsAssignedPod(pod) {
+		if utils.GetApplicationIDFromPod(pod) != "" && utils.IsAssignedPod(pod) {
 			if meta, ok := getAppMetadata(pod, true); ok {
 				podsRecovered++
 				pods = append(pods, pod)

--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -609,8 +609,7 @@ func TestListApplication(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(pods), 3)
 	for _, pod := range pods {
-		name, err := utils.GetApplicationIDFromPod(pod)
-		assert.NilError(t, err, "Could not retrieve application id from pod")
+		name := utils.GetApplicationIDFromPod(pod)
 		expected := expectOutput[name]
 		description := descriptionMap[name]
 		assert.Assert(t, expected, description)

--- a/pkg/appmgmt/general/podevent_handler_test.go
+++ b/pkg/appmgmt/general/podevent_handler_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/apache/yunikorn-k8shim/pkg/cache"
+	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 )
 
 const appID = "app00001"
@@ -100,6 +101,9 @@ func newPod(name string) *v1.Pod {
 				"queue":         "root.a",
 				"applicationId": appID,
 			},
+		},
+		Spec: v1.PodSpec{
+			SchedulerName: constants.SchedulerName,
 		},
 	}
 }

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -283,11 +283,7 @@ func (ctx *Context) updatePodInCache(oldObj, newObj interface{}) {
 func (ctx *Context) filterPods(obj interface{}) bool {
 	switch obj := obj.(type) {
 	case *v1.Pod:
-		if utils.GeneralPodFilter(obj) {
-			_, err := utils.GetApplicationIDFromPod(obj)
-			return err == nil
-		}
-		return false
+		return utils.GetApplicationIDFromPod(obj) != ""
 	default:
 		return false
 	}

--- a/pkg/cache/context_recovery.go
+++ b/pkg/cache/context_recovery.go
@@ -103,8 +103,7 @@ func (ctx *Context) recover(mgr []interfaces.Recoverable, due time.Duration) err
 				continue
 			}
 			// yunikorn scheduled pods add to existing allocations
-			_, err = utils.GetApplicationIDFromPod(&pod)
-			ykPod := utils.GeneralPodFilter(&pod) && err == nil
+			ykPod := utils.GetApplicationIDFromPod(&pod) != ""
 			switch {
 			case ykPod:
 				if existingAlloc := getExistingAllocation(mgr, &pod); existingAlloc != nil {

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -64,7 +64,7 @@ func initContextAndAPIProviderForTest() (*Context, *client.MockedAPIProvider) {
 	return context, apis
 }
 
-func newPodHelper(name, namespace, podUID, nodeName string, podPhase v1.PodPhase) *v1.Pod {
+func newPodHelper(name, namespace, podUID, nodeName string, appID string, podPhase v1.PodPhase) *v1.Pod {
 	return &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
@@ -74,6 +74,7 @@ func newPodHelper(name, namespace, podUID, nodeName string, podPhase v1.PodPhase
 			Name:      name,
 			Namespace: namespace,
 			UID:       types.UID(podUID),
+			Labels:    map[string]string{constants.LabelApplicationID: appID},
 		},
 		Spec: v1.PodSpec{
 			NodeName:      nodeName,
@@ -622,7 +623,7 @@ func TestRecoverTask(t *testing.T) {
 		Metadata: interfaces.TaskMetadata{
 			ApplicationID: appID,
 			TaskID:        taskUID1,
-			Pod:           newPodHelper("pod1", podNamespace, taskUID1, fakeNodeName, v1.PodRunning),
+			Pod:           newPodHelper("pod1", podNamespace, taskUID1, fakeNodeName, appID, v1.PodRunning),
 		},
 	})
 	assert.Assert(t, task != nil)
@@ -635,7 +636,7 @@ func TestRecoverTask(t *testing.T) {
 		Metadata: interfaces.TaskMetadata{
 			ApplicationID: appID,
 			TaskID:        taskUID2,
-			Pod:           newPodHelper("pod2", podNamespace, taskUID2, fakeNodeName, v1.PodSucceeded),
+			Pod:           newPodHelper("pod2", podNamespace, taskUID2, fakeNodeName, appID, v1.PodSucceeded),
 		},
 	})
 	assert.Assert(t, task != nil)
@@ -648,7 +649,7 @@ func TestRecoverTask(t *testing.T) {
 		Metadata: interfaces.TaskMetadata{
 			ApplicationID: appID,
 			TaskID:        taskUID3,
-			Pod:           newPodHelper("pod3", podNamespace, taskUID3, fakeNodeName, v1.PodFailed),
+			Pod:           newPodHelper("pod3", podNamespace, taskUID3, fakeNodeName, appID, v1.PodFailed),
 		},
 	})
 	assert.Assert(t, task != nil)
@@ -661,7 +662,7 @@ func TestRecoverTask(t *testing.T) {
 		Metadata: interfaces.TaskMetadata{
 			ApplicationID: appID,
 			TaskID:        taskUID4,
-			Pod:           newPodHelper("pod4", podNamespace, taskUID4, "", v1.PodPending),
+			Pod:           newPodHelper("pod4", podNamespace, taskUID4, "", appID, v1.PodPending),
 		},
 	})
 	assert.Assert(t, task != nil)
@@ -738,7 +739,7 @@ func TestTaskReleaseAfterRecovery(t *testing.T) {
 		Metadata: interfaces.TaskMetadata{
 			ApplicationID: appID,
 			TaskID:        pod1UID,
-			Pod:           newPodHelper(pod1Name, namespace, pod1UID, fakeNodeName, v1.PodRunning),
+			Pod:           newPodHelper(pod1Name, namespace, pod1UID, fakeNodeName, appID, v1.PodRunning),
 		},
 	})
 
@@ -750,7 +751,7 @@ func TestTaskReleaseAfterRecovery(t *testing.T) {
 		Metadata: interfaces.TaskMetadata{
 			ApplicationID: appID,
 			TaskID:        pod2UID,
-			Pod:           newPodHelper(pod2Name, namespace, pod2UID, fakeNodeName, v1.PodRunning),
+			Pod:           newPodHelper(pod2Name, namespace, pod2UID, fakeNodeName, appID, v1.PodRunning),
 		},
 	})
 

--- a/pkg/cache/node_coordinator.go
+++ b/pkg/cache/node_coordinator.go
@@ -33,9 +33,10 @@ import (
 // this coordinator only looks after the pods that are not scheduled by yunikorn,
 // and it registers update/delete handler to the pod informer. It ensures that the
 // following operations are done
-//  1) when a pod is becoming Running, add occupied node resource
-//  2) when a pod is terminated, sub the occupied node resource
-//  3) when a pod is deleted, sub the occupied node resource
+//  1. when a pod is becoming Running, add occupied node resource
+//  2. when a pod is terminated, sub the occupied node resource
+//  3. when a pod is deleted, sub the occupied node resource
+//
 // each of these updates will trigger a node UPDATE action to update the occupied
 // resource in the scheduler-core.
 type nodeResourceCoordinator struct {
@@ -50,11 +51,7 @@ func newNodeResourceCoordinator(nodes *schedulerNodes) *nodeResourceCoordinator 
 func (c *nodeResourceCoordinator) filterPods(obj interface{}) bool {
 	switch obj := obj.(type) {
 	case *v1.Pod:
-		if utils.GeneralPodFilter(obj) {
-			_, err := utils.GetApplicationIDFromPod(obj)
-			return err != nil
-		}
-		return true
+		return utils.GetApplicationIDFromPod(obj) == ""
 	default:
 		return false
 	}

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -90,6 +90,9 @@ const NamespaceQuota = "yunikorn.apache.org/namespace.quota"
 // AnnotationAllowPreemption set on PriorityClass, opt out of preemption for pods with this priority class
 const AnnotationAllowPreemption = "yunikorn.apache.org/allow-preemption"
 
+// AnnotationIgnoreApplication set on Pod prevents by admission controller, prevents YuniKorn from honoring application ID
+const AnnotationIgnoreApplication = "yunikorn.apache.org/ignore-application"
+
 // AnnotationGenerateAppID adds application ID to workloads in the namespace even if not set in the admission config.
 // Overrides the regexp behaviour if set, checked before the regexp is evaluated.
 // true: add an application ID label

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -109,6 +109,16 @@ func GetQueueNameFromPod(pod *v1.Pod) string {
 }
 
 func GetApplicationIDFromPod(pod *v1.Pod) (string, error) {
+	// if pod was tagged with ignore-application, return
+	if value := GetPodAnnotationValue(pod, constants.AnnotationIgnoreApplication); value != "" {
+		ignore, err := strconv.ParseBool(value)
+		if err != nil {
+			log.Logger().Warn("Failed to parse annotation "+constants.AnnotationIgnoreApplication, zap.Error(err))
+		} else if ignore {
+			return "", nil
+		}
+	}
+
 	// application ID can be defined in annotations
 	if value := GetPodAnnotationValue(pod, constants.AnnotationApplicationID); value != "" {
 		return value, nil

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -74,7 +74,7 @@ func NeedRecovery(pod *v1.Pod) bool {
 	// 1. Pod is scheduled by us
 	// 2. pod is already assigned to a node
 	// 3. pod is not in terminated state
-	if GeneralPodFilter(pod) && IsAssignedPod(pod) && !IsPodTerminated(pod) {
+	if GetApplicationIDFromPod(pod) != "" && IsAssignedPod(pod) && !IsPodTerminated(pod) {
 		return true
 	}
 
@@ -94,10 +94,6 @@ func IsAssignedPod(pod *v1.Pod) bool {
 	return len(pod.Spec.NodeName) != 0
 }
 
-func GeneralPodFilter(pod *v1.Pod) bool {
-	return strings.Compare(pod.Spec.SchedulerName, constants.SchedulerName) == 0
-}
-
 func GetQueueNameFromPod(pod *v1.Pod) string {
 	queueName := constants.ApplicationDefaultQueue
 	if an := GetPodLabelValue(pod, constants.LabelQueueName); an != "" {
@@ -108,34 +104,35 @@ func GetQueueNameFromPod(pod *v1.Pod) string {
 	return queueName
 }
 
-func GetApplicationIDFromPod(pod *v1.Pod) (string, error) {
+// GetApplicationIDFromPod returns the applicationID (if present) from a Pod or an empty string if not present.
+// If an applicationID is present, the Pod is managed by YuniKorn. Otherwise, it is managed by an external scheduler.
+func GetApplicationIDFromPod(pod *v1.Pod) string {
+	// SchedulerName needs to match
+	if strings.Compare(pod.Spec.SchedulerName, constants.SchedulerName) != 0 {
+		return ""
+	}
 	// if pod was tagged with ignore-application, return
 	if value := GetPodAnnotationValue(pod, constants.AnnotationIgnoreApplication); value != "" {
 		ignore, err := strconv.ParseBool(value)
 		if err != nil {
 			log.Logger().Warn("Failed to parse annotation "+constants.AnnotationIgnoreApplication, zap.Error(err))
 		} else if ignore {
-			return "", nil
+			return ""
 		}
 	}
-
 	// application ID can be defined in annotations
 	if value := GetPodAnnotationValue(pod, constants.AnnotationApplicationID); value != "" {
-		return value, nil
+		return value
 	}
-
-	// application ID can be defined in labels
 	if value := GetPodLabelValue(pod, constants.LabelApplicationID); value != "" {
-		return value, nil
+		return value
 	}
-
 	// application ID can be defined in labels
 	if value := GetPodLabelValue(pod, constants.SparkLabelAppID); value != "" {
-		return value, nil
+		return value
 	}
-
-	return "", fmt.Errorf("unable to retrieve application ID from pod spec, %s",
-		pod.Spec.String())
+	// no application ID found, this is not a YuniKorn-managed Pod
+	return ""
 }
 
 // compare the existing pod condition with the given one, return true if the pod condition remains not changed.

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -443,6 +443,22 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 				Annotations: map[string]string{constants.AnnotationApplicationID: appIDInAnnotation},
 			},
 		}, false, appIDInAnnotation},
+		{"AppID defined but ignore-application set", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					constants.AnnotationApplicationID:     appIDInAnnotation,
+					constants.AnnotationIgnoreApplication: "true",
+				},
+			},
+		}, false, ""},
+		{"AppID defined and ignore-application invalid", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					constants.AnnotationApplicationID:     appIDInAnnotation,
+					constants.AnnotationIgnoreApplication: "invalid",
+				},
+			},
+		}, false, appIDInAnnotation},
 		{"AppID defined in label and annotation", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{constants.AnnotationApplicationID: appIDInAnnotation},

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -92,8 +92,8 @@ func (sp *YuniKornSchedulerPlugin) PreFilter(_ context.Context, state *framework
 		zap.String("pod", pod.Name))
 
 	// we don't process pods without appID defined
-	appID, err := utils.GetApplicationIDFromPod(pod)
-	if err != nil {
+	appID := utils.GetApplicationIDFromPod(pod)
+	if appID == "" {
 		log.Logger().Debug("Skipping pod in the prefilter plugin because no applicationID is defined",
 			zap.String("namespace", pod.Namespace),
 			zap.String("pod", pod.Name))
@@ -144,8 +144,8 @@ func (sp *YuniKornSchedulerPlugin) Filter(_ context.Context, _ *framework.CycleS
 		zap.String("node", nodeInfo.Node().Name))
 
 	// we don't process pods without appID defined
-	appID, err := utils.GetApplicationIDFromPod(pod)
-	if err != nil {
+	appID := utils.GetApplicationIDFromPod(pod)
+	if appID == "" {
 		log.Logger().Debug("Skipping pod in the filter plugin because no applicationID is defined",
 			zap.String("namespace", pod.Namespace),
 			zap.String("pod", pod.Name))
@@ -194,8 +194,8 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 		zap.String("assignedNode", nodeName))
 
 	// we don't process pods without appID defined
-	appID, err := utils.GetApplicationIDFromPod(pod)
-	if err != nil {
+	appID := utils.GetApplicationIDFromPod(pod)
+	if appID == "" {
 		log.Logger().Debug("Skipping pod in the postbind plugin because no applicationID is defined",
 			zap.String("namespace", pod.Namespace),
 			zap.String("pod", pod.Name))


### PR DESCRIPTION
### What is this PR for?
The admission controller allows pods in configured namespaces to be either
bypassed entirely, or passed through to YuniKorn but not labeled for
processing (useful in the plugin deployment to pass through to the embedded
default scheduler). However, if YuniKorn detects an applicationId or Spark
spark-app-selector, it will attempt to schedule that Pod via YuniKorn
regardless. This may not succeed if there is not a valid queue available
which matches placement rules.

To prevent this, the admission controller will now annotate pods which are
in non-labeled namespaces to mark them as ignored by YuniKorn, and the
scheduler will honor this annotation. This ensures that a namespace is
either processed completely by YuniKorn, or not at all

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1707

### How should this be tested?
Unit tests updated.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
