### PR TITLE
[YUNIKORN-1746] Improve the performance of nodeInfoListerImpl.List()

### DIFF
--- a/pkg/cache/external/scheduler_cache_test.go
+++ b/pkg/cache/external/scheduler_cache_test.go
@@ -220,7 +220,6 @@ func TestUpdateNode(t *testing.T) {
 
 	// first add the old node
 	cache.AddNode(oldNode)
-	assert.Equal(t, int64(1), cache.nodesMapGeneration, "invalid generation counter")
 
 	// make sure the node is added to the cache
 	nodeInCache := cache.GetNode("host0001")
@@ -238,7 +237,72 @@ func TestUpdateNode(t *testing.T) {
 	assert.Equal(t, nodeInCache.Node().Spec.Unschedulable, false)
 
 	cache.removeNode(newNode)
-	assert.Equal(t, int64(2), cache.nodesMapGeneration, "invalid generation counter")
+	assert.Equal(t, 0, len(cache.nodesInfoList), "nodesInfo list size")
+}
+
+func TestGetNodesInfo(t *testing.T) {
+	cache := NewSchedulerCache(client.NewMockedAPIProvider(false).GetAPIs())
+	assert.Assert(t, cache.nodesInfoList == nil)
+	node := &v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      "host0001",
+			Namespace: "default",
+			UID:       "Node-UID-00001",
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: true,
+		},
+	}
+	cache.AddNode(node)
+	assert.Assert(t, cache.nodesInfoList == nil)
+	nodesInfo := cache.GetNodesInfo()
+	assert.Assert(t, nodesInfo != nil, "nodesInfo list was not created")
+	assert.Equal(t, 1, len(nodesInfo), "nodesInfo list size")
+	assert.Equal(t, "host0001", nodesInfo[0].Node().Name)
+
+	// update
+	updatedNode := &v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      "host0001",
+			Namespace: "default",
+			UID:       "Node-UID-00001",
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: false,
+		},
+	}
+	cache.updateNode(updatedNode)
+	assert.Assert(t, cache.nodesInfoList != nil, "nodesInfo list was deleted")
+	assert.Equal(t, 1, len(cache.nodesInfoList), "nodesInfo list size")
+	assert.Equal(t, "host0001", cache.nodesInfoList[0].Node().Name)
+
+	// add new
+	newNode := &v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      "host0002",
+			Namespace: "default",
+			UID:       "Node-UID-00002",
+		},
+	}
+	cache.AddNode(newNode)
+	assert.Assert(t, cache.nodesInfoList == nil, "nodesInfo list was not invalidated")
+	nodesInfo = cache.GetNodesInfo()
+	assert.Assert(t, nodesInfo != nil, "nodesInfo list was not created")
+	assert.Equal(t, 2, len(nodesInfo), "nodesInfo list size")
+	m := make(map[string]bool)
+	for _, info := range nodesInfo {
+		m[info.Node().Name] = true
+	}
+	assert.Equal(t, true, m["host0001"], "node not found")
+	assert.Equal(t, true, m["host0002"], "node not found")
+
+	// remove
+	cache.removeNode(node)
+	assert.Assert(t, cache.nodesInfoList == nil, "nodesInfo list was not invalidated")
+	nodesInfo = cache.GetNodesInfo()
+	assert.Assert(t, nodesInfo != nil, "nodesInfo list was not created")
+	assert.Equal(t, 1, len(nodesInfo), "nodesInfo list size")
+	assert.Equal(t, "host0002", nodesInfo[0].Node().Name)
 }
 
 func TestUpdateNonExistNode(t *testing.T) {
@@ -288,9 +352,8 @@ func add2Cache(cache *SchedulerCache, objects ...interface{}) error {
 func TestGetNodesInfoMap(t *testing.T) {
 	// empty map
 	cache := NewSchedulerCache(client.NewMockedAPIProvider(false).GetAPIs())
-	ref, gen := cache.GetNodesInfoMap()
+	ref := cache.GetNodesInfoMap()
 	assert.Equal(t, len(ref), 0)
-	assert.Equal(t, int64(0), gen)
 
 	for i := 0; i < 10; i++ {
 		cache.AddNode(&v1.Node{
@@ -309,9 +372,8 @@ func TestGetNodesInfoMap(t *testing.T) {
 		})
 	}
 
-	ref, gen = cache.GetNodesInfoMap()
+	ref = cache.GetNodesInfoMap()
 	assert.Equal(t, len(ref), 10)
-	assert.Equal(t, int64(10), gen)
 	for k, v := range ref {
 		assert.Assert(t, v.Node() != nil, "node %s should not be nil", k)
 		assert.Equal(t, len(v.Node().Labels), 2)

--- a/pkg/plugin/support/nodeinfo_lister.go
+++ b/pkg/plugin/support/nodeinfo_lister.go
@@ -28,28 +28,14 @@ import (
 
 type nodeInfoListerImpl struct {
 	cache *external.SchedulerCache
-
-	nodes    []*framework.NodeInfo
-	nodesGen int64
 }
 
-func (n *nodeInfoListerImpl) List() ([]*framework.NodeInfo, error) {
-	nodes, gen := n.cache.GetNodesInfoMap()
-
-	if n.nodesGen != gen {
-		nodeList := make([]*framework.NodeInfo, 0, len(nodes))
-		for _, node := range nodes {
-			nodeList = append(nodeList, node)
-		}
-		n.nodes = nodeList
-		n.nodesGen = gen
-	}
-
-	return n.nodes, nil
+func (n nodeInfoListerImpl) List() ([]*framework.NodeInfo, error) {
+	return n.cache.GetNodesInfo(), nil
 }
 
-func (n *nodeInfoListerImpl) HavePodsWithAffinityList() ([]*framework.NodeInfo, error) {
-	nodes, _ := n.cache.GetNodesInfoMap()
+func (n nodeInfoListerImpl) HavePodsWithAffinityList() ([]*framework.NodeInfo, error) {
+	nodes := n.cache.GetNodesInfoMap()
 	result := make([]*framework.NodeInfo, 0, len(nodes))
 	for _, node := range nodes {
 		if len(node.PodsWithAffinity) > 0 {
@@ -59,8 +45,8 @@ func (n *nodeInfoListerImpl) HavePodsWithAffinityList() ([]*framework.NodeInfo, 
 	return result, nil
 }
 
-func (n *nodeInfoListerImpl) HavePodsWithRequiredAntiAffinityList() ([]*framework.NodeInfo, error) {
-	nodes, _ := n.cache.GetNodesInfoMap()
+func (n nodeInfoListerImpl) HavePodsWithRequiredAntiAffinityList() ([]*framework.NodeInfo, error) {
+	nodes := n.cache.GetNodesInfoMap()
 	result := make([]*framework.NodeInfo, 0, len(nodes))
 	for _, node := range nodes {
 		if len(node.PodsWithRequiredAntiAffinity) > 0 {
@@ -70,8 +56,8 @@ func (n *nodeInfoListerImpl) HavePodsWithRequiredAntiAffinityList() ([]*framewor
 	return result, nil
 }
 
-func (n *nodeInfoListerImpl) Get(nodeName string) (*framework.NodeInfo, error) {
-	nodes, _ := n.cache.GetNodesInfoMap()
+func (n nodeInfoListerImpl) Get(nodeName string) (*framework.NodeInfo, error) {
+	nodes := n.cache.GetNodesInfoMap()
 	node, ok := nodes[nodeName]
 	if !ok {
 		return nil, errors.New("node not found")
@@ -85,8 +71,7 @@ var _ framework.NodeInfoLister = &nodeInfoListerImpl{}
 // not safe for access without acquiring the scheduler cache read lock first.
 func NewNodeInfoLister(cache *external.SchedulerCache) framework.NodeInfoLister {
 	nl := &nodeInfoListerImpl{
-		cache:    cache,
-		nodesGen: -1,
+		cache: cache,
 	}
 	return nl
 }

--- a/pkg/plugin/support/nodeinfo_lister_test.go
+++ b/pkg/plugin/support/nodeinfo_lister_test.go
@@ -30,8 +30,14 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/client"
 )
 
+const (
+	host1 = "host0001"
+	host2 = "host0002"
+	host3 = "host0003"
+)
+
 func TestList(t *testing.T) {
-	lister := initLister(t)
+	lister, cache := initLister(t)
 	nodes, err := lister.List()
 	assert.NilError(t, err, "List failed")
 	assert.Assert(t, nodes != nil, "nodes was nil")
@@ -40,34 +46,58 @@ func TestList(t *testing.T) {
 	for _, node := range nodes {
 		m[node.Node().Name] = node
 	}
-	_, ok := m["host0001"]
+	_, ok := m[host1]
 	assert.Assert(t, ok, "host0001 missing")
-	_, ok = m["host0002"]
+	_, ok = m[host2]
 	assert.Assert(t, ok, "host0002 missing")
+	assert.Equal(t, int64(2), lister.nodesGen)
+
+	cache.AddNode(&v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      host3,
+			Namespace: "default",
+			UID:       "Node-UID-00003",
+		},
+	})
+	nodes, err = lister.List()
+	assert.NilError(t, err, "List failed")
+	assert.Assert(t, nodes != nil, "nodes was nil")
+	assert.Equal(t, 3, len(nodes), "wrong length")
+	m = make(map[string]*framework.NodeInfo)
+	for _, node := range nodes {
+		m[node.Node().Name] = node
+	}
+	_, ok = m[host1]
+	assert.Assert(t, ok, "host0001 missing")
+	_, ok = m[host2]
+	assert.Assert(t, ok, "host0002 missing")
+	_, ok = m[host3]
+	assert.Assert(t, ok, "host0003 missing")
+	assert.Equal(t, int64(3), lister.nodesGen)
 }
 
 func TestGet(t *testing.T) {
-	lister := initLister(t)
-	node, err := lister.Get("host0001")
+	lister, _ := initLister(t)
+	node, err := lister.Get(host1)
 	assert.NilError(t, err, "Get failed")
 	assert.Assert(t, node != nil, "node was nil")
-	assert.Equal(t, "host0001", node.Node().Name, "wrong name for node")
+	assert.Equal(t, host1, node.Node().Name, "wrong name for node")
 	node, err = lister.Get("invalid")
 	assert.Assert(t, err != nil, "invalid node was found")
 	assert.Assert(t, node == nil, "node was not nil")
 }
 
 func TestHavePodsWithAffinityList(t *testing.T) {
-	lister := initLister(t)
+	lister, _ := initLister(t)
 	nodes, err := lister.HavePodsWithAffinityList()
 	assert.NilError(t, err, "HavePodsWithAffinityList failed")
 	assert.Assert(t, nodes != nil, "nodes was nil")
 	assert.Equal(t, 1, len(nodes), "wrong length")
-	assert.Equal(t, "host0001", nodes[0].Node().Name, "wrong name for node")
+	assert.Equal(t, host1, nodes[0].Node().Name, "wrong name for node")
 }
 
 func TestHavePodsWithRequiredAntiAffinityList(t *testing.T) {
-	lister := initLister(t)
+	lister, _ := initLister(t)
 	nodes, err := lister.HavePodsWithRequiredAntiAffinityList()
 	assert.NilError(t, err, "HavePodsWithAffinityList failed")
 	assert.Assert(t, nodes != nil, "nodes was nil")
@@ -75,28 +105,28 @@ func TestHavePodsWithRequiredAntiAffinityList(t *testing.T) {
 	assert.Equal(t, "host0002", nodes[0].Node().Name, "wrong name for node")
 }
 
-func initLister(t *testing.T) *nodeInfoListerImpl {
+func initLister(t *testing.T) (*nodeInfoListerImpl, *external.SchedulerCache) {
 	cache := external.NewSchedulerCache(client.NewMockedAPIProvider(false).GetAPIs())
 	lister, ok := NewSharedLister(cache).NodeInfos().(*nodeInfoListerImpl)
 	assert.Assert(t, ok, "wrong type for node lister")
 
 	cache.AddNode(&v1.Node{
 		ObjectMeta: apis.ObjectMeta{
-			Name:      "host0001",
+			Name:      host1,
 			Namespace: "default",
 			UID:       "Node-UID-00001",
 		},
 	})
 	cache.AddNode(&v1.Node{
 		ObjectMeta: apis.ObjectMeta{
-			Name:      "host0002",
+			Name:      host2,
 			Namespace: "default",
 			UID:       "Node-UID-00002",
 		},
 	})
 
-	cache.GetNode("host0001").PodsWithAffinity = append(cache.GetNode("host0001").PodsWithAffinity, &framework.PodInfo{})
-	cache.GetNode("host0002").PodsWithRequiredAntiAffinity = append(cache.GetNode("host0002").PodsWithRequiredAntiAffinity, &framework.PodInfo{})
+	cache.GetNode(host1).PodsWithAffinity = append(cache.GetNode(host1).PodsWithAffinity, &framework.PodInfo{})
+	cache.GetNode(host2).PodsWithRequiredAntiAffinity = append(cache.GetNode(host2).PodsWithRequiredAntiAffinity, &framework.PodInfo{})
 
-	return lister
+	return lister, cache
 }


### PR DESCRIPTION
### What is this PR for?
The method `nodeInfoListerImpl.List()` is called very frequently and always creates a slice with the same content over and over again. It's only necessary to update if a nodes joins/leaves the cluster.
The code is also on a critical path, optimizing it has visible performance benefits.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1746

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
