### PR TITLE
[YUNIKORN-1797] K8Shim: Implement scoped logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,6 +403,12 @@ test: clean
 	go test ./pkg/... -cover -race -tags deadlock -coverprofile=coverage.txt -covermode=atomic
 	go vet $(REPO)...
 
+# Run benchmarks
+.PHONY: bench
+bench:
+	@echo "running benchmarks"
+	go test -v -run '^Benchmark' -bench . ./pkg/...
+
 # Generate FSM graphs (dot/png)
 .PHONY: fsm_graph
 fsm_graph: clean

--- a/pkg/admission/conf/am_conf.go
+++ b/pkg/admission/conf/am_conf.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	v1 "k8s.io/api/core/v1"
 	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -306,10 +305,6 @@ func (acc *AdmissionControllerConf) updateConfigMaps(configMaps []*v1.ConfigMap,
 	// hot refresh
 	acc.enableConfigHotRefresh = parseConfigBool(configs, schedulerconf.CMSvcEnableConfigHotRefresh, schedulerconf.DefaultEnableConfigHotRefresh)
 
-	// logging
-	logLevel := parseConfigInt(configs, schedulerconf.CMLogLevel, schedulerconf.DefaultLoggingLevel)
-	log.GetZapConfigs().Level.SetLevel(zapcore.Level(logLevel))
-
 	// scheduler
 	acc.policyGroup = parseConfigString(configs, schedulerconf.CMSvcPolicyGroup, schedulerconf.DefaultPolicyGroup)
 
@@ -333,6 +328,9 @@ func (acc *AdmissionControllerConf) updateConfigMaps(configMaps []*v1.ConfigMap,
 
 	// labeling
 	acc.defaultQueueName = parseConfigString(configs, AMFilteringDefaultQueueName, DefaultFilteringQueueName)
+
+	// logging
+	log.UpdateLoggingConfig(configs)
 
 	acc.dumpConfigurationInternal()
 }

--- a/pkg/admission/conf/am_conf_test.go
+++ b/pkg/admission/conf/am_conf_test.go
@@ -21,12 +21,10 @@ package conf
 import (
 	"testing"
 
-	"go.uber.org/zap/zapcore"
 	"gotest.tools/v3/assert"
 	v1 "k8s.io/api/core/v1"
 
 	schedulerconf "github.com/apache/yunikorn-k8shim/pkg/conf"
-	"github.com/apache/yunikorn-k8shim/pkg/log"
 )
 
 func TestConfigMapVars(t *testing.T) {
@@ -88,12 +86,6 @@ func TestConfigMapVars(t *testing.T) {
 	assert.Equal(t, conf.GetBypassAuth(), DefaultAccessControlBypassAuth)
 	assert.Equal(t, conf.GetTrustControllers(), DefaultAccessControlTrustControllers)
 	assert.Equal(t, conf.GetGenerateUniqueAppIds(), DefaultFilteringGenerateUniqueAppIds)
-
-	// test faulty settings for int values
-	NewAdmissionControllerConf([]*v1.ConfigMap{nil, {Data: map[string]string{
-		schedulerconf.CMLogLevel: "not int",
-	}}})
-	assert.Equal(t, log.GetZapConfigs().Level.Level(), zapcore.Level(schedulerconf.DefaultLoggingLevel))
 
 	// test faulty settings for regexp values
 	conf = NewAdmissionControllerConf([]*v1.ConfigMap{nil, {Data: map[string]string{

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -72,7 +72,6 @@ func NewMockedAPIProvider(showError bool) *MockedAPIProvider {
 				PolicyGroup:          "queues",
 				Interval:             0,
 				KubeConfig:           "",
-				LoggingLevel:         0,
 				VolumeBindTimeout:    0,
 				TestMode:             true,
 				EventChannelCapacity: 0,

--- a/pkg/cmd/admissioncontroller/main.go
+++ b/pkg/cmd/admissioncontroller/main.go
@@ -52,6 +52,7 @@ type WebHook struct {
 }
 
 func main() {
+	log.SetDefaultLogger(log.Admission)
 	configMaps, err := client.LoadBootstrapConfigMaps(schedulerconf.GetSchedulerNamespace())
 	if err != nil {
 		log.Logger().Fatal("Failed to load initial configmaps", zap.Error(err))

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -55,6 +55,7 @@ func main() {
 	conf.SiSHA = siSHA
 	conf.ShimSHA = shimSHA
 
+	log.SetDefaultLogger(log.K8Shim)
 	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s arch=%s coreSHA=%s siSHA=%s shimSHA=%s", version, date, false, goVersion, arch, coreSHA, siSHA, shimSHA))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
@@ -68,7 +69,7 @@ func main() {
 	}
 
 	log.Logger().Info("Starting scheduler", zap.String("name", constants.SchedulerName))
-	serviceContext := entrypoint.StartAllServicesWithLogger(log.Logger(), log.GetZapConfigs())
+	serviceContext := entrypoint.StartAllServicesWithLogger(log.RootLogger(), log.GetZapConfigs())
 
 	if sa, ok := serviceContext.RMProxy.(api.SchedulerAPI); ok {
 		ss := shim.NewShimScheduler(sa, conf.GetSchedulerConf(), configMaps)

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -65,7 +65,6 @@ func assertDefaults(t *testing.T, conf *SchedulerConf) {
 	assert.Equal(t, conf.ClusterID, DefaultClusterID)
 	assert.Equal(t, conf.PolicyGroup, DefaultPolicyGroup)
 	assert.Equal(t, conf.ClusterVersion, BuildVersion)
-	assert.Equal(t, conf.LoggingLevel, DefaultLoggingLevel)
 	assert.Equal(t, conf.EventChannelCapacity, DefaultEventChannelCapacity)
 	assert.Equal(t, conf.DispatchTimeout, DefaultDispatchTimeout)
 	assert.Equal(t, conf.KubeQPS, DefaultKubeQPS)
@@ -90,7 +89,6 @@ func TestParseConfigMap(t *testing.T) {
 		{CMSvcEnableConfigHotRefresh, "EnableConfigHotRefresh", false},
 		{CMSvcPlaceholderImage, "PlaceHolderImage", "test-image"},
 		{CMSvcNodeInstanceTypeNodeLabelKey, "InstanceTypeNodeLabelKey", "node.kubernetes.io/instance-type"},
-		{CMLogLevel, "LoggingLevel", -1},
 		{CMKubeQPS, "KubeQPS", 2345},
 		{CMKubeBurst, "KubeBurst", 3456},
 	}
@@ -123,7 +121,6 @@ func TestUpdateConfigMapNonReloadable(t *testing.T) {
 		{CMSvcDisableGangScheduling, "DisableGangScheduling", true, false},
 		{CMSvcPlaceholderImage, "PlaceHolderImage", "test-image", false},
 		{CMSvcNodeInstanceTypeNodeLabelKey, "InstanceTypeNodeLabelKey", "node.kubernetes.io/instance-type", false},
-		{CMLogLevel, "LoggingLevel", -1, true},
 		{CMKubeQPS, "KubeQPS", 2345, false},
 		{CMKubeBurst, "KubeBurst", 3456, false},
 	}

--- a/pkg/log/filtered_core.go
+++ b/pkg/log/filtered_core.go
@@ -1,0 +1,54 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package log
+
+import "go.uber.org/zap/zapcore"
+
+type filteredCore struct {
+	level zapcore.Level
+	inner zapcore.Core
+}
+
+var _ zapcore.Core = filteredCore{}
+
+func (f filteredCore) Enabled(level zapcore.Level) bool {
+	if level < f.level {
+		return false
+	}
+	return f.inner.Enabled(level)
+}
+
+func (f filteredCore) With(fields []zapcore.Field) zapcore.Core {
+	return f.inner.With(fields)
+}
+
+func (f filteredCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if entry.Level < f.level {
+		return ce
+	}
+	return f.inner.Check(entry, ce)
+}
+
+func (f filteredCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	return f.inner.Write(entry, fields)
+}
+
+func (f filteredCore) Sync() error {
+	return f.inner.Sync()
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -45,18 +45,21 @@ func (h LoggerHandle) String() string {
 
 // Logger constants for configuration
 const (
+	nullLogger  = ""
 	defaultLog  = "log.level"
 	logPrefix   = "log."
 	levelSuffix = ".level"
 )
 
 // Predefined loggers: when adding new loggers, ids must be sequential, and all must be added to the loggers slice in the same order
+var (
+	K8Shim     = &LoggerHandle{id: 1, name: "k8shim"}
+	Kubernetes = &LoggerHandle{id: 2, name: "kubernetes"}
+	Admission  = &LoggerHandle{id: 3, name: "admission"}
+	Test       = &LoggerHandle{id: 4, name: "test"}
+)
 
-var K8Shim = &LoggerHandle{id: 1, name: "k8shim"}
-var Kubernetes = &LoggerHandle{id: 2, name: "kubernetes"}
-var Admission = &LoggerHandle{id: 3, name: "admission"}
-var Test = &LoggerHandle{id: 4, name: "test"}
-
+// this tracks all the known logger handles, used to preallocate the real logger instances when configuration changes
 var loggers = []*LoggerHandle{
 	K8Shim,
 	Kubernetes,
@@ -64,26 +67,31 @@ var loggers = []*LoggerHandle{
 	Test,
 }
 
+// structure to hold all current logger configuration state
 type loggerConfig struct {
 	loggers []*zap.Logger
 }
 
+// tracks the currently used set of loggers; replaced completely whenever configuration changes
 var currentLoggerConfig = atomic.Pointer[loggerConfig]{}
+
+// tracks the default logger handle, which is used for legacy log.Logger() calls
 var defaultLogger = atomic.Pointer[LoggerHandle]{}
 
-// Logger retrieves the global logger
+// Logger retrieves the global logger. This is for compatibility with legacy code and
+// should not be used for new log messages; use Log(loggerHandle) instead
 func Logger() *zap.Logger {
 	once.Do(initLogger)
 	return Log(defaultLogger.Load())
 }
 
-// RootLogger retrieves the root logger
+// RootLogger retrieves the root logger, used to pass the configured logger to the scheduler core on startup
 func RootLogger() *zap.Logger {
 	once.Do(initLogger)
 	return logger
 }
 
-// Log retrieves a standard logger
+// Log retrieves a named logger
 func Log(handle *LoggerHandle) *zap.Logger {
 	once.Do(initLogger)
 	if handle == nil || handle.id == 0 {
@@ -93,6 +101,8 @@ func Log(handle *LoggerHandle) *zap.Logger {
 	return conf.loggers[handle.id-1]
 }
 
+// createLogger creates a new, named logger that has log levels filtered based on the given configuration.
+// levelMap contains a mapping of fully-qualified logger names to log levels
 func createLogger(levelMap map[string]zapcore.Level, name string) *zap.Logger {
 	level := loggerLevel(levelMap, name)
 	return logger.Named(name).WithOptions(zap.WrapCore(func(inner zapcore.Core) zapcore.Core {
@@ -100,22 +110,39 @@ func createLogger(levelMap map[string]zapcore.Level, name string) *zap.Logger {
 	}))
 }
 
+// loggerLevel computes the log level that should be associated with an arbitrarily named logger.
+// The levelMap is used to look up the level. If not found, the parent logger is looked up until no further
+// parents can be tried, consulting levelMap for each possible match. For example, given a logger named
+// k8shim.context.cache, the following keys will be looked up in levelMap:
+//
+//	"k8shim.context.cache"
+//	"k8shim.context"
+//	"k8shim"
+//	"" (default logger)
+//
+// The first key that returns a match determines the log level returned. This allows a level of
+// "k8shim" to control all the child loggers as well if there is not a more specific override.
+// If no configuration can be found, even for the default empty logger, InfoLevel will be returned.
 func loggerLevel(levelMap map[string]zapcore.Level, name string) zapcore.Level {
-	for ; name != ""; name = parentLogger(name) {
+	for ; name != nullLogger; name = parentLogger(name) {
 		if level, ok := levelMap[name]; ok {
 			return level
 		}
 	}
-	if level, ok := levelMap[""]; ok {
+	if level, ok := levelMap[nullLogger]; ok {
 		return level
 	}
 	return zapcore.InfoLevel
 }
 
+// parentLogger returns the name of the parent logger or the empty string "" if no parent exists.
+// Loggers are named with periods (.) as separators; i.e. the parent logger of "a.b.c" is "a.b", the parent of
+// "a.b" is "a", and the parent of "a" is "".
 func parentLogger(name string) string {
 	i := strings.LastIndex(name, ".")
 	if i < 0 {
-		return ""
+		// no remaining periods; parent is the null logger
+		return nullLogger
 	}
 	return name[0:i]
 }
@@ -178,45 +205,59 @@ func SetDefaultLogger(handle *LoggerHandle) {
 	defaultLogger.Store(handle)
 }
 
-// UpdateLoggingConfig is used to reconfigure logging.
-// This uses config keys of the form log.{logger}.level={level}.
-// The default level is set by log.level={level}
+// UpdateLoggingConfig is used to reconfigure logging. This uses config keys of the form log.{logger}.level={level}.
+// The default level is set by log.level={level}. The {level} value can be either numeric (-1 through 5), or
+// textual (DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, or ERROR). See zapcore documentation for more details.
 func UpdateLoggingConfig(config map[string]string) {
 	once.Do(initLogger)
 	initLoggingConfig(config)
 }
 
+// initLoggingConfig replaces the existing set of loggers with new ones configured according to the given
+// configuration. All keys of the form "log.{name}.level" will be parsed and a map of logger name -> logger level
+// will be created. For each defined logger handle (see above), a new logger instance is created using the
+// most specific configuration found. For example, a logger named "a.b.c" will be configured by "log.a.b.c.level".
+// If this key does not exist, "a.b" will be consulted, then "a", and finally "". If no configuration is found for a
+// given key, Info will be used. Finally, the finest log level specified in any configuration will be used to set the
+// zap log level of the root logger. So if two loggers (one INFO, and one DEBUG) are configured, the root logger will
+// be set to DEBUG level. If both loggers were at INFO level, the root logger would be set to INFO.
+// Each configured logger will filter log messages at its own level by wrapping the underlying zap.Core implementation
+// with one that checks the enabled log level first.
 func initLoggingConfig(config map[string]string) {
 	levelMap := make(map[string]zapcore.Level)
-	levelMap[""] = zapcore.InfoLevel
+	levelMap[nullLogger] = zapcore.InfoLevel
 	zapLoggers := make([]*zap.Logger, len(loggers))
 
-	// override default level if found
+	// override default level if found (log.level key)
 	if defaultLevel, ok := config[defaultLog]; ok {
 		if levelRef := parseLevel(defaultLevel); levelRef != nil {
-			levelMap[""] = *levelRef
+			levelMap[nullLogger] = *levelRef
 		}
 	}
 
 	// parse out log entries and build level map
 	for k, v := range config {
+		// disallow spaces and periods
 		if strings.Contains(k, "..") || strings.Contains(k, " ") {
-			// disallow spaces and periods
 			continue
 		}
+		// ensure config key starts with "log."
 		name, ok := strings.CutPrefix(k, logPrefix)
 		if !ok {
 			continue
 		}
+		// ensure config key ends with ".level"
 		name, ok = strings.CutSuffix(name, levelSuffix)
 		if !ok {
 			continue
 		}
+		// if value is a valid log level, store it in the level map
 		if levelRef := parseLevel(v); levelRef != nil {
 			levelMap[name] = *levelRef
 		}
 	}
 
+	// compute the finest log level necessary to allow all loggers to succeed
 	minLevel := zapcore.InvalidLevel - 1
 	for _, v := range levelMap {
 		if minLevel > v {
@@ -224,14 +265,21 @@ func initLoggingConfig(config map[string]string) {
 		}
 	}
 
+	// create each configured logger and initialize the overall configuration
 	for i := 0; i < len(loggers); i++ {
 		zapLoggers[i] = createLogger(levelMap, loggers[i].name)
 	}
 	newLoggerConfig := loggerConfig{loggers: zapLoggers}
+
+	// update the root zap logger level
 	zapConfigs.Level.SetLevel(minLevel)
+
+	// atomically update the set of loggers
 	currentLoggerConfig.Store(&newLoggerConfig)
 }
 
+// parseLevel parses a textual (or numeric) log level into a zapcore.Level instance. Both numeric (-1 <= level <= 5)
+// and textual (DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL) are supported.
 func parseLevel(level string) *zapcore.Level {
 	// parse text
 	zapLevel, err := zapcore.ParseLevel(level)

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -52,16 +52,16 @@ const (
 
 // Predefined loggers: when adding new loggers, ids must be sequential, and all must be added to the loggers slice in the same order
 
-var K8Shim = LoggerHandle{id: 1, name: "k8shim"}
-var Kubernetes = LoggerHandle{id: 2, name: "kubernetes"}
-var Admission = LoggerHandle{id: 3, name: "admission"}
-var Test = LoggerHandle{id: 4, name: "test"}
+var K8Shim = &LoggerHandle{id: 1, name: "k8shim"}
+var Kubernetes = &LoggerHandle{id: 2, name: "kubernetes"}
+var Admission = &LoggerHandle{id: 3, name: "admission"}
+var Test = &LoggerHandle{id: 4, name: "test"}
 
 var loggers = []*LoggerHandle{
-	&K8Shim,
-	&Kubernetes,
-	&Admission,
-	&Test,
+	K8Shim,
+	Kubernetes,
+	Admission,
+	Test,
 }
 
 type loggerConfig struct {
@@ -74,7 +74,7 @@ var defaultLogger = atomic.Pointer[LoggerHandle]{}
 // Logger retrieves the global logger
 func Logger() *zap.Logger {
 	once.Do(initLogger)
-	return Log(*defaultLogger.Load())
+	return Log(defaultLogger.Load())
 }
 
 // RootLogger retrieves the root logger
@@ -84,10 +84,10 @@ func RootLogger() *zap.Logger {
 }
 
 // Log retrieves a standard logger
-func Log(handle LoggerHandle) *zap.Logger {
+func Log(handle *LoggerHandle) *zap.Logger {
 	once.Do(initLogger)
-	if handle.id == 0 {
-		handle = *defaultLogger.Load()
+	if handle == nil || handle.id == 0 {
+		handle = defaultLogger.Load()
 	}
 	conf := currentLoggerConfig.Load()
 	return conf.loggers[handle.id-1]
@@ -121,7 +121,7 @@ func parentLogger(name string) string {
 }
 
 func initLogger() {
-	defaultLogger.Store(&K8Shim)
+	defaultLogger.Store(K8Shim)
 	outputPaths := []string{"stdout"}
 
 	zapConfigs = &zap.Config{
@@ -173,9 +173,9 @@ func GetZapConfigs() *zap.Config {
 }
 
 // SetDefaultLogger allows customization of the default logger
-func SetDefaultLogger(handle LoggerHandle) {
+func SetDefaultLogger(handle *LoggerHandle) {
 	once.Do(initLogger)
-	defaultLogger.Store(&handle)
+	defaultLogger.Store(handle)
 }
 
 // UpdateLoggingConfig is used to reconfigure logging.

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -26,12 +26,23 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"gotest.tools/v3/assert"
 )
 
 var logDir string
 var logFile string
 
 var iterations = 100000
+
+func TestLoggerIds(t *testing.T) {
+	_ = Logger()
+	// validate that all loggers are populated and have sequential ids
+	for i := 0; i < len(loggers); i++ {
+		handle := loggers[i]
+		assert.Assert(t, handle != nil, "nil handle for index", i)
+		assert.Equal(t, handle.id, i+1, "wrong id", handle.name)
+	}
+}
 
 func BenchmarkLegacyLoggerDebug(b *testing.B) {
 	benchmarkLegacyLoggerDebug(b.N)
@@ -225,5 +236,5 @@ func initTestLogger() {
 	if err != nil {
 		panic(err)
 	}
-	defer logger.Sync()
+	defer logger.Sync() //nolint:errcheck
 }

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -1,0 +1,202 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"gotest.tools/v3/assert"
+)
+
+var logDir string
+var logFile string
+
+var iterations = 100000
+
+func TestLegacyLoggerPerformance(t *testing.T) {
+	_ = Logger() // make sure logger is initialized once
+	initTestLogger(t)
+	defer resetTestLogger(t)
+
+	debugStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		RootLogger().Debug("test", zap.String("foo", "bar"))
+	}
+	debugNsOp := (time.Since(debugStart).Nanoseconds()) / int64(iterations)
+
+	infoStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		RootLogger().Info("test", zap.String("foo", "bar"))
+	}
+	infoNsOp := (time.Since(infoStart).Nanoseconds()) / int64(iterations)
+
+	warnStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		RootLogger().Warn("test", zap.String("foo", "bar"))
+	}
+	warnNsOp := (time.Since(warnStart).Nanoseconds()) / int64(iterations)
+
+	resetTestLogger(t)
+
+	RootLogger().Info("log.Logger() performance",
+		zap.Int64("debug (ns/op)", debugNsOp),
+		zap.Int64("info (ns/op)", infoNsOp),
+		zap.Int64("warn (ns/op)", warnNsOp))
+}
+
+func TestLoggerPerformance(t *testing.T) {
+	_ = RootLogger() // make sure logger is initialized once
+	initTestLogger(t)
+	defer resetTestLogger(t)
+
+	debugStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		Log(K8Shim).Debug("test", zap.String("foo", "bar"))
+	}
+	debugNsOp := (time.Since(debugStart).Nanoseconds()) / int64(iterations)
+
+	infoStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		Log(K8Shim).Info("test", zap.String("foo", "bar"))
+	}
+	infoNsOp := (time.Since(infoStart).Nanoseconds()) / int64(iterations)
+
+	warnStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		Log(K8Shim).Warn("test", zap.String("foo", "bar"))
+	}
+	warnNsOp := (time.Since(warnStart).Nanoseconds()) / int64(iterations)
+
+	resetTestLogger(t)
+
+	Log(Test).Info("log.Log(...) performance (root=INFO)",
+		zap.Int64("debug (ns/op)", debugNsOp),
+		zap.Int64("info (ns/op)", infoNsOp),
+		zap.Int64("warn (ns/op)", warnNsOp))
+}
+
+func TestLoggerPerformanceWithEnabledDebug(t *testing.T) {
+	_ = RootLogger() // make sure logger is initialized once
+	initTestLogger(t)
+	UpdateLoggingConfig(map[string]string{
+		"log.test.level": "DEBUG",
+	})
+	defer resetTestLogger(t)
+
+	writtenDebugStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		Log(Test).Debug("test", zap.String("foo", "bar"))
+	}
+	writtenDebugNsOp := (time.Since(writtenDebugStart).Nanoseconds()) / int64(iterations)
+
+	debugStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		Log(K8Shim).Debug("test", zap.String("foo", "bar"))
+	}
+	debugNsOp := (time.Since(debugStart).Nanoseconds()) / int64(iterations)
+
+	infoStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		Log(K8Shim).Info("test", zap.String("foo", "bar"))
+	}
+	infoNsOp := (time.Since(infoStart).Nanoseconds()) / int64(iterations)
+
+	warnStart := time.Now()
+	for i := 0; i < iterations; i++ {
+		Log(K8Shim).Warn("test", zap.String("foo", "bar"))
+	}
+	warnNsOp := (time.Since(warnStart).Nanoseconds()) / int64(iterations)
+
+	resetTestLogger(t)
+
+	Log(Test).Info("log.Log(...) performance (root=DEBUG)",
+		zap.Int64("debug (written) (ns/op)", writtenDebugNsOp),
+		zap.Int64("debug (filtered) (ns/op)", debugNsOp),
+		zap.Int64("info (ns/op)", infoNsOp),
+		zap.Int64("warn (ns/op)", warnNsOp))
+}
+
+func resetTestLogger(t *testing.T) {
+	// flush log
+	logger.Sync() //nolint:errcheck
+
+	// init default logger
+	initLogger()
+
+	// update logger config to defaults
+	UpdateLoggingConfig(map[string]string{})
+
+	// stat log file
+	if logFile != "" {
+		stat, err := os.Stat(logFile)
+		assert.NilError(t, err, "log file not found")
+		Log(Test).Info("Wrote logs of size", zap.Int64("size", stat.Size()))
+		logFile = ""
+	}
+	// remove original log dir
+	if logDir != "" {
+		err := os.RemoveAll(logDir)
+		assert.NilError(t, err, "failed to remove temp dir")
+	}
+}
+
+// initTestLogger is basically the same as the default initLogger() function but uses a temporary file.
+// this ensures that the logging API is actually used, while allowing us to avoid massive log spam to stdout
+func initTestLogger(t *testing.T) {
+	path, err := os.MkdirTemp("", "log*")
+	assert.NilError(t, err, "failed to create temp dir")
+	logDir = path
+	logFile = fmt.Sprintf("%s/log.stdout", logDir)
+	outputPaths := []string{logFile}
+	fmt.Printf("Logging to %s", logFile)
+	zapConfigs = &zap.Config{
+		Level:             zap.NewAtomicLevelAt(zapcore.Level(0)),
+		Development:       false,
+		DisableCaller:     false,
+		DisableStacktrace: false,
+		Sampling:          nil,
+		Encoding:          "console",
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey:    "message",
+			LevelKey:      "level",
+			TimeKey:       "time",
+			NameKey:       "logger",
+			CallerKey:     "caller",
+			StacktraceKey: "stacktrace",
+			LineEnding:    zapcore.DefaultLineEnding,
+			// note: https://godoc.org/go.uber.org/zap/zapcore#EncoderConfig
+			// only EncodeName is optional all others must be set
+			EncodeLevel:    zapcore.CapitalLevelEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		},
+		OutputPaths:      outputPaths,
+		ErrorOutputPaths: []string{"stderr"},
+	}
+
+	logger, err = zapConfigs.Build()
+	assert.NilError(t, err, "failed to create logger")
+	defer logger.Sync() //nolint:errcheck
+}

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -180,6 +180,34 @@ func benchmarkScopedLoggerInfoFiltered(iterations int) int64 {
 	return (time.Since(start).Nanoseconds()) / int64(iterations)
 }
 
+func TestParseLevel(t *testing.T) {
+	assert.Equal(t, zapcore.DebugLevel, *parseLevel("-2"), "out of range low")
+	assert.Equal(t, zapcore.DebugLevel, *parseLevel("-1"))
+	assert.Equal(t, zapcore.InfoLevel, *parseLevel("0"))
+	assert.Equal(t, zapcore.WarnLevel, *parseLevel("1"))
+	assert.Equal(t, zapcore.ErrorLevel, *parseLevel("2"))
+	assert.Equal(t, zapcore.DPanicLevel, *parseLevel("3"))
+	assert.Equal(t, zapcore.PanicLevel, *parseLevel("4"))
+	assert.Equal(t, zapcore.FatalLevel, *parseLevel("5"))
+	assert.Equal(t, zapcore.FatalLevel, *parseLevel("6"), "out of range high")
+	assert.Assert(t, parseLevel("+2-3") == nil, "parse error")
+	assert.Equal(t, zapcore.DebugLevel, *parseLevel("Debug"))
+	assert.Equal(t, zapcore.InfoLevel, *parseLevel("iNFO"))
+	assert.Equal(t, zapcore.WarnLevel, *parseLevel("WaRn"))
+	assert.Equal(t, zapcore.ErrorLevel, *parseLevel("ERROR"))
+	assert.Equal(t, zapcore.DPanicLevel, *parseLevel("dpanic"))
+	assert.Equal(t, zapcore.PanicLevel, *parseLevel("PAnIC"))
+	assert.Equal(t, zapcore.FatalLevel, *parseLevel("faTal"))
+	assert.Assert(t, parseLevel("x") == nil, "parse error")
+}
+
+func TestParentLogger(t *testing.T) {
+	assert.Equal(t, "", parentLogger(""), "nullLogger")
+	assert.Equal(t, "", parentLogger("a"), "level 1")
+	assert.Equal(t, "a", parentLogger("a.b"), "level 2")
+	assert.Equal(t, "a.b", parentLogger("a.b.c"), "level 3")
+}
+
 func resetTestLogger() {
 	// flush log
 	logger.Sync() //nolint:errcheck

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -36,6 +36,10 @@ var iterations = 100000
 
 func TestLoggerIds(t *testing.T) {
 	_ = Logger()
+
+	// validate logger count
+	assert.Equal(t, 4, len(loggers), "wrong logger count")
+
 	// validate that all loggers are populated and have sequential ids
 	for i := 0; i < len(loggers); i++ {
 		handle := loggers[i]

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -216,6 +216,7 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 
 // NewSchedulerPlugin initializes a new plugin and returns it
 func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+	log.SetDefaultLogger(log.K8Shim)
 	log.Logger().Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s arch=%s coreSHA=%s siSHA=%s shimSHA=%s", conf.BuildVersion, conf.BuildDate, conf.IsPluginVersion, conf.GoVersion, conf.Arch, conf.CoreSHA, conf.SiSHA, conf.ShimSHA))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
@@ -229,7 +230,7 @@ func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Pl
 	}
 
 	// start the YK core scheduler
-	serviceContext := entrypoint.StartAllServicesWithLogger(log.Logger(), log.GetZapConfigs())
+	serviceContext := entrypoint.StartAllServicesWithLogger(log.RootLogger(), log.GetZapConfigs())
 	if sa, ok := serviceContext.RMProxy.(api.SchedulerAPI); ok {
 		// we need our own informer factory here because the informers we get from the framework handle aren't yet initialized
 		informerFactory := informers.NewSharedInformerFactory(handle.ClientSet(), 0)


### PR DESCRIPTION
Add API support for scoped logging to the Kubernetes shim and admission controller. This will allow for fine-grained logging control per-subsystem.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1797

### How should this be tested?
All shim log messages should now go to the "k8shim" logger, and admission logs to the "admission" logger. Future PRs will move individual subsystems to even more specific loggers.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
