### PR TITLE
[YUNIKORN-1555] Deduplicate async pod events during recovery

### DIFF
--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -23,14 +23,12 @@ import (
 	"sort"
 	"time"
 
-	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/apache/yunikorn-k8shim/pkg/appmgmt/general"
 	"github.com/apache/yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/yunikorn-k8shim/pkg/cache"
 	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
+	"go.uber.org/zap"
 )
 
 // WaitForRecovery initiates and waits for the app management service to finish recovery. If recovery
@@ -66,13 +64,13 @@ func (svc *AppManagementService) recoverApps() (map[string]interfaces.ManagedApp
 
 			// Track pods that we have already seen in order to
 			// skip redundant handling of async events in RecoveryDone
-			seenEvents := make(map[types.UID]string)
+			seenEvents := make(map[string]string)
 			for _, pod := range pods {
 				if utils.NeedRecovery(pod) {
 					app := svc.podEventHandler.HandleEvent(general.AddPod, general.Recovery, pod)
 					recoveringApps[app.GetApplicationID()] = app
 				}
-				seenEvents[pod.UID] = pod.GetResourceVersion()
+				seenEvents[string(pod.UID)] = pod.GetResourceVersion()
 			}
 			log.Logger().Info("Recovery finished")
 			svc.podEventHandler.RecoveryDone(seenEvents)

--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -65,13 +65,13 @@ func (svc *AppManagementService) recoverApps() (map[string]interfaces.ManagedApp
 
 			// Track pods that we have already seen in order to
 			// skip redundant handling of async events in RecoveryDone
-			seenPods := make(map[string]string)
+			seenPods := make(map[string]bool)
 			for _, pod := range pods {
 				if utils.NeedRecovery(pod) {
 					app := svc.podEventHandler.HandleEvent(general.AddPod, general.Recovery, pod)
 					recoveringApps[app.GetApplicationID()] = app
 				}
-				seenPods[string(pod.UID)] = pod.GetResourceVersion()
+				seenPods[string(pod.UID)] = true
 			}
 			log.Logger().Info("Recovery finished")
 			svc.podEventHandler.RecoveryDone(seenPods)

--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -64,16 +64,16 @@ func (svc *AppManagementService) recoverApps() (map[string]interfaces.ManagedApp
 
 			// Track pods that we have already seen in order to
 			// skip redundant handling of async events in RecoveryDone
-			seenEvents := make(map[string]string)
+			seenPods := make(map[string]string)
 			for _, pod := range pods {
 				if utils.NeedRecovery(pod) {
 					app := svc.podEventHandler.HandleEvent(general.AddPod, general.Recovery, pod)
 					recoveringApps[app.GetApplicationID()] = app
 				}
-				seenEvents[string(pod.UID)] = pod.GetResourceVersion()
+				seenPods[string(pod.UID)] = pod.GetResourceVersion()
 			}
 			log.Logger().Info("Recovery finished")
-			svc.podEventHandler.RecoveryDone(seenEvents)
+			svc.podEventHandler.RecoveryDone(seenPods)
 		}
 	}
 

--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -23,12 +23,13 @@ import (
 	"sort"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/apache/yunikorn-k8shim/pkg/appmgmt/general"
 	"github.com/apache/yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/yunikorn-k8shim/pkg/cache"
 	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
-	"go.uber.org/zap"
 )
 
 // WaitForRecovery initiates and waits for the app management service to finish recovery. If recovery

--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -63,18 +63,23 @@ func (svc *AppManagementService) recoverApps() (map[string]interfaces.ManagedApp
 				return pods[i].CreationTimestamp.Unix() < pods[j].CreationTimestamp.Unix()
 			})
 
-			// Track pods that we have already seen in order to
+			// Track terminated pods that we have already seen in order to
 			// skip redundant handling of async events in RecoveryDone
-			seenPods := make(map[string]bool)
+			// This filter is used for terminated pods to remain consistent
+			// with pod filters in the informer
+			terminatedYkPods := make(map[string]bool)
 			for _, pod := range pods {
-				if utils.NeedRecovery(pod) {
-					app := svc.podEventHandler.HandleEvent(general.AddPod, general.Recovery, pod)
-					recoveringApps[app.GetApplicationID()] = app
+				if utils.GetApplicationIDFromPod(pod) != "" {
+					if !utils.IsPodTerminated(pod) {
+						app := svc.podEventHandler.HandleEvent(general.AddPod, general.Recovery, pod)
+						recoveringApps[app.GetApplicationID()] = app
+						continue
+					}
+					terminatedYkPods[string(pod.UID)] = true
 				}
-				seenPods[string(pod.UID)] = true
 			}
 			log.Logger().Info("Recovery finished")
-			svc.podEventHandler.RecoveryDone(seenPods)
+			svc.podEventHandler.RecoveryDone(terminatedYkPods)
 		}
 	}
 

--- a/pkg/appmgmt/general/podevent_handler.go
+++ b/pkg/appmgmt/general/podevent_handler.go
@@ -89,7 +89,7 @@ func (p *PodEventHandler) internalHandle(eventType EventType, source EventSource
 	}
 }
 
-func (p *PodEventHandler) RecoveryDone(seenEvents map[string]string) {
+func (p *PodEventHandler) RecoveryDone(seenPods map[string]string) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -102,7 +102,7 @@ func (p *PodEventHandler) RecoveryDone(seenEvents map[string]string) {
 			// been processed in the initial app recovery routine
 			// If the pod resource version of the seen event matches that of the async event,
 			// this indicates that it is a duplicate object and should be skipped
-			seenVersion, ok := seenEvents[string(event.pod.UID)]
+			seenVersion, ok := seenPods[string(event.pod.UID)]
 			if ok && seenVersion == event.pod.GetResourceVersion() && event.eventType == AddPod {
 				continue
 			}

--- a/pkg/appmgmt/general/podevent_handler.go
+++ b/pkg/appmgmt/general/podevent_handler.go
@@ -25,8 +25,6 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/types"
-
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -91,7 +89,7 @@ func (p *PodEventHandler) internalHandle(eventType EventType, source EventSource
 	}
 }
 
-func (p *PodEventHandler) RecoveryDone(seenEvents map[types.UID]string) {
+func (p *PodEventHandler) RecoveryDone(seenEvents map[string]string) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -104,7 +102,7 @@ func (p *PodEventHandler) RecoveryDone(seenEvents map[types.UID]string) {
 			// been processed in the initial app recovery routine
 			// If the pod resource version of the seen event matches that of the async event,
 			// this indicates that it is a duplicate object and should be skipped
-			seenVersion, ok := seenEvents[event.pod.UID]
+			seenVersion, ok := seenEvents[string(event.pod.UID)]
 			if ok && seenVersion == event.pod.GetResourceVersion() && event.eventType == AddPod {
 				continue
 			}

--- a/pkg/appmgmt/general/podevent_handler_test.go
+++ b/pkg/appmgmt/general/podevent_handler_test.go
@@ -86,9 +86,9 @@ func TestRecoveryDone(t *testing.T) {
 	podEventHandler.HandleEvent(AddPod, Informers, pod3v1)
 	podEventHandler.HandleEvent(UpdatePod, Informers, pod3v2)
 
-	seenEvents := map[types.UID]string{
-		pod2.UID: pod2.GetResourceVersion(), // should not be added
-		pod3.UID: pod3.GetResourceVersion(), // should be updated with new version and ultimately completed
+	seenEvents := map[string]string{
+		string(pod2.UID): pod2.GetResourceVersion(), // should not be added
+		string(pod3.UID): pod3.GetResourceVersion(), // should be updated with new version and ultimately completed
 	}
 	podEventHandler.RecoveryDone(seenEvents)
 

--- a/pkg/appmgmt/general/podevent_handler_test.go
+++ b/pkg/appmgmt/general/podevent_handler_test.go
@@ -86,11 +86,11 @@ func TestRecoveryDone(t *testing.T) {
 	podEventHandler.HandleEvent(AddPod, Informers, pod3v1)
 	podEventHandler.HandleEvent(UpdatePod, Informers, pod3v2)
 
-	seenEvents := map[string]string{
+	seenPods := map[string]string{
 		string(pod2.UID): pod2.GetResourceVersion(), // should not be added
 		string(pod3.UID): pod3.GetResourceVersion(), // should be updated with new version and ultimately completed
 	}
-	podEventHandler.RecoveryDone(seenEvents)
+	podEventHandler.RecoveryDone(seenPods)
 
 	assert.Equal(t, len(podEventHandler.asyncEvents), 0)
 	app := amProtocol.GetApplication(appID)


### PR DESCRIPTION
### What is this PR for?
Follow up to https://github.com/apache/yunikorn-k8shim/pull/532. Original PR failed to address duplicated events coming from the informer via `asyncEvent`s as this scenario was not covered by unit tests.

Changes involve passing state between recovery methods to deduplicate `AddPod` operations given the pod UID.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [x] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-1555](https://issues.apache.org/jira/browse/YUNIKORN-1555)

### How should this be tested?
Unit tests modified

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
