### PR TITLE
[YUNIKORN-1732] Fix Makefile calculation of SHA hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ DOCKER_ARCH := amd64
 endif
 
 # Image hashes
-CORE_SHA=$(shell go list -m "github.com/apache/yunikorn-core" | cut -d " " -f2 | cut -d "-" -f3)
-SI_SHA=$(shell go list -m "github.com/apache/yunikorn-scheduler-interface" | cut -d " " -f2 | cut -d "-" -f3)
+CORE_SHA=$(shell go list -f '{{.Version}}' -m "github.com/apache/yunikorn-core" | cut -d "-" -f3)
+SI_SHA=$(shell go list -f '{{.Version}}' -m "github.com/apache/yunikorn-scheduler-interface" | cut -d "-" -f3)
 SHIM_SHA=$(shell git rev-parse --short=12 HEAD)
 
 # Kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ DOCKER_ARCH := amd64
 endif
 
 # Image hashes
-CORE_SHA=$(shell go list -m "github.com/apache/yunikorn-core" | cut -d "-" -f4)
-SI_SHA=$(shell go list -m "github.com/apache/yunikorn-scheduler-interface" | cut -d "-" -f5)
+CORE_SHA=$(shell go list -m "github.com/apache/yunikorn-core" | cut -d " " -f2 | cut -d "-" -f3)
+SI_SHA=$(shell go list -m "github.com/apache/yunikorn-scheduler-interface" | cut -d " " -f2 | cut -d "-" -f3)
 SHIM_SHA=$(shell git rev-parse --short=12 HEAD)
 
 # Kubeconfig


### PR DESCRIPTION
### What is this PR for?
Fix the Makefile's calculation of SHA hashes for build components. The scripts used are brittle and fail if the output of `go list -m` doesn't fit the expected pattern (especially when replacing local dependencies).

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1732

### How should this be tested?
Build now succeeds where it failed previously and generates proper hashes.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
