### PR TITLE
[YUNIKORN-1723] Remove string comparison from hasReadyCondition() function

### DIFF
--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -217,7 +217,7 @@ func (nc *schedulerNodes) schedulerNodeEventHandler() func(obj interface{}) {
 }
 
 func hasReadyCondition(node *v1.Node) bool {
-	if node != nil && node.Status.String() != "nil" {
+	if node != nil {
 		for _, condition := range node.Status.Conditions {
 			if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
 				return true


### PR DESCRIPTION
### What is this PR for?
Remove the comparison `NodeStatus.String()` against `nil`. It's unnecessary and expensive.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1723

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
