### PR TITLE
[YUNIKORN-1750] remove sprintf from logging calls

### DIFF
--- a/pkg/admission/conf/am_conf.go
+++ b/pkg/admission/conf/am_conf.go
@@ -351,8 +351,8 @@ func parseConfigRegexps(config map[string]string, key string, defaultValue strin
 	value := parseConfigString(config, key, defaultValue)
 	result, err := parseRegexes(value)
 	if err != nil {
-		log.Logger().Error(fmt.Sprintf("Unable to parse regex values '%s' for configuration '%s', using default value '%s'",
-			value, key, defaultValue), zap.Error(err))
+		log.Logger().Error("Unable to parse regex values, using default",
+			zap.String("key", key), zap.String("value", value), zap.String("default", defaultValue), zap.Error(err))
 		result, err = parseRegexes(defaultValue)
 		if err != nil {
 			log.Logger().Fatal("BUG: can't parse default regex pattern", zap.Error(err))
@@ -365,8 +365,8 @@ func parseConfigBool(config map[string]string, key string, defaultValue bool) bo
 	value := parseConfigString(config, key, fmt.Sprintf("%t", defaultValue))
 	result, err := strconv.ParseBool(value)
 	if err != nil {
-		log.Logger().Error(fmt.Sprintf("Unable to parse bool value '%s' for configuration '%s', using default value '%t'",
-			value, key, defaultValue), zap.Error(err))
+		log.Logger().Error("Unable to parse bool value, using default",
+			zap.String("key", key), zap.String("value", value), zap.Bool("default", defaultValue), zap.Error(err))
 		result = defaultValue
 	}
 	return result
@@ -376,8 +376,8 @@ func parseConfigInt(config map[string]string, key string, defaultValue int) int 
 	value := parseConfigString(config, key, fmt.Sprintf("%d", defaultValue))
 	result, err := strconv.ParseInt(value, 10, 31)
 	if err != nil {
-		log.Logger().Error(fmt.Sprintf("Unable to parse int value '%s' for configuration '%s', using default value '%d'",
-			value, key, defaultValue), zap.Error(err))
+		log.Logger().Error("Unable to parse int value, using default",
+			zap.String("key", key), zap.String("value", value), zap.Int("default", defaultValue), zap.Error(err))
 		return defaultValue
 	}
 	return int(result)


### PR DESCRIPTION
### What is this PR for?

Don't use `fmt.Sprintf` in zap logging.

### What type of PR is it?
* [ ] - Bug Fix
* [X] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-1750

### How should this be tested?

1. Create the following ConfigMap:

```yaml
apiVersion: v1
data:
  log.level: "not int"
kind: ConfigMap
metadata:
  name: yunikorn-defaults
  namespace: yunikorn
```

2. Run admission webhook.
3. We should see the following error message:

```
Unable to parse int value, using default    {"key": "log.level", "value": "not int", "default": 0, "error": "strconv.ParseInt: parsing \"not int\": invalid syntax"}
```

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
