### PR TITLE
[YUNIKORN-1708] Filtered owner references for placeholder pods.

### DIFF
--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -105,15 +105,7 @@ func isStateAwareDisabled(pod *v1.Pod) bool {
 }
 
 func getOwnerReference(pod *v1.Pod) []metav1.OwnerReference {
-	if len(pod.OwnerReferences) > 0 {
-		// Filter the pod kind owner reference
-		// keep this because we need to find the original pod
-		for _, ref := range pod.OwnerReferences {
-			if ref.Kind == reflect.TypeOf(v1.Pod{}).Name() {
-				return []metav1.OwnerReference{ref}
-			}
-		}
-	}
+	// Just return the originator pod as the owner of placeholder pods
 	controller := false
 	blockOwnerDeletion := true
 	ref := metav1.OwnerReference{

--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -19,7 +19,6 @@
 package general
 
 import (
-	"reflect"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -109,8 +108,8 @@ func getOwnerReference(pod *v1.Pod) []metav1.OwnerReference {
 	controller := false
 	blockOwnerDeletion := true
 	ref := metav1.OwnerReference{
-		APIVersion:         v1.SchemeGroupVersion.String(),
-		Kind:               reflect.TypeOf(v1.Pod{}).Name(),
+		APIVersion:         "v1",
+		Kind:               "Pod",
 		Name:               pod.Name,
 		UID:                pod.UID,
 		Controller:         &controller,

--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -104,9 +104,15 @@ func isStateAwareDisabled(pod *v1.Pod) bool {
 	return result
 }
 
-func getOwnerReferences(pod *v1.Pod) []metav1.OwnerReference {
+func getOwnerReference(pod *v1.Pod) []metav1.OwnerReference {
 	if len(pod.OwnerReferences) > 0 {
-		return pod.OwnerReferences
+		// Filter the pod kind owner reference
+		// keep this because we need to find the original pod
+		for _, ref := range pod.OwnerReferences {
+			if ref.Kind == reflect.TypeOf(v1.Pod{}).Name() {
+				return []metav1.OwnerReference{ref}
+			}
+		}
 	}
 	controller := false
 	blockOwnerDeletion := true

--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -167,6 +167,7 @@ func TestOriginatorPod(t *testing.T) {
 	owner := apis.OwnerReference{
 		APIVersion: "v1",
 		UID:        "UID-POD-00002",
+		Kind:       "Pod",
 	}
 	refer := []apis.OwnerReference{
 		owner,
@@ -448,16 +449,33 @@ func TestGetOwnerReferences(t *testing.T) {
 			UID:  "uid",
 		},
 	}
-	returnedOwnerRefs := getOwnerReferences(podWithOwnerRef)
-	assert.Assert(t, len(returnedOwnerRefs) == 1, "Only one owner reference is expected")
-	assert.DeepEqual(t, ownerRef, returnedOwnerRefs[0])
 
-	returnedOwnerRefs = getOwnerReferences(podWithNoOwnerRef)
+	returnedOwnerRefs := getOwnerReference(podWithOwnerRef)
+	assert.Assert(t, len(returnedOwnerRefs) == 1, "Only one owner reference is expected")
+	assert.Equal(t, returnedOwnerRefs[0].Name, podWithOwnerRef.Name, "Unexpected owner reference name")
+	assert.Equal(t, returnedOwnerRefs[0].UID, podWithOwnerRef.UID, "Unexpected owner reference UID")
+	assert.Equal(t, returnedOwnerRefs[0].Kind, "Pod", "Unexpected owner reference Kind")
+	assert.Equal(t, returnedOwnerRefs[0].APIVersion, v1.SchemeGroupVersion.String(), "Unexpected owner reference Kind")
+
+	returnedOwnerRefs = getOwnerReference(podWithNoOwnerRef)
 	assert.Assert(t, len(returnedOwnerRefs) == 1, "Only one owner reference is expected")
 	assert.Equal(t, returnedOwnerRefs[0].Name, podWithNoOwnerRef.Name, "Unexpected owner reference name")
 	assert.Equal(t, returnedOwnerRefs[0].UID, podWithNoOwnerRef.UID, "Unexpected owner reference UID")
 	assert.Equal(t, returnedOwnerRefs[0].Kind, "Pod", "Unexpected owner reference Kind")
 	assert.Equal(t, returnedOwnerRefs[0].APIVersion, v1.SchemeGroupVersion.String(), "Unexpected owner reference Kind")
+
+	// Set pod with owner reference and kind is pod
+	ownerRef.Kind = "Pod"
+	podWithOwnerRef = &v1.Pod{
+		ObjectMeta: apis.ObjectMeta{
+			OwnerReferences: []apis.OwnerReference{ownerRef},
+		},
+	}
+
+	returnedOwnerRefs = getOwnerReference(podWithOwnerRef)
+	returnedOwnerRefs = getOwnerReference(podWithOwnerRef)
+	assert.Assert(t, len(returnedOwnerRefs) == 1, "Only one owner reference is expected")
+	assert.DeepEqual(t, ownerRef, returnedOwnerRefs[0])
 }
 
 type Template struct {

--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -169,6 +169,7 @@ func TestOriginatorPod(t *testing.T) {
 		UID:        "UID-POD-00002",
 		Kind:       "Pod",
 	}
+
 	refer := []apis.OwnerReference{
 		owner,
 	}
@@ -209,10 +210,12 @@ func TestOriginatorPod(t *testing.T) {
 	}
 	am.AddPod(&pod1)
 	assert.Equal(t, len(app.GetNewTasks()), 2)
-	task, err = app.GetTask("UID-POD-00002")
+	task, err = app.GetTask("UID-POD-00001")
 	assert.Assert(t, err == nil)
 
-	// app originator task should be pod 2
+	// app originator task should be pod 1
+	// even the pod 2 is the ownerreference for pod 1
+	// And pod 1 is first added to the AM service
 	assert.Equal(t, app.GetOriginatingTask().GetTaskID(), task.GetTaskID())
 }
 
@@ -463,18 +466,6 @@ func TestGetOwnerReferences(t *testing.T) {
 	assert.Equal(t, returnedOwnerRefs[0].UID, podWithNoOwnerRef.UID, "Unexpected owner reference UID")
 	assert.Equal(t, returnedOwnerRefs[0].Kind, "Pod", "Unexpected owner reference Kind")
 	assert.Equal(t, returnedOwnerRefs[0].APIVersion, v1.SchemeGroupVersion.String(), "Unexpected owner reference Kind")
-
-	// Set pod with owner reference and kind is pod
-	ownerRef.Kind = "Pod"
-	podWithOwnerRef = &v1.Pod{
-		ObjectMeta: apis.ObjectMeta{
-			OwnerReferences: []apis.OwnerReference{ownerRef},
-		},
-	}
-
-	returnedOwnerRefs = getOwnerReference(podWithOwnerRef)
-	assert.Assert(t, len(returnedOwnerRefs) == 1, "Only one owner reference is expected")
-	assert.DeepEqual(t, ownerRef, returnedOwnerRefs[0])
 }
 
 type Template struct {

--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -473,7 +473,6 @@ func TestGetOwnerReferences(t *testing.T) {
 	}
 
 	returnedOwnerRefs = getOwnerReference(podWithOwnerRef)
-	returnedOwnerRefs = getOwnerReference(podWithOwnerRef)
 	assert.Assert(t, len(returnedOwnerRefs) == 1, "Only one owner reference is expected")
 	assert.DeepEqual(t, ownerRef, returnedOwnerRefs[0])
 }

--- a/pkg/appmgmt/general/metadata.go
+++ b/pkg/appmgmt/general/metadata.go
@@ -110,7 +110,7 @@ func getAppMetadata(pod *v1.Pod, recovery bool) (interfaces.ApplicationMetadata,
 		tags[constants.AnnotationTaskGroups] = pod.Annotations[constants.AnnotationTaskGroups]
 	}
 
-	ownerReferences := getOwnerReferences(pod)
+	ownerReferences := getOwnerReference(pod)
 	schedulingPolicyParams := utils.GetSchedulingPolicyParam(pod)
 	tags[constants.AnnotationSchedulingPolicyParam] = pod.Annotations[constants.AnnotationSchedulingPolicyParam]
 

--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -48,16 +48,8 @@ type Placeholder struct {
 }
 
 func newPlaceholder(placeholderName string, app *Application, taskGroup v1alpha1.TaskGroup) *Placeholder {
+	// Here the owner reference is always the originator pod
 	ownerRefs := app.getPlaceholderOwnerReferences()
-	// we need to set the controller field to false, because since we don't know what exactly the controller will do,
-	// we might have some unexpected behaviour.
-	// For example if it is a replication controller, some pods (placeholders and/or real pods) might be deleted
-	// in order to meet the requested replication factor.
-	// Since we need the owner reference only for having the placeholders garbage collected,
-	// we can just set the controller field = false, so we can avoid any kind of side effects.
-	for _, r := range ownerRefs {
-		*r.Controller = false
-	}
 	annotations := utils.MergeMaps(taskGroup.Annotations, map[string]string{
 		constants.AnnotationPlaceholderFlag: "true",
 		constants.AnnotationTaskGroupName:   taskGroup.Name,

--- a/pkg/cache/placeholder_manager_test.go
+++ b/pkg/cache/placeholder_manager_test.go
@@ -118,7 +118,6 @@ func TestCreateAppPlaceholdersWithOwnReference(t *testing.T) {
 	pods := createAndCheckPlaceholderCreate(mockedAPIProvider, app, t)
 	for _, pod := range pods {
 		assert.Assert(t, len(pod.OwnerReferences) == 1, "The pod should have exactly one owner reference set")
-		assert.Assert(t, *pod.OwnerReferences[0].Controller == false, "The owner reference should not be a controller")
 		assert.Equal(t, pod.OwnerReferences[0].Name, ownRef.Name, "The owner reference name does not match")
 		assert.Equal(t, pod.OwnerReferences[0].UID, ownRef.UID, "The owner reference UID does not match")
 	}

--- a/test/e2e/framework/helpers/k8s/pod_conf.go
+++ b/test/e2e/framework/helpers/k8s/pod_conf.go
@@ -90,11 +90,6 @@ func InitSleepPod(conf SleepPodConfig) (*v1.Pod, error) {
 		}
 	}
 
-	if conf.UID != "" {
-		owner := metav1.OwnerReference{APIVersion: "v1", Kind: "ReplicaSet", Name: "ReplicaSetJob", UID: conf.UID}
-		owners = []metav1.OwnerReference{owner}
-	}
-
 	optedOut := "true"
 	if !conf.Optedout {
 		optedOut = "false"

--- a/test/e2e/simple_preemptor/simple_preemptor_test.go
+++ b/test/e2e/simple_preemptor/simple_preemptor_test.go
@@ -22,16 +22,17 @@ import (
 	"fmt"
 	"strings"
 
-	tests "github.com/apache/yunikorn-k8shim/test/e2e"
-	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/common"
-	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/k8s"
-	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/yunikorn"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tests "github.com/apache/yunikorn-k8shim/test/e2e"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/common"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/k8s"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/yunikorn"
 )
 
 var kClient k8s.KubeCtl

--- a/test/e2e/simple_preemptor/simple_preemptor_test.go
+++ b/test/e2e/simple_preemptor/simple_preemptor_test.go
@@ -22,18 +22,16 @@ import (
 	"fmt"
 	"strings"
 
+	tests "github.com/apache/yunikorn-k8shim/test/e2e"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/common"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/k8s"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/yunikorn"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-
-	tests "github.com/apache/yunikorn-k8shim/test/e2e"
-	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/common"
-	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/k8s"
-	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/yunikorn"
 )
 
 var kClient k8s.KubeCtl
@@ -182,10 +180,10 @@ var _ = ginkgo.Describe("SimplePreemptor", func() {
 		// Define sleepPod
 		sleepPodConfigs := k8s.SleepPodConfig{Name: "sleepjob", NS: dev, Mem: sleepPodMemLimit1, Time: 600, RequiredNode: Worker1}
 		sleepPod2Configs := k8s.SleepPodConfig{Name: "sleepjob2", NS: dev, Mem: sleepPodMemLimit1, Time: 600, RequiredNode: Worker1}
-		sleepPod3Configs := k8s.SleepPodConfig{Name: "sleepjob3", NS: dev, Mem: sleepPodMemLimit1, Time: 600, RequiredNode: Worker1}
+		sleepPod3Configs := k8s.SleepPodConfig{Name: "sleepjob3", NS: dev, Mem: sleepPodMemLimit1, Time: 600, RequiredNode: Worker1, AppID: "test01"}
 
-		// random uid in pod spec to ensure this Non-opted pod doesn't become originator
-		sleepPod4Configs := k8s.SleepPodConfig{Name: "sleepjob4", NS: dev, Mem: sleepPodMemLimit2, Time: 600, Optedout: true, UID: types.UID("ddd")}
+		// add the same AppID to sleepPod3Configs so that sleepPod4Configs is not the originator pod
+		sleepPod4Configs := k8s.SleepPodConfig{Name: "sleepjob4", NS: dev, Mem: sleepPodMemLimit2, Time: 600, Optedout: true, AppID: "test01"}
 		sleepPod5Configs := k8s.SleepPodConfig{Name: "sleepjob5", NS: dev, Mem: sleepPodMemLimit2, Time: 600, Optedout: false}
 		sleepPod6Configs := k8s.SleepPodConfig{Name: "sleepjob6", NS: dev, Mem: sleepPodMemLimit2, Time: 600, Optedout: false}
 		sleepPod7Configs := k8s.SleepPodConfig{Name: "sleepjob7", NS: dev, Mem: sleepPodMemLimit2, Time: 600, RequiredNode: Worker2}
@@ -218,7 +216,7 @@ var _ = ginkgo.Describe("SimplePreemptor", func() {
 			600)
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
 
-		// assert sleeppod6 is killed
+		// assert sleeppod4 is killed
 		err = kClient.WaitForPodEvent(dev, "sleepjob4", "Killing", 1200)
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
### What is this PR for?
In AWS EMR on EKS service, the driver real pod's ownerReference is configmap.
And placeholder's ownerReference is also the driver configmap.

When user cancels emr-containers job, the job-submitter is terminated,
but the placeholder still remains in pending state.
https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/emr-eks.html


Make sure configmap owner reference is not returned for pod, it will return the real driver pod itself
because when the placeholder pod set ownerreference to configmap, the configmap will not be deleted for placeholder pod
to GC, we need set the placeholder pod's ownerreference to the real driver pod, when the real driver pod is deleted, the
placeholder will be deleted as well.

The placeholders should really only have one owner: the pod that triggered the creation nothing else.

The placeholder manager should just default to generate just that one.


### What type of PR is it?
* [x] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1708
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
