### PR TITLE
[YUNIKORN-1744] Enable recovery for MockScheduler

### DIFF
--- a/pkg/appmgmt/appmgmt.go
+++ b/pkg/appmgmt/appmgmt.go
@@ -56,21 +56,14 @@ func NewAMService(amProtocol interfaces.ApplicationManagementProtocol,
 	}
 
 	log.Logger().Info("Initializing new AppMgmt service")
-
-	if !apiProvider.IsTestingMode() {
-		log.Logger().Info("Registering Spark operator with the AppMgmt service")
-		appManager.register(
-			// registered app plugins
-			// for general apps
-			general.NewManager(apiProvider, podEventHandler),
-			// for spark operator - SparkApplication
-			sparkoperator.NewManager(amProtocol, apiProvider),
-			// for application crds
-			application.NewAppManager(amProtocol, apiProvider))
-	} else {
-		podEventHandler = general.NewPodEventHandler(amProtocol, false)
-		appManager.register(general.NewManager(apiProvider, podEventHandler))
-	}
+	appManager.register(
+		// registered app plugins
+		// for general apps
+		general.NewManager(apiProvider, podEventHandler),
+		// for spark operator - SparkApplication
+		sparkoperator.NewManager(amProtocol, apiProvider),
+		// for application crds
+		application.NewAppManager(amProtocol, apiProvider))
 
 	return appManager
 }

--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -36,14 +36,12 @@ import (
 // is canceled (used by testing code) or an error occurs, an error will be returned. In production, this
 // method will block until recovery completes.
 func (svc *AppManagementService) WaitForRecovery() error {
-	if !svc.apiProvider.IsTestingMode() {
-		apps, err := svc.recoverApps()
-		if err != nil {
-			return err
-		}
-		if !svc.waitForAppRecovery(apps) {
-			return errors.New("recovery aborted")
-		}
+	apps, err := svc.recoverApps()
+	if err != nil {
+		return err
+	}
+	if !svc.waitForAppRecovery(apps) {
+		return errors.New("recovery aborted")
 	}
 	return nil
 }

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -985,16 +985,14 @@ func (ctx *Context) updatePodCondition(task *Task, podCondition *v1.PodCondition
 				zap.Any("podCondition", podCondition))
 			// call api-server to do the pod condition update
 			if podutil.UpdatePodCondition(&task.pod.Status, podCondition) {
-				if !ctx.apiProvider.IsTestingMode() {
-					podCopy := task.pod.DeepCopy()
-					_, err := ctx.apiProvider.GetAPIs().KubeClient.UpdateStatus(podCopy)
-					if err == nil {
-						return true
-					}
-					// only log the error here, no need to handle it if the update failed
-					log.Logger().Error("update pod condition failed",
-						zap.Error(err))
+				podCopy := task.pod.DeepCopy()
+				_, err := ctx.apiProvider.GetAPIs().KubeClient.UpdateStatus(podCopy)
+				if err == nil {
+					return true
 				}
+				// only log the error here, no need to handle it if the update failed
+				log.Logger().Error("update pod condition failed",
+					zap.Error(err))
 			}
 		}
 	}

--- a/pkg/cache/context_recovery.go
+++ b/pkg/cache/context_recovery.go
@@ -19,13 +19,11 @@
 package cache
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/apache/yunikorn-k8shim/pkg/appmgmt/interfaces"
@@ -38,14 +36,9 @@ import (
 )
 
 func (ctx *Context) WaitForRecovery(recoverableAppManagers []interfaces.Recoverable, maxTimeout time.Duration) error {
-	// Currently, disable recovery when testing in a mocked cluster,
-	// because mock pod/node lister is not easy. We do have unit tests for
-	// waitForAppRecovery/recover separately.
-	if !ctx.apiProvider.IsTestingMode() {
-		if err := ctx.recover(recoverableAppManagers, maxTimeout); err != nil {
-			log.Logger().Error("nodes recovery failed", zap.Error(err))
-			return err
-		}
+	if err := ctx.recover(recoverableAppManagers, maxTimeout); err != nil {
+		log.Logger().Error("nodes recovery failed", zap.Error(err))
+		return err
 	}
 
 	return nil
@@ -80,86 +73,77 @@ func (ctx *Context) recover(mgr []interfaces.Recoverable, due time.Duration) err
 		ctx.nodes.addAndReportNode(node, false)
 	}
 
-	// current, disable getting pods for a node during test,
-	// because in the tests, we don't really send existing allocations
-	// we simply simulate to accept or reject nodes on conditions.
-	if !ctx.apiProvider.IsTestingMode() {
-		var podList *corev1.PodList
-		podList, err = ctx.apiProvider.GetAPIs().KubeClient.GetClientSet().
-			CoreV1().Pods("").
-			List(context.Background(), metav1.ListOptions{})
-		if err != nil {
-			return err
-		}
+	pods, err := ctx.apiProvider.GetAPIs().PodInformer.Lister().List(labels.Everything())
+	if err != nil {
+		return err
+	}
 
-		nodeOccupiedResources := make(map[string]*si.Resource)
-		for i := 0; i < len(podList.Items); i++ {
-			pod := podList.Items[i]
-			// only handle assigned pods
-			if !utils.IsAssignedPod(&pod) {
-				log.Logger().Info("Skipping unassigned pod",
+	nodeOccupiedResources := make(map[string]*si.Resource)
+	for _, pod := range pods {
+		// only handle assigned pods
+		if !utils.IsAssignedPod(pod) {
+			log.Logger().Info("Skipping unassigned pod",
+				zap.String("podUID", string(pod.UID)),
+				zap.String("podName", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)))
+			continue
+		}
+		// yunikorn scheduled pods add to existing allocations
+		ykPod := utils.GetApplicationIDFromPod(pod) != ""
+		switch {
+		case ykPod:
+			if existingAlloc := getExistingAllocation(mgr, pod); existingAlloc != nil {
+				log.Logger().Debug("Adding resources for existing pod",
+					zap.String("appID", existingAlloc.ApplicationID),
 					zap.String("podUID", string(pod.UID)),
-					zap.String("podName", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)))
-				continue
-			}
-			// yunikorn scheduled pods add to existing allocations
-			ykPod := utils.GetApplicationIDFromPod(&pod) != ""
-			switch {
-			case ykPod:
-				if existingAlloc := getExistingAllocation(mgr, &pod); existingAlloc != nil {
-					log.Logger().Debug("Adding resources for existing pod",
-						zap.String("appID", existingAlloc.ApplicationID),
-						zap.String("podUID", string(pod.UID)),
-						zap.String("podName", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
-						zap.String("nodeName", existingAlloc.NodeID),
-						zap.Stringer("resources", common.GetPodResource(&pod)))
-					existingAlloc.AllocationTags = common.CreateTagsForTask(&pod)
-					if err = ctx.nodes.addExistingAllocation(existingAlloc); err != nil {
-						log.Logger().Warn("Failed to add existing allocation", zap.Error(err))
-					}
-				} else {
-					log.Logger().Warn("No allocation found for existing pod",
-						zap.String("podUID", string(pod.UID)),
-						zap.String("podName", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
-						zap.String("nodeName", pod.Spec.NodeName),
-						zap.Stringer("resources", common.GetPodResource(&pod)))
+					zap.String("podName", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+					zap.String("nodeName", existingAlloc.NodeID),
+					zap.Stringer("resources", common.GetPodResource(pod)))
+				existingAlloc.AllocationTags = common.CreateTagsForTask(pod)
+				if err = ctx.nodes.addExistingAllocation(existingAlloc); err != nil {
+					log.Logger().Warn("Failed to add existing allocation", zap.Error(err))
 				}
-			case !utils.IsPodTerminated(&pod):
-				// pod is not terminated (succeed or failed) state,
-				// and it has a node assigned, that means the scheduler
-				// has already allocated the pod onto a node
-				// we should report this occupied resource to scheduler-core
-				occupiedResource := nodeOccupiedResources[pod.Spec.NodeName]
-				if occupiedResource == nil {
-					occupiedResource = common.NewResourceBuilder().Build()
-				}
-				podResource := common.GetPodResource(&pod)
-				log.Logger().Debug("Adding resources for occupied pod",
+			} else {
+				log.Logger().Warn("No allocation found for existing pod",
 					zap.String("podUID", string(pod.UID)),
 					zap.String("podName", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
 					zap.String("nodeName", pod.Spec.NodeName),
-					zap.Stringer("resources", podResource))
-				occupiedResource = common.Add(occupiedResource, podResource)
-				nodeOccupiedResources[pod.Spec.NodeName] = occupiedResource
-				ctx.nodes.cache.AddPod(&pod)
-			default:
-				log.Logger().Debug("Skipping terminated pod",
-					zap.String("podUID", string(pod.UID)),
-					zap.String("podName", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)))
+					zap.Stringer("resources", common.GetPodResource(pod)))
 			}
+		case !utils.IsPodTerminated(pod):
+			// pod is not terminated (succeed or failed) state,
+			// and it has a node assigned, that means the scheduler
+			// has already allocated the pod onto a node
+			// we should report this occupied resource to scheduler-core
+			occupiedResource := nodeOccupiedResources[pod.Spec.NodeName]
+			if occupiedResource == nil {
+				occupiedResource = common.NewResourceBuilder().Build()
+			}
+			podResource := common.GetPodResource(pod)
+			log.Logger().Debug("Adding resources for occupied pod",
+				zap.String("podUID", string(pod.UID)),
+				zap.String("podName", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+				zap.String("nodeName", pod.Spec.NodeName),
+				zap.Stringer("resources", podResource))
+			occupiedResource = common.Add(occupiedResource, podResource)
+			nodeOccupiedResources[pod.Spec.NodeName] = occupiedResource
+			ctx.nodes.cache.AddPod(pod)
+		default:
+			log.Logger().Debug("Skipping terminated pod",
+				zap.String("podUID", string(pod.UID)),
+				zap.String("podName", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)))
 		}
+	}
 
-		// why we need to calculate the occupied resources here? why not add an event-handler
-		// in node_coordinator#addPod?
-		// this is because the occupied resources must be calculated and counted before the
-		// scheduling started. If we do both updating existing occupied resources along with
-		// new pods scheduling, due to the fact that we cannot predicate the ordering of K8s
-		// events, it could be dangerous because we might schedule pods onto some node that
-		// doesn't have enough capacity (occupied resources not yet reported).
-		for nodeName, occupiedResource := range nodeOccupiedResources {
-			if cachedNode := ctx.nodes.getNode(nodeName); cachedNode != nil {
-				cachedNode.updateOccupiedResource(occupiedResource, AddOccupiedResource)
-			}
+	// why we need to calculate the occupied resources here? why not add an event-handler
+	// in node_coordinator#addPod?
+	// this is because the occupied resources must be calculated and counted before the
+	// scheduling started. If we do both updating existing occupied resources along with
+	// new pods scheduling, due to the fact that we cannot predicate the ordering of K8s
+	// events, it could be dangerous because we might schedule pods onto some node that
+	// doesn't have enough capacity (occupied resources not yet reported).
+	for nodeName, occupiedResource := range nodeOccupiedResources {
+		if cachedNode := ctx.nodes.getNode(nodeName); cachedNode != nil {
+			cachedNode.updateOccupiedResource(occupiedResource, AddOccupiedResource)
 		}
 	}
 

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -193,6 +193,26 @@ func (m *MockedAPIProvider) SetPodLister(lister corev1.PodLister) {
 	}
 }
 
+func (m *MockedAPIProvider) GetPodListerMock() *test.PodListerMock {
+	if informer, ok := m.clients.PodInformer.(*test.MockedPodInformer); ok {
+		if lister, ok := informer.Lister().(*test.PodListerMock); ok {
+			return lister
+		}
+		return nil
+	}
+	return nil
+}
+
+func (m *MockedAPIProvider) GetNodeListerMock() *test.NodeListerMock {
+	if informer, ok := m.clients.NodeInformer.(*test.MockedNodeInformer); ok {
+		if lister, ok := informer.Lister().(*test.NodeListerMock); ok {
+			return lister
+		}
+		return nil
+	}
+	return nil
+}
+
 func (m *MockedAPIProvider) GetAPIs() *Clients {
 	return m.clients
 }

--- a/pkg/common/test/podlister_mock.go
+++ b/pkg/common/test/podlister_mock.go
@@ -27,22 +27,26 @@ import (
 )
 
 type PodListerMock struct {
-	allPods []*v1.Pod
+	pods map[*v1.Pod]struct{}
 }
 
 func NewPodListerMock() *PodListerMock {
 	return &PodListerMock{
-		allPods: make([]*v1.Pod, 0),
+		pods: make(map[*v1.Pod]struct{}),
 	}
 }
 
 func (n *PodListerMock) AddPod(pod *v1.Pod) {
-	n.allPods = append(n.allPods, pod)
+	n.pods[pod] = struct{}{}
+}
+
+func (n *PodListerMock) DeletePod(pod *v1.Pod) {
+	delete(n.pods, pod)
 }
 
 func (n *PodListerMock) List(selector labels.Selector) (ret []*v1.Pod, err error) {
 	result := make([]*v1.Pod, 0)
-	for _, pod := range n.allPods {
+	for pod := range n.pods {
 		if selector.Matches(labels.Set(pod.Labels)) {
 			result = append(result, pod)
 		}
@@ -51,9 +55,9 @@ func (n *PodListerMock) List(selector labels.Selector) (ret []*v1.Pod, err error
 }
 
 func (n *PodListerMock) Get(name string) (*v1.Pod, error) {
-	for _, n := range n.allPods {
-		if n.Name == name {
-			return n, nil
+	for pod := range n.pods {
+		if pod.Name == name {
+			return pod, nil
 		}
 	}
 	return nil, fmt.Errorf("pod %s is not found", name)

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -274,6 +274,30 @@ func (fc *MockScheduler) stop() {
 	fc.started.Store(false)
 }
 
+func (fc *MockScheduler) AddPodToLister(pod *v1.Pod) {
+	lister := fc.apiProvider.GetPodListerMock()
+	if lister == nil {
+		panic("lister is unset or it has unsupported type")
+	}
+	lister.AddPod(pod)
+}
+
+func (fc *MockScheduler) RemovePodFromLister(pod *v1.Pod) {
+	lister := fc.apiProvider.GetPodListerMock()
+	if lister == nil {
+		panic("lister is unset or it has unsupported type")
+	}
+	lister.DeletePod(pod)
+}
+
+func (fc *MockScheduler) AddNodeToLister(node *v1.Node) {
+	lister := fc.apiProvider.GetNodeListerMock()
+	if lister == nil {
+		panic("lister is unset or it has unsupported type")
+	}
+	lister.AddNode(node)
+}
+
 func (fc *MockScheduler) AddPod(pod *v1.Pod) {
 	fc.ensureStarted()
 	fc.apiProvider.AddPod(pod)


### PR DESCRIPTION
### What is this PR for?
Remove `IsTestingMode()` calls to make recovery possible when using `MockScheduler`.
Add methods so we can simulate existing nodes and pods.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
