### PR TITLE
[YUNIKORN-1712] Placeholder allocations are being removed twice

### DIFF
--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -484,7 +484,7 @@ func (task *Task) postTaskFailed(reason string) {
 // send different requests to scheduler-core, depending on current task state
 func (task *Task) beforeTaskCompleted() {
 	// We should make sure here the task.releaseAllocation() is called only once.
-	if task.IsReleased() {
+	if !task.IsReleased() {
 		task.releaseAllocation()
 		task.setReleased(true)
 	}


### PR DESCRIPTION
### What is this PR for?

Under some circumstances, it seems that placeholder allocations are being removed multiple times:

```
2023-04-25T06:25:46.279Z	INFO	scheduler/partition.go:1233	replacing placeholder allocation {"appID": "spark-000000031tn2lgv2gar", "allocationId": "20a4cf77-7095-4635-b9e9-43a7564385c4"}
...
2023-04-25T06:25:46.299Z	INFO	scheduler/partition.go:1233	replacing placeholder allocation {"appID": "spark-000000031tn2lgv2gar", "allocationId": "20a4cf77-7095-4635-b9e9-43a7564385c4"}
```


This message only appears once in the codebase, in PartitionContext.removeAllocation(). Furthermore, it is guarded by a test for release.TerminationType == si.TerminationType_PLACEHOLDER_REPLACED. This would seem to indicate that removeAllocation() is somehow being called twice. I believe this would cause the used resources on the node to be subtracted twice for the same allocation. This quickly results in health checks failing:

```
2023-04-25T06:26:10.632Z        WARN    scheduler/health_checker.go:176 Scheduler is not healthy        {"health check values": [..., {"Name":"Consistency of data","Succeeded":false,"Description":"Check if node total resource = allocated resource + occupied resource + available resource","DiagnosisMessage":"Nodes with inconsistent data: [\"ip-10-0-112-148.eu-central-1.compute.internal\"]"}, ...]}
```


**First case:**
Note for allocate new to place the released placeholder:
If the task termination type is PLACEHOLDER_REPLACED, it means the core side was already aware,
we should not release the allocation here to avoid release twice.
Because when the placeHolder was replaced, the task will call NotifyTaskComplete to release the allocation.


**Second case**
TODO:
We need to investigate the delete pod for the released placeholder:

2023-04-25T06:25:46.279Z	INFO	scheduler/partition.go:1233	replacing placeholder allocation	{"appID": "spark-000000031tn2lgv2gar", "allocationId": "20a4cf77-7095-4635-b9e9-43a7564385c4"}
2023-04-25T06:25:46.279Z	INFO	objects/application_state.go:132	Application state transition	{"appID": "spark-000000031tn2lgv2gar", "source": "Starting", "destination": "Completing", "event": "completeApplication"}
2023-04-25T06:25:46.279Z	WARN	scheduler/partition.go:1272	replacing placeholder: placeholder is larger than real allocation	{"allocationID": "2b68c8e8-d578-41b9-9ed1-32daa99773d6", "requested resource": "map[memory:1712324608 vcore:1200]", "placeholderID": "20a4cf77-7095-4635-b9e9-43a7564385c4", "placeholder resource": "map[memory:2147483648 vcore:1200]"}
2023-04-25T06:25:46.279Z	INFO	scheduler/partition.go:1286	replacing placeholder allocation on node	{"nodeID": "ip-10-0-112-148.eu-central-1.compute.internal", "allocationId": "20a4cf77-7095-4635-b9e9-43a7564385c4", "allocation nodeID": "ip-10-0-112-148.eu-central-1.compute.internal"}
2023-04-25T06:25:46.279Z	INFO	cache/task_state.go:372	object transition	{"object": {}, "source": "Scheduling", "destination": "Allocated", "event": "TaskAllocated"}
2023-04-25T06:25:46.279Z	INFO	cache/context.go:468	Binding Pod Volumes skipped: all volumes already bound	{"podName": "spark-000000031tn2lgv2gar-driver"}
2023-04-25T06:25:46.279Z	INFO	client/kubeclient.go:112	bind pod to node	{"podName": "spark-000000031tn2lgv2gar-driver", "podUID": "19d0ed5c-8cbe-4115-9971-a4adef5ed38c", "nodeID": "ip-10-0-112-148.eu-central-1.compute.internal"}
2023-04-25T06:25:46.291Z	INFO	cache/task.go:404	successfully bound pod	{"podName": "spark-000000031tn2lgv2gar-driver"}
2023-04-25T06:25:46.291Z	INFO	cache/task_state.go:372	object transition	{"object": {}, "source": "Allocated", "destination": "Bound", "event": "TaskBound"}
**2023-04-25T06:25:46.299Z	INFO	general/general.go:213	delete pod	{"appType": "general", "namespace": "sandbox", "podName": "tg-spark-driver-app-spark-000000031tn2lgv2gar-0", "podUID": "98e2100c-aebb-4a2a-82ca-1206dde51322"}**
2023-04-25T06:25:46.299Z	INFO	cache/task.go:543	releasing allocations	{"numOfAsksToRelease": 0, "numOfAllocationsToRelease": 1}
2023-04-25T06:25:46.299Z	INFO	scheduler/partition.go:1233	replacing placeholder allocation	{"appID": "spark-000000031tn2lgv2gar", "allocationId": "20a4cf77-7095-4635-b9e9-43a7564385c4"}

Why the delete pod happened after the real pod in shim side task bound.

**Further investigation:**
Because we call the updatePod already to trigger the complete task:
```
func (p *PodEventHandler) updatePod(pod *v1.Pod) interfaces.ManagedApp {
	if taskMeta, ok := getTaskMetadata(pod); ok {
		if app := p.amProtocol.GetApplication(taskMeta.ApplicationID); app != nil {
			p.amProtocol.NotifyTaskComplete(taskMeta.ApplicationID, taskMeta.TaskID)
			return app
		}
	}
	return nil
}

func (p *PodEventHandler) deletePod(pod *v1.Pod) interfaces.ManagedApp {
	if taskMeta, ok := getTaskMetadata(pod); ok {
		if app := p.amProtocol.GetApplication(taskMeta.ApplicationID); app != nil {
			p.amProtocol.NotifyTaskComplete(taskMeta.ApplicationID, taskMeta.TaskID)
			return app
		}
	}
	return nil
}
```
When the placeholder pod update pod status to successfully, we release the first time:

For example:

```
**2023-04-25T08:18:20.075Z	INFO	general/general.go:179	task completes	{"appType": "general", "namespace": "sandbox", "podName": "tg-spark-driver-app-spark-000000031tnfkjkiold-0", "podUID": "bdc85fe0-a563-46b6-b7a4-6621db526b81", "podStatus": "Succeeded"}**
2023-04-25T08:18:20.075Z	INFO	cache/task.go:543	releasing allocations	{"numOfAsksToRelease": 0, "numOfAllocationsToRelease": 1}
2023-04-25T08:18:20.075Z	INFO	cache/task_state.go:372	object transition	{"object": {}, "source": "Bound", "destination": "Completed", "event": "CompleteTask"}
2023-04-25T08:18:20.075Z	INFO	scheduler/partition.go:1233	replacing placeholder allocation	{"appID": "spark-000000031tnfkjkiold", "allocationId": "dce21212-6fb6-491e-bc22-ebc3ecddb1d0"}
```

The "podStatus": "Succeeded" to call the updatePod, this will call the release first time.

```
// when pod resource is modified, we need to act accordingly
// e.g vertical scale out the pod, this requires the scheduler to be aware of this
func (os *Manager) updatePod(old, new interface{}) {
	oldPod, err := utils.Convert2Pod(old)
	if err != nil {
		log.Logger().Error("expecting a pod object", zap.Error(err))
		return
	}

	newPod, err := utils.Convert2Pod(new)
	if err != nil {
		log.Logger().Error("expecting a pod object", zap.Error(err))
		return
	}

	// triggered when pod status' phase changes
	if oldPod.Status.Phase != newPod.Status.Phase {
		// pod succeed or failed means all containers in the pod have been terminated,
		// and these container won't be restarted. In this case, we can safely release
		// the resources for this allocation. And mark the task is done.
		if utils.IsPodTerminated(newPod) {
			log.Logger().Info("task completes",
				zap.String("appType", os.Name()),
				zap.String("namespace", newPod.Namespace),
				zap.String("podName", newPod.Name),
				zap.String("podUID", string(newPod.UID)),
				zap.String("podStatus", string(newPod.Status.Phase)))
			os.podEventHandler.HandleEvent(UpdatePod, Informers, newPod)
		}
	}
}
```

And when the placeholder pod deleted, it will call the secend time:

```
2023-04-25T08:18:20.094Z	INFO	general/general.go:213	delete pod	{"appType": "general", "namespace": "sandbox", "podName": "tg-spark-driver-app-spark-000000031tnfkjkiold-0", "podUID": "bdc85fe0-a563-46b6-b7a4-6621db526b81"}
2023-04-25T08:18:20.094Z	INFO	cache/task.go:543	releasing allocations	{"numOfAsksToRelease": 0, "numOfAllocationsToRelease": 1}
2023-04-25T08:18:20.094Z	INFO	scheduler/partition.go:1233	replacing placeholder allocation	{"appID": "spark-000000031tnfkjkiold", "allocationId": "dce21212-6fb6-491e-bc22-ebc3ecddb1d0"}
```

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
