### PR TITLE
[YUNIKORN-1772] remove Context.SelectApplications

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -925,15 +925,12 @@ func (ctx *Context) getTask(appID string, taskID string) *Task {
 	return task
 }
 
-func (ctx *Context) SelectApplications(filter func(app *Application) bool) []*Application {
+func (ctx *Context) GetAllApplications() []*Application {
 	ctx.lock.RLock()
 	defer ctx.lock.RUnlock()
 
-	apps := make([]*Application, 0)
+	apps := make([]*Application, 0, len(ctx.applications))
 	for _, app := range ctx.applications {
-		if filter != nil && !filter(app) {
-			continue
-		}
 		apps = append(apps, app)
 	}
 

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -276,7 +276,7 @@ func (ss *KubernetesShim) canHandle(se events.SchedulerEvent) bool {
 
 // each schedule iteration, we scan all apps and triggers app state transition
 func (ss *KubernetesShim) schedule() {
-	apps := ss.context.SelectApplications(nil)
+	apps := ss.context.GetAllApplications()
 	for _, app := range apps {
 		if app.Schedule() {
 			ss.setOutstandingAppsFound(true)

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -152,23 +152,21 @@ func (fc *MockScheduler) waitForSchedulerState(t *testing.T, expectedState strin
 }
 
 func (fc *MockScheduler) waitAndAssertApplicationState(t *testing.T, appID, expectedState string) {
-	appList := fc.context.SelectApplications(func(app *cache.Application) bool {
-		return app.GetApplicationID() == appID
-	})
-	assert.Equal(t, len(appList), 1)
-	assert.Equal(t, appList[0].GetApplicationID(), appID)
+	app := fc.context.GetApplication(appID)
+	assert.Equal(t, app != nil, true)
+	assert.Equal(t, app.GetApplicationID(), appID)
 	deadline := time.Now().Add(10 * time.Second)
 	for {
-		if appList[0].GetApplicationState() == expectedState {
+		if app.GetApplicationState() == expectedState {
 			break
 		}
 		log.Logger().Info("waiting for app state",
 			zap.String("expected", expectedState),
-			zap.String("actual", appList[0].GetApplicationState()))
+			zap.String("actual", app.GetApplicationState()))
 		time.Sleep(time.Second)
 		if time.Now().After(deadline) {
 			t.Errorf("application %s doesn't reach expected state in given time, expecting: %s, actual: %s",
-				appID, expectedState, appList[0].GetApplicationState())
+				appID, expectedState, app.GetApplicationState())
 		}
 	}
 }
@@ -191,13 +189,11 @@ func (fc *MockScheduler) removeApplication(appId string) error {
 }
 
 func (fc *MockScheduler) waitAndAssertTaskState(t *testing.T, appID, taskID, expectedState string) {
-	appList := fc.context.SelectApplications(func(app *cache.Application) bool {
-		return app.GetApplicationID() == appID
-	})
-	assert.Equal(t, len(appList), 1)
-	assert.Equal(t, appList[0].GetApplicationID(), appID)
+	app := fc.context.GetApplication(appID)
+	assert.Equal(t, app != nil, true)
+	assert.Equal(t, app.GetApplicationID(), appID)
 
-	task, err := appList[0].GetTask(taskID)
+	task, err := app.GetTask(taskID)
 	assert.NilError(t, err, "Task retrieval failed")
 	deadline := time.Now().Add(10 * time.Second)
 	for {


### PR DESCRIPTION
### What is this PR for?

* Remove cache Context.SelectApplications, because we only use it with `nil` filter in production code.
* For testing code, we can use cache Context.GetApplication to replace it.

### What type of PR is it?
* [ ] - Bug Fix
* [X] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-1772

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
