### PR TITLE
[YUNIKORN-1745] Add implementation to MockedAPIProvider.AddEventHandler()

### DIFF
--- a/pkg/appmgmt/appmgmt.go
+++ b/pkg/appmgmt/appmgmt.go
@@ -67,6 +67,9 @@ func NewAMService(amProtocol interfaces.ApplicationManagementProtocol,
 			sparkoperator.NewManager(amProtocol, apiProvider),
 			// for application crds
 			application.NewAppManager(amProtocol, apiProvider))
+	} else {
+		podEventHandler = general.NewPodEventHandler(amProtocol, false)
+		appManager.register(general.NewManager(apiProvider, podEventHandler))
 	}
 
 	return appManager

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
@@ -33,10 +34,13 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/client/informers/externalversions/yunikorn.apache.org/v1alpha1"
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/yunikorn-k8shim/pkg/conf"
+	"github.com/apache/yunikorn-k8shim/pkg/log"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/api"
 )
 
 type Type int
+
+var informerTypes = [...]string{"Pod", "Node", "ConfigMap", "Storage", "PV", "PVC", "Application", "PriorityClass"}
 
 const (
 	PodInformerHandlers Type = iota
@@ -48,6 +52,10 @@ const (
 	ApplicationInformerHandlers
 	PriorityClassInformerHandlers
 )
+
+func (t Type) String() string {
+	return informerTypes[t]
+}
 
 type APIProvider interface {
 	GetAPIs() *Clients
@@ -174,6 +182,7 @@ func (s *APIFactory) AddEventHandler(handlers *ResourceEventHandlers) {
 		h = fns
 	}
 
+	log.Logger().Info("registering event handler", zap.Stringer("type", handlers.Type))
 	s.addEventHandlers(handlers.Type, h, 0)
 }
 

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -75,6 +75,7 @@ func (fc *MockScheduler) init() {
 }
 
 func (fc *MockScheduler) start() {
+	fc.apiProvider.RunEventHandler() // must be called first
 	fc.scheduler.Run()
 }
 
@@ -231,4 +232,5 @@ func (fc *MockScheduler) waitAndVerifySchedulerAllocations(
 func (fc *MockScheduler) stop() {
 	close(fc.stopChan)
 	fc.scheduler.Stop()
+	fc.apiProvider.Stop()
 }


### PR DESCRIPTION
### What is this PR for?
Implement `MockedAPIProvider.AddEventHandler()` to register event handlers from the shim `Context`. This is useful for testing because we can simulate shared informers and can test the shim+core together as a whole without an active cluster.

This PR is part of a bigger effort YUNIKORN-1740.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1745

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
