### PR TITLE
[YUNIKORN-1683] Add more information to BuildInfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ init:
 build: init
 	@echo "building scheduler binary"
 	go build -o=${DEV_BIN_DIR}/${BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
 	./pkg/cmd/shim/
 	@chmod +x ${DEV_BIN_DIR}/${BINARY}
 
@@ -234,7 +234,7 @@ build: init
 build_plugin: init
 	@echo "building scheduler plugin binary"
 	go build -o=${DEV_BIN_DIR}/${PLUGIN_BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
 	./pkg/cmd/schedulerplugin/
 	@chmod +x ${DEV_BIN_DIR}/${PLUGIN_BINARY}
 
@@ -244,7 +244,7 @@ scheduler: init
 	@echo "building binary for scheduler docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/shim/
 
@@ -254,7 +254,7 @@ plugin: init
 	@echo "building binary for plugin docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${PLUGIN_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/schedulerplugin/
 	
@@ -302,7 +302,7 @@ admission: init
 	@echo "building admission controller binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${ADMISSION_CONTROLLER_BIN_DIR}/${POD_ADMISSION_CONTROLLER_BINARY} -ldflags \
-    '-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE}' \
+    '-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
     -tags netgo -installsuffix netgo \
     ./pkg/cmd/admissioncontroller
 
@@ -328,7 +328,7 @@ simulation:
 	@echo "building gang web client binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${GANG_BIN_DIR}/${GANG_CLIENT_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/simulation/gang/gangclient
 	@echo "building gang web server binary"
@@ -371,7 +371,7 @@ webtest_image: build_web_test_server_prod
 build_web_test_server_dev:
 	@echo "building local web server binary"
 	go build -o=${DEV_BIN_DIR}/${TEST_SERVER_BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
 	./pkg/cmd/webtest/
 	@chmod +x ${DEV_BIN_DIR}/${TEST_SERVER_BINARY}
 
@@ -380,7 +380,7 @@ build_web_test_server_prod:
 	@echo "building web server binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${TEST_SERVER_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/webtest/
 

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ init:
 build: init
 	@echo "building scheduler binary"
 	go build -o=${DEV_BIN_DIR}/${BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	./pkg/cmd/shim/
 	@chmod +x ${DEV_BIN_DIR}/${BINARY}
 
@@ -234,7 +234,7 @@ build: init
 build_plugin: init
 	@echo "building scheduler plugin binary"
 	go build -o=${DEV_BIN_DIR}/${PLUGIN_BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	./pkg/cmd/schedulerplugin/
 	@chmod +x ${DEV_BIN_DIR}/${PLUGIN_BINARY}
 
@@ -244,7 +244,7 @@ scheduler: init
 	@echo "building binary for scheduler docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/shim/
 
@@ -254,7 +254,7 @@ plugin: init
 	@echo "building binary for plugin docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${PLUGIN_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/schedulerplugin/
 	
@@ -302,7 +302,7 @@ admission: init
 	@echo "building admission controller binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${ADMISSION_CONTROLLER_BIN_DIR}/${POD_ADMISSION_CONTROLLER_BINARY} -ldflags \
-    '-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
+    '-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH}' \
     -tags netgo -installsuffix netgo \
     ./pkg/cmd/admissioncontroller
 
@@ -328,7 +328,7 @@ simulation:
 	@echo "building gang web client binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${GANG_BIN_DIR}/${GANG_CLIENT_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/simulation/gang/gangclient
 	@echo "building gang web server binary"
@@ -371,7 +371,7 @@ webtest_image: build_web_test_server_prod
 build_web_test_server_dev:
 	@echo "building local web server binary"
 	go build -o=${DEV_BIN_DIR}/${TEST_SERVER_BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH}' \
 	./pkg/cmd/webtest/
 	@chmod +x ${DEV_BIN_DIR}/${TEST_SERVER_BINARY}
 
@@ -380,7 +380,7 @@ build_web_test_server_prod:
 	@echo "building web server binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${TEST_SERVER_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/webtest/
 

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ init:
 build: init
 	@echo "building scheduler binary"
 	go build -o=${DEV_BIN_DIR}/${BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	./pkg/cmd/shim/
 	@chmod +x ${DEV_BIN_DIR}/${BINARY}
 
@@ -234,7 +234,7 @@ build: init
 build_plugin: init
 	@echo "building scheduler plugin binary"
 	go build -o=${DEV_BIN_DIR}/${PLUGIN_BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	./pkg/cmd/schedulerplugin/
 	@chmod +x ${DEV_BIN_DIR}/${PLUGIN_BINARY}
 
@@ -244,7 +244,7 @@ scheduler: init
 	@echo "building binary for scheduler docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/shim/
 
@@ -254,7 +254,7 @@ plugin: init
 	@echo "building binary for plugin docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${PLUGIN_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/schedulerplugin/
 	

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ init:
 build: init
 	@echo "building scheduler binary"
 	go build -o=${DEV_BIN_DIR}/${BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	./pkg/cmd/shim/
 	@chmod +x ${DEV_BIN_DIR}/${BINARY}
 
@@ -234,7 +234,7 @@ build: init
 build_plugin: init
 	@echo "building scheduler plugin binary"
 	go build -o=${DEV_BIN_DIR}/${PLUGIN_BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
 	./pkg/cmd/schedulerplugin/
 	@chmod +x ${DEV_BIN_DIR}/${PLUGIN_BINARY}
 

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ init:
 build: init
 	@echo "building scheduler binary"
 	go build -o=${DEV_BIN_DIR}/${BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
 	./pkg/cmd/shim/
 	@chmod +x ${DEV_BIN_DIR}/${BINARY}
 
@@ -234,7 +234,7 @@ build: init
 build_plugin: init
 	@echo "building scheduler plugin binary"
 	go build -o=${DEV_BIN_DIR}/${PLUGIN_BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
 	./pkg/cmd/schedulerplugin/
 	@chmod +x ${DEV_BIN_DIR}/${PLUGIN_BINARY}
 
@@ -244,7 +244,7 @@ scheduler: init
 	@echo "building binary for scheduler docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/shim/
 
@@ -254,7 +254,7 @@ plugin: init
 	@echo "building binary for plugin docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${PLUGIN_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/schedulerplugin/
 	
@@ -302,7 +302,7 @@ admission: init
 	@echo "building admission controller binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${ADMISSION_CONTROLLER_BIN_DIR}/${POD_ADMISSION_CONTROLLER_BINARY} -ldflags \
-    '-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
+    '-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
     -tags netgo -installsuffix netgo \
     ./pkg/cmd/admissioncontroller
 
@@ -328,7 +328,7 @@ simulation:
 	@echo "building gang web client binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${GANG_BIN_DIR}/${GANG_CLIENT_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/simulation/gang/gangclient
 	@echo "building gang web server binary"
@@ -371,7 +371,7 @@ webtest_image: build_web_test_server_prod
 build_web_test_server_dev:
 	@echo "building local web server binary"
 	go build -o=${DEV_BIN_DIR}/${TEST_SERVER_BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
+	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
 	./pkg/cmd/webtest/
 	@chmod +x ${DEV_BIN_DIR}/${TEST_SERVER_BINARY}
 
@@ -380,7 +380,7 @@ build_web_test_server_prod:
 	@echo "building web server binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${TEST_SERVER_BINARY} -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION}' \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/webtest/
 

--- a/pkg/cmd/schedulerplugin/main.go
+++ b/pkg/cmd/schedulerplugin/main.go
@@ -19,13 +19,11 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 
 	"github.com/apache/yunikorn-k8shim/pkg/conf"
-	"github.com/apache/yunikorn-k8shim/pkg/log"
 	"github.com/apache/yunikorn-k8shim/pkg/schedulerplugin"
 )
 
@@ -43,12 +41,11 @@ func main() {
 	conf.BuildVersion = version
 	conf.BuildDate = date
 	conf.IsPluginVersion = true
+	conf.GoVersion = goVersion
 	conf.DockerArch = dockerArch
 	conf.CoreSHA = coreSHA
 	conf.SiSHA = siSHA
 	conf.ShimSHA = shimSHA
-
-	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s dockerArch=%s coreSHA=%s siSHA=%s shimSHA=%s", version, date, false, goVersion, dockerArch, coreSHA, siSHA, shimSHA))
 
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(schedulerplugin.SchedulerPluginName, schedulerplugin.NewSchedulerPlugin))

--- a/pkg/cmd/schedulerplugin/main.go
+++ b/pkg/cmd/schedulerplugin/main.go
@@ -33,14 +33,16 @@ var (
 	version string
 	date    string
 	goVersion string
+	dockerArch string
 )
 
 func main() {
 	conf.BuildVersion = version
 	conf.BuildDate = date
 	conf.IsPluginVersion = true
+	conf.DockerArch = dockerArch
 
-	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date), zap.Bool("isPluginVersion", true), zap.String("goVersion", goVersion))
+	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date), zap.Bool("isPluginVersion", true), zap.String("goVersion", goVersion), zap.String("dockerArch", dockerArch))
 
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(schedulerplugin.SchedulerPluginName, schedulerplugin.NewSchedulerPlugin))

--- a/pkg/cmd/schedulerplugin/main.go
+++ b/pkg/cmd/schedulerplugin/main.go
@@ -19,7 +19,7 @@
 package main
 
 import (
-	"go.uber.org/zap"
+	"fmt"
 	"os"
 
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
@@ -34,6 +34,9 @@ var (
 	date    string
 	goVersion string
 	dockerArch string
+	coreSHA string
+	siSHA string
+	shimSHA string
 )
 
 func main() {
@@ -41,8 +44,11 @@ func main() {
 	conf.BuildDate = date
 	conf.IsPluginVersion = true
 	conf.DockerArch = dockerArch
+	conf.CoreSHA = coreSHA
+	conf.SiSHA = siSHA
+	conf.ShimSHA = shimSHA
 
-	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date), zap.Bool("isPluginVersion", true), zap.String("goVersion", goVersion), zap.String("dockerArch", dockerArch))
+	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s dockerArch=%s coreSHA=%s siSHA=%s shimSHA=%s", version, date, false, goVersion, dockerArch, coreSHA, siSHA, shimSHA))
 
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(schedulerplugin.SchedulerPluginName, schedulerplugin.NewSchedulerPlugin))

--- a/pkg/cmd/schedulerplugin/main.go
+++ b/pkg/cmd/schedulerplugin/main.go
@@ -28,13 +28,13 @@ import (
 )
 
 var (
-	version string
-	date    string
-	goVersion string
+	version    string
+	date       string
+	goVersion  string
 	dockerArch string
-	coreSHA string
-	siSHA string
-	shimSHA string
+	coreSHA    string
+	siSHA      string
+	shimSHA    string
 )
 
 func main() {

--- a/pkg/cmd/schedulerplugin/main.go
+++ b/pkg/cmd/schedulerplugin/main.go
@@ -28,13 +28,13 @@ import (
 )
 
 var (
-	version    string
-	date       string
-	goVersion  string
-	dockerArch string
-	coreSHA    string
-	siSHA      string
-	shimSHA    string
+	version   string
+	date      string
+	goVersion string
+	arch      string
+	coreSHA   string
+	siSHA     string
+	shimSHA   string
 )
 
 func main() {
@@ -42,7 +42,7 @@ func main() {
 	conf.BuildDate = date
 	conf.IsPluginVersion = true
 	conf.GoVersion = goVersion
-	conf.DockerArch = dockerArch
+	conf.Arch = arch
 	conf.CoreSHA = coreSHA
 	conf.SiSHA = siSHA
 	conf.ShimSHA = shimSHA

--- a/pkg/cmd/schedulerplugin/main.go
+++ b/pkg/cmd/schedulerplugin/main.go
@@ -19,23 +19,28 @@
 package main
 
 import (
+	"go.uber.org/zap"
 	"os"
 
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 
 	"github.com/apache/yunikorn-k8shim/pkg/conf"
+	"github.com/apache/yunikorn-k8shim/pkg/log"
 	"github.com/apache/yunikorn-k8shim/pkg/schedulerplugin"
 )
 
 var (
 	version string
 	date    string
+	goVersion string
 )
 
 func main() {
 	conf.BuildVersion = version
 	conf.BuildDate = date
 	conf.IsPluginVersion = true
+
+	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date), zap.Bool("isPluginVersion", true), zap.String("goVersion", goVersion))
 
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(schedulerplugin.SchedulerPluginName, schedulerplugin.NewSchedulerPlugin))

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -36,13 +36,13 @@ import (
 )
 
 var (
-	version string
-	date    string
-	goVersion string
+	version    string
+	date       string
+	goVersion  string
 	dockerArch string
-	coreSHA string
-	siSHA string
-	shimSHA string
+	coreSHA    string
+	siSHA      string
+	shimSHA    string
 )
 
 func main() {

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -37,14 +37,16 @@ import (
 var (
 	version string
 	date    string
+	goVersion string
 )
 
 func main() {
 	conf.BuildVersion = version
 	conf.BuildDate = date
 	conf.IsPluginVersion = false
+	conf.GoVersion = goVersion
 
-	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date))
+	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date), zap.Bool("isPluginVersion", false), zap.String("goVersion", goVersion))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -39,6 +40,9 @@ var (
 	date    string
 	goVersion string
 	dockerArch string
+	coreSHA string
+	siSHA string
+	shimSHA string
 )
 
 func main() {
@@ -47,8 +51,11 @@ func main() {
 	conf.IsPluginVersion = false
 	conf.GoVersion = goVersion
 	conf.DockerArch = dockerArch
+	conf.CoreSHA = coreSHA
+	conf.SiSHA = siSHA
+	conf.ShimSHA = shimSHA
 
-	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date), zap.Bool("isPluginVersion", false), zap.String("goVersion", goVersion), zap.String("dockerArch", dockerArch))
+	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s dockerArch=%s coreSHA=%s siSHA=%s shimSHA=%s", version, date, false, goVersion, dockerArch, coreSHA, siSHA, shimSHA))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -36,13 +36,13 @@ import (
 )
 
 var (
-	version    string
-	date       string
-	goVersion  string
-	dockerArch string
-	coreSHA    string
-	siSHA      string
-	shimSHA    string
+	version   string
+	date      string
+	goVersion string
+	arch      string
+	coreSHA   string
+	siSHA     string
+	shimSHA   string
 )
 
 func main() {
@@ -50,12 +50,12 @@ func main() {
 	conf.BuildDate = date
 	conf.IsPluginVersion = false
 	conf.GoVersion = goVersion
-	conf.DockerArch = dockerArch
+	conf.Arch = arch
 	conf.CoreSHA = coreSHA
 	conf.SiSHA = siSHA
 	conf.ShimSHA = shimSHA
 
-	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s dockerArch=%s coreSHA=%s siSHA=%s shimSHA=%s", version, date, false, goVersion, dockerArch, coreSHA, siSHA, shimSHA))
+	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s arch=%s coreSHA=%s siSHA=%s shimSHA=%s", version, date, false, goVersion, arch, coreSHA, siSHA, shimSHA))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -38,6 +38,7 @@ var (
 	version string
 	date    string
 	goVersion string
+	dockerArch string
 )
 
 func main() {
@@ -45,8 +46,9 @@ func main() {
 	conf.BuildDate = date
 	conf.IsPluginVersion = false
 	conf.GoVersion = goVersion
+	conf.DockerArch = dockerArch
 
-	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date), zap.Bool("isPluginVersion", false), zap.String("goVersion", goVersion))
+	log.Logger().Info("Build info", zap.String("version", version), zap.String("date", date), zap.Bool("isPluginVersion", false), zap.String("goVersion", goVersion), zap.String("dockerArch", dockerArch))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -93,6 +93,7 @@ var (
 	BuildVersion    string
 	BuildDate       string
 	IsPluginVersion bool
+	GoVersion       string
 )
 
 var once sync.Once

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -94,7 +94,7 @@ var (
 	BuildDate       string
 	IsPluginVersion bool
 	GoVersion       string
-	DockerArch      string
+	Arch            string
 	CoreSHA         string
 	SiSHA           string
 	ShimSHA         string

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -95,9 +95,9 @@ var (
 	IsPluginVersion bool
 	GoVersion       string
 	DockerArch      string
-	CoreSHA 		string
-	SiSHA 			string
-	ShimSHA 		string
+	CoreSHA         string
+	SiSHA           string
+	ShimSHA         string
 )
 
 var once sync.Once

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -94,6 +94,7 @@ var (
 	BuildDate       string
 	IsPluginVersion bool
 	GoVersion       string
+	DockerArch      string
 )
 
 var once sync.Once

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -95,6 +95,9 @@ var (
 	IsPluginVersion bool
 	GoVersion       string
 	DockerArch      string
+	CoreSHA 		string
+	SiSHA 			string
+	ShimSHA 		string
 )
 
 var once sync.Once

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -216,7 +216,7 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 
 // NewSchedulerPlugin initializes a new plugin and returns it
 func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
-	log.Logger().Info("Build info", zap.String("version", conf.BuildVersion), zap.String("date", conf.BuildDate), zap.String("goVersion", conf.GoVersion), zap.String("dockerArch", conf.DockerArch))
+	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s dockerArch=%s coreSHA=%s siSHA=%s shimSHA=%s", conf.BuildVersion, conf.BuildDate, conf.IsPluginVersion, conf.GoVersion, conf.DockerArch, conf.CoreSHA, conf.SiSHA, conf.ShimSHA))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -216,7 +216,7 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 
 // NewSchedulerPlugin initializes a new plugin and returns it
 func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
-	log.Logger().Info("Build info", zap.String("version", conf.BuildVersion), zap.String("date", conf.BuildDate))
+	log.Logger().Info("Build info", zap.String("version", conf.BuildVersion), zap.String("date", conf.BuildDate), zap.String("goVersion", conf.GoVersion))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -216,7 +216,7 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 
 // NewSchedulerPlugin initializes a new plugin and returns it
 func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
-	log.Logger().Info("Build info", zap.String("version", conf.BuildVersion), zap.String("date", conf.BuildDate), zap.String("goVersion", conf.GoVersion))
+	log.Logger().Info("Build info", zap.String("version", conf.BuildVersion), zap.String("date", conf.BuildDate), zap.String("goVersion", conf.GoVersion), zap.String("dockerArch", conf.DockerArch))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -216,7 +216,7 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 
 // NewSchedulerPlugin initializes a new plugin and returns it
 func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
-	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s dockerArch=%s coreSHA=%s siSHA=%s shimSHA=%s", conf.BuildVersion, conf.BuildDate, conf.IsPluginVersion, conf.GoVersion, conf.DockerArch, conf.CoreSHA, conf.SiSHA, conf.ShimSHA))
+	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s arch=%s coreSHA=%s siSHA=%s shimSHA=%s", conf.BuildVersion, conf.BuildDate, conf.IsPluginVersion, conf.GoVersion, conf.Arch, conf.CoreSHA, conf.SiSHA, conf.ShimSHA))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -216,6 +216,7 @@ func (ss *KubernetesShim) registerShimLayer() error {
 	buildInfoMap["buildDate"] = conf.BuildDate
 	buildInfoMap["isPluginVersion"] = strconv.FormatBool(conf.IsPluginVersion)
 	buildInfoMap["goVersion"] = conf.GoVersion
+	buildInfoMap["dockerArch"] = conf.DockerArch
 
 	configMaps, err := ss.context.LoadConfigMaps()
 	if err != nil {

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -215,6 +215,7 @@ func (ss *KubernetesShim) registerShimLayer() error {
 	buildInfoMap["buildVersion"] = conf.BuildVersion
 	buildInfoMap["buildDate"] = conf.BuildDate
 	buildInfoMap["isPluginVersion"] = strconv.FormatBool(conf.IsPluginVersion)
+	buildInfoMap["goVersion"] = conf.GoVersion
 
 	configMaps, err := ss.context.LoadConfigMaps()
 	if err != nil {

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -216,7 +216,7 @@ func (ss *KubernetesShim) registerShimLayer() error {
 	buildInfoMap["buildDate"] = conf.BuildDate
 	buildInfoMap["isPluginVersion"] = strconv.FormatBool(conf.IsPluginVersion)
 	buildInfoMap["goVersion"] = conf.GoVersion
-	buildInfoMap["dockerArch"] = conf.DockerArch
+	buildInfoMap["arch"] = conf.Arch
 	buildInfoMap["coreSHA"] = conf.CoreSHA
 	buildInfoMap["siSHA"] = conf.SiSHA
 	buildInfoMap["shimSHA"] = conf.ShimSHA

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -217,6 +217,9 @@ func (ss *KubernetesShim) registerShimLayer() error {
 	buildInfoMap["isPluginVersion"] = strconv.FormatBool(conf.IsPluginVersion)
 	buildInfoMap["goVersion"] = conf.GoVersion
 	buildInfoMap["dockerArch"] = conf.DockerArch
+	buildInfoMap["coreSHA"] = conf.CoreSHA
+	buildInfoMap["siSHA"] = conf.SiSHA
+	buildInfoMap["shimSHA"] = conf.ShimSHA
 
 	configMaps, err := ss.context.LoadConfigMaps()
 	if err != nil {


### PR DESCRIPTION
### What is this PR for?

- scheduler plugin and scheduler added goVersion, dockerArch, coreSHA, siSHA, shimSHA in BuildInfo.
- `-X main` add for others:
`-X main.goVersion=${GO_VERSION} -X main.dockerArch=${DOCKER_ARCH}`

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1683

### How should this be tested?
http://localhost:9080/ws/v1/clusters
```
[
   {
      "startTime":1682841368688533200,
      "rmBuildInformation":[
         {
            "buildDate":"2023-04-30T15:24:58+0800",
            "buildVersion":"latest",
            "coreSHA":"5a92a28c8aab",
            "dockerArch":"amd64",
            "goVersion":"1.20.3",
            "isPluginVersion":"true",
            "rmId":"mycluster",
            "shimSHA":"6d22cd208b1a",
            "siSHA":"b29b20a234e0"
         }
      ],
      "partition":"default",
      "clusterName":"kubernetes"
   }
]
```
### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
