### PR TITLE
[YUNIKORN-1742] Add new methods to MockScheduler to handle Kubernetes objects

### DIFF
--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -46,6 +46,7 @@ type MockedAPIProvider struct {
 }
 
 type operation int
+
 type informerEvent struct {
 	handlerType Type
 	op          operation
@@ -383,6 +384,10 @@ func (m *MockedAPIProvider) UpdatePriorityClass(oldObj *schedv1.PriorityClass, n
 		op:          Update,
 		handlerType: PriorityClassInformerHandlers,
 	}
+}
+
+func (m *MockedAPIProvider) GetPodBindStats() BindStats {
+	return m.clients.KubeClient.(*KubeClientMock).GetBindStats()
 }
 
 // MockedPersistentVolumeInformer implements PersistentVolumeInformer interface

--- a/pkg/common/test/namespacelister_mock.go
+++ b/pkg/common/test/namespacelister_mock.go
@@ -47,7 +47,7 @@ func (nsl *MockNamespaceLister) Add(ns *v1.Namespace) {
 func (nsl *MockNamespaceLister) Get(name string) (*v1.Namespace, error) {
 	ns, ok := nsl.namespaces[name]
 	if !ok {
-		return nil, fmt.Errorf("namespace is not found")
+		return nil, fmt.Errorf("namespace %s is not found", name)
 	}
 	return ns, nil
 }


### PR DESCRIPTION
### What is this PR for?
* Add new methods to `MockedScheduler` so that developers can take advantage of the new mock shared informer feature of `MockedAPIProvider`. 
* Saving statistics about pod binding.
* Setting mock event recorder to avoid blocking.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1742

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
