### PR TITLE
[YUNIKORN-1821] Fix shell script in authz use cases

### DIFF
--- a/deployments/examples/authz/k8s-api-access/create-user.sh
+++ b/deployments/examples/authz/k8s-api-access/create-user.sh
@@ -16,15 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-USERS=("admin admin" "sue group-a" "bob group-a" "kim group-b" "yono group-b" "anonymous anonymous")
+USERS=("admin" "sue" "bob" "kim" "yono" "anonymous")
+USERS_GROUP=("admin" "group-a" "group-a" "group-b" "group-b" "anonymous")
 AUTH_FOLDER=./auth
 CERT_REQUEST_FILE=./certification_request.yaml
 
 mkdir -p $AUTH_FOLDER
 for ((i = 0; i < ${#USERS[@]}; ++i)); do
-    USER=("${USERS[i]}")
-    USERNAME=${USER[0]}
-    GROUP=${USER[1]}
+    USERNAME="${USERS[i]}"
+    GROUP="${USERS_GROUP[i]}"
     AUTH_FILE=$AUTH_FOLDER/$USERNAME
     echo "username: $USERNAME , group: $GROUP"
     # create a CSR for the user

--- a/deployments/examples/authz/k8s-api-access/remove-user.sh
+++ b/deployments/examples/authz/k8s-api-access/remove-user.sh
@@ -16,11 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-USERS=("admin admin" "sue group-a" "bob group-a" "kim dev" "yono test" "anonymous anonymous")
+USERS=("admin" "sue" "bob" "kim" "yono" "anonymous")
 
 for ((i = 0; i < ${#USERS[@]}; ++i)); do
-    USER=("${USERS[i]}")
-    USERNAME=${USER[0]}
+    USERNAME="${USERS[i]}"
 
     kubectl delete csr/"$USERNAME"-csr
     kubectl config unset contexts."$USERNAME"-context


### PR DESCRIPTION
### What is this PR for?
When the shell script uses a two-dimensional array, if you use double quotes (required by shellcheck) when accessing variables, the access results will not be as expected. ex. `username: admin admin`
I split two-dimensional array to two array.

### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1821/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
