### PR TITLE
[YUNIKORN-1743] Enable predicates for MockScheduler

### DIFF
--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -20,10 +20,13 @@ package client
 
 import (
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	schedv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/client-go/informers"
+	k8fake "k8s.io/client-go/kubernetes/fake"
 	corev1 "k8s.io/client-go/listers/core/v1"
 	storagev1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
@@ -89,8 +92,9 @@ func NewMockedAPIProvider(showError bool) *MockedAPIProvider {
 			StorageInformer:       &MockedStorageClassInformer{},
 			VolumeBinder:          nil,
 			AppInformer:           test.NewAppInformerMock(),
-			NamespaceInformer:     test.NewMockNamespaceInformer(),
+			NamespaceInformer:     test.NewMockNamespaceInformer(false),
 			PriorityClassInformer: test.NewMockPriorityClassInformer(),
+			InformerFactory:       informers.NewSharedInformerFactory(k8fake.NewSimpleClientset(), time.Second*60),
 		},
 		events:       make(chan informerEvent),
 		eventHandler: make(chan *ResourceEventHandlers),

--- a/pkg/common/test/namespaceinformer_mock.go
+++ b/pkg/common/test/namespaceinformer_mock.go
@@ -28,9 +28,9 @@ type MockNamespaceInformer struct {
 	lister listersV1.NamespaceLister
 }
 
-func NewMockNamespaceInformer() informersV1.NamespaceInformer {
+func NewMockNamespaceInformer(errIfNotFound bool) informersV1.NamespaceInformer {
 	return &MockNamespaceInformer{
-		lister: NewMockNamespaceLister(),
+		lister: NewMockNamespaceLister(errIfNotFound),
 	}
 }
 

--- a/pkg/common/test/namespacelister_mock.go
+++ b/pkg/common/test/namespacelister_mock.go
@@ -27,12 +27,14 @@ import (
 )
 
 type MockNamespaceLister struct {
-	namespaces map[string]*v1.Namespace
+	namespaces    map[string]*v1.Namespace
+	errIfNotFound bool
 }
 
-func NewMockNamespaceLister() listersV1.NamespaceLister {
+func NewMockNamespaceLister(errIfNotFound bool) listersV1.NamespaceLister {
 	return &MockNamespaceLister{
-		namespaces: make(map[string]*v1.Namespace),
+		namespaces:    make(map[string]*v1.Namespace),
+		errIfNotFound: errIfNotFound,
 	}
 }
 
@@ -47,7 +49,10 @@ func (nsl *MockNamespaceLister) Add(ns *v1.Namespace) {
 func (nsl *MockNamespaceLister) Get(name string) (*v1.Namespace, error) {
 	ns, ok := nsl.namespaces[name]
 	if !ok {
-		return nil, fmt.Errorf("namespace %s is not found", name)
+		if nsl.errIfNotFound {
+			return nil, fmt.Errorf("namespace %s is not found", name)
+		}
+		return nil, nil
 	}
 	return ns, nil
 }


### PR DESCRIPTION
### What is this PR for?
Predicates are not running when MockScheduler is used.  This PR removes certain `IsTestingMode()` calls which prevents the predicates from being called.
Some existing MockScheduler tests were upgraded so they don't fail with the new code.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1743

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
