### PR TITLE
[YUNIKORN-1273] Add configurable option to have unique application ids in a namespace

### DIFF
--- a/pkg/admission/admission_controller_test.go
+++ b/pkg/admission/admission_controller_test.go
@@ -50,6 +50,7 @@ const (
 	validUserInfoAnnotation = "{\"user\":\"test\",\"groups\":[\"devops\",\"system:authenticated\"]}"
 )
 
+// nolint: funlen
 func TestUpdateLabels(t *testing.T) {
 	// verify when appId/queue are not given,
 	// we patch it correctly
@@ -73,7 +74,8 @@ func TestUpdateLabels(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	patch = updateLabels("default", pod, patch)
+	c := createAdmissionControllerForTest()
+	patch = c.updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -83,7 +85,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, updatedMap["random"], "random")
 		assert.Equal(t, updatedMap["queue"], "root.default")
 		assert.Equal(t, updatedMap["disableStateAware"], "true")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], constants.AutoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -110,7 +112,7 @@ func TestUpdateLabels(t *testing.T) {
 		Spec:   v1.PodSpec{},
 		Status: v1.PodStatus{},
 	}
-	patch = updateLabels("default", pod, patch)
+	patch = c.updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -147,7 +149,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	patch = updateLabels("default", pod, patch)
+	patch = c.updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -157,7 +159,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, updatedMap["random"], "random")
 		assert.Equal(t, updatedMap["queue"], "root.abc")
 		assert.Equal(t, updatedMap["disableStateAware"], "true")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], constants.AutoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -180,7 +182,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	patch = updateLabels("default", pod, patch)
+	patch = c.updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -189,7 +191,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, len(updatedMap), 3)
 		assert.Equal(t, updatedMap["queue"], "root.default")
 		assert.Equal(t, updatedMap["disableStateAware"], "true")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], constants.AutoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -209,7 +211,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	patch = updateLabels("default", pod, patch)
+	patch = c.updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -218,7 +220,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, len(updatedMap), 3)
 		assert.Equal(t, updatedMap["queue"], "root.default")
 		assert.Equal(t, updatedMap["disableStateAware"], "true")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], constants.AutoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -236,7 +238,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status:     v1.PodStatus{},
 	}
 
-	patch = updateLabels("default", pod, patch)
+	patch = c.updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -245,7 +247,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, len(updatedMap), 3)
 		assert.Equal(t, updatedMap["queue"], "root.default")
 		assert.Equal(t, updatedMap["disableStateAware"], "true")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], constants.AutoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -403,20 +405,6 @@ func errorResponseMock(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(500)
 	resp := `{}`
 	w.Write([]byte(resp)) //nolint:errcheck
-}
-
-func TestGenerateAppID(t *testing.T) {
-	appID := generateAppID("this-is-a-namespace")
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-this-is-a-namespace", autoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 36)
-
-	appID = generateAppID("short")
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-short", autoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 22)
-
-	appID = generateAppID(strings.Repeat("long", 100))
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-long", autoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 63)
 }
 
 func TestMutate(t *testing.T) {
@@ -988,4 +976,10 @@ func createNamespaceClassCacheForTest() *NamespaceCache {
 	return &NamespaceCache{
 		nameSpaces: make(map[string]nsFlags),
 	}
+}
+
+func createAdmissionControllerForTest() *AdmissionController {
+	pcCache := createPriorityClassCacheForTest()
+	nsCache := createNamespaceClassCacheForTest()
+	return InitAdmissionController(createConfig(), pcCache, nsCache)
 }

--- a/pkg/admission/conf/am_conf.go
+++ b/pkg/admission/conf/am_conf.go
@@ -48,10 +48,11 @@ const (
 	AMWebHookSchedulerServiceAddress = WebHookPrefix + "schedulerServiceAddress"
 
 	// filtering configuration
-	AMFilteringProcessNamespaces = FilteringPrefix + "processNamespaces"
-	AMFilteringBypassNamespaces  = FilteringPrefix + "bypassNamespaces"
-	AMFilteringLabelNamespaces   = FilteringPrefix + "labelNamespaces"
-	AMFilteringNoLabelNamespaces = FilteringPrefix + "noLabelNamespaces"
+	AMFilteringProcessNamespaces    = FilteringPrefix + "processNamespaces"
+	AMFilteringBypassNamespaces     = FilteringPrefix + "bypassNamespaces"
+	AMFilteringLabelNamespaces      = FilteringPrefix + "labelNamespaces"
+	AMFilteringNoLabelNamespaces    = FilteringPrefix + "noLabelNamespaces"
+	AMFilteringGenerateUniqueAppIds = FilteringPrefix + "generateUniqueAppId"
 
 	// access control configuration
 	AMAccessControlBypassAuth       = AccessControlPrefix + "bypassAuth"
@@ -67,10 +68,11 @@ const (
 	DefaultWebHookSchedulerServiceAddress = "yunikorn-service:9080"
 
 	// filtering defaults
-	DefaultFilteringProcessNamespaces = ""
-	DefaultFilteringBypassNamespaces  = "^kube-system$"
-	DefaultFilteringLabelNamespaces   = ""
-	DefaultFilteringNoLabelNamespaces = ""
+	DefaultFilteringProcessNamespaces    = ""
+	DefaultFilteringBypassNamespaces     = "^kube-system$"
+	DefaultFilteringLabelNamespaces      = ""
+	DefaultFilteringNoLabelNamespaces    = ""
+	DefaultFilteringGenerateUniqueAppIds = false
 
 	// access control defaults
 	DefaultAccessControlBypassAuth       = false
@@ -93,6 +95,7 @@ type AdmissionControllerConf struct {
 	bypassNamespaces        []*regexp.Regexp
 	labelNamespaces         []*regexp.Regexp
 	noLabelNamespaces       []*regexp.Regexp
+	generateUniqueAppIds    bool
 	bypassAuth              bool
 	trustControllers        bool
 	systemUsers             []*regexp.Regexp
@@ -174,6 +177,12 @@ func (acc *AdmissionControllerConf) GetNoLabelNamespaces() []*regexp.Regexp {
 	acc.lock.RLock()
 	defer acc.lock.RUnlock()
 	return acc.noLabelNamespaces
+}
+
+func (acc *AdmissionControllerConf) GetGenerateUniqueAppIds() bool {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.generateUniqueAppIds
 }
 
 func (acc *AdmissionControllerConf) GetBypassAuth() bool {
@@ -304,6 +313,7 @@ func (acc *AdmissionControllerConf) updateConfigMaps(configMaps []*v1.ConfigMap,
 	acc.bypassNamespaces = parseConfigRegexps(configs, AMFilteringBypassNamespaces, DefaultFilteringBypassNamespaces)
 	acc.labelNamespaces = parseConfigRegexps(configs, AMFilteringLabelNamespaces, DefaultFilteringLabelNamespaces)
 	acc.noLabelNamespaces = parseConfigRegexps(configs, AMFilteringNoLabelNamespaces, DefaultFilteringNoLabelNamespaces)
+	acc.generateUniqueAppIds = parseConfigBool(configs, AMFilteringGenerateUniqueAppIds, DefaultFilteringGenerateUniqueAppIds)
 
 	// access control
 	acc.bypassAuth = parseConfigBool(configs, AMAccessControlBypassAuth, DefaultAccessControlBypassAuth)

--- a/pkg/admission/conf/am_conf_test.go
+++ b/pkg/admission/conf/am_conf_test.go
@@ -37,6 +37,7 @@ func TestConfigMapVars(t *testing.T) {
 		AMFilteringBypassNamespaces:      "testBypassNamespaces",
 		AMFilteringLabelNamespaces:       "testLabelNamespaces",
 		AMFilteringNoLabelNamespaces:     "testNolabelNamespaces",
+		AMFilteringGenerateUniqueAppIds:  "true",
 		AMAccessControlBypassAuth:        "true",
 		AMAccessControlSystemUsers:       "^systemuser$",
 		AMAccessControlExternalUsers:     "^yunikorn$",
@@ -50,6 +51,7 @@ func TestConfigMapVars(t *testing.T) {
 	assert.Equal(t, conf.GetBypassNamespaces()[0].String(), "testBypassNamespaces")
 	assert.Equal(t, conf.GetLabelNamespaces()[0].String(), "testLabelNamespaces")
 	assert.Equal(t, conf.GetNoLabelNamespaces()[0].String(), "testNolabelNamespaces")
+	assert.Equal(t, conf.GetGenerateUniqueAppIds(), true)
 	assert.Equal(t, conf.GetBypassAuth(), true)
 	assert.Equal(t, conf.GetSystemUsers()[0].String(), "^systemuser$")
 	assert.Equal(t, conf.GetExternalUsers()[0].String(), "^yunikorn$")
@@ -76,9 +78,11 @@ func TestConfigMapVars(t *testing.T) {
 	conf = NewAdmissionControllerConf([]*v1.ConfigMap{nil, {Data: map[string]string{
 		AMAccessControlBypassAuth:       "xyz",
 		AMAccessControlTrustControllers: "xyz",
+		AMFilteringGenerateUniqueAppIds: "xyz",
 	}}})
 	assert.Equal(t, conf.GetBypassAuth(), DefaultAccessControlBypassAuth)
 	assert.Equal(t, conf.GetTrustControllers(), DefaultAccessControlTrustControllers)
+	assert.Equal(t, conf.GetGenerateUniqueAppIds(), DefaultFilteringGenerateUniqueAppIds)
 
 	// test disable / enable of config hot refresh
 	conf = NewAdmissionControllerConf([]*v1.ConfigMap{nil, nil})


### PR DESCRIPTION
### What is this PR for?
Ability to configure autogenerated application ids. Currently, if the app id is not specified, yunikorn generates the application id with the name 'yunikorn-<name_space>-autogen' and all the pods with no application id are bundled under that name. This change adds an option to have unique auto-generated names. Appends pod uid after the namespace name to make it unique.

First time? Check out the contributing guide - http://yunikorn.apache.org/community/how_to_contribute
Successfully ran these commands in k8shim
make license-check
make lint
make test


### What type of PR is it?
* [ ] - Bug Fix
* [X] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN/1273
* https://issues.apache.org/jira/browse/YUNIKORN-1273
### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [NO] - The licenses files need update.
* [NO] - There is breaking changes for older versions.
* [NO] - It needs documentation.
