### PR TITLE
[YUNIKORN-1615] Ensure node coordinator accounts for all non-yunikorn pod updates

### DIFF
--- a/pkg/appmgmt/appmgmt.go
+++ b/pkg/appmgmt/appmgmt.go
@@ -98,16 +98,21 @@ func (svc *AppManagementService) register(managers ...interfaces.AppManager) {
 	}
 }
 
-func (svc *AppManagementService) Start() error {
+func (svc *AppManagementService) ServiceInit() error {
 	for _, optService := range svc.managers {
-		// init service before starting
+		// init services
 		if err := optService.ServiceInit(); err != nil {
 			log.Logger().Error("service init fails",
 				zap.String("serviceName", optService.Name()),
 				zap.Error(err))
 			return err
 		}
+	}
+	return nil
+}
 
+func (svc *AppManagementService) Start() error {
+	for _, optService := range svc.managers {
 		log.Logger().Info("starting app management service",
 			zap.String("serviceName", optService.Name()))
 		if err := optService.Start(); err != nil {

--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -64,6 +64,11 @@ func (os *Manager) Name() string {
 
 // this implements AppManagementService interface
 func (os *Manager) ServiceInit() error {
+	return nil
+}
+
+// this implements AppManagementService interface
+func (os *Manager) Start() error {
 	os.apiProvider.AddEventHandler(
 		&client.ResourceEventHandlers{
 			Type:     client.PodInformerHandlers,
@@ -72,13 +77,6 @@ func (os *Manager) ServiceInit() error {
 			UpdateFn: os.updatePod,
 			DeleteFn: os.deletePod,
 		})
-	return nil
-}
-
-// this implements AppManagementService interface
-func (os *Manager) Start() error {
-	// generic app manager leverages the shared context,
-	// no other service, go routine is required to be started
 	return nil
 }
 

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -119,6 +119,7 @@ func (ctx *Context) AddSchedulingEventHandlers() {
 	ctx.apiProvider.AddEventHandler(&client.ResourceEventHandlers{
 		Type:     client.PodInformerHandlers,
 		FilterFn: nodeCoordinator.filterPods,
+		AddFn:    nodeCoordinator.addPod,
 		UpdateFn: nodeCoordinator.updatePod,
 		DeleteFn: nodeCoordinator.deletePod,
 	})

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -27,11 +27,11 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	podv1 "k8s.io/kubernetes/pkg/api/v1/pod"
 
 	"github.com/apache/yunikorn-k8shim/pkg/apis/yunikorn.apache.org/v1alpha1"
@@ -222,6 +222,7 @@ func PodForTest(podName, memory, cpu string) *v1.Pod {
 		},
 		ObjectMeta: apis.ObjectMeta{
 			Name: podName,
+			UID:  types.UID("UID-" + podName),
 		},
 		Spec: v1.PodSpec{
 			Containers: containers,


### PR DESCRIPTION
Under certain circumstances, the node coordinator has been observed updating occupied resources on a node to negative values.

Ensure that we handle all pod add/update/delete events for non-yunikorn pods appropriately.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1615

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
