### PR TITLE
[YUNIKORN-1843] Shim: Remove deprecated logger functionality

### DIFF
--- a/pkg/cmd/admissioncontroller/main.go
+++ b/pkg/cmd/admissioncontroller/main.go
@@ -52,7 +52,6 @@ type WebHook struct {
 }
 
 func main() {
-	log.SetDefaultLogger(log.Admission)
 	configMaps, err := client.LoadBootstrapConfigMaps(schedulerconf.GetSchedulerNamespace())
 	if err != nil {
 		log.Log(log.Admission).Fatal("Failed to load initial configmaps", zap.Error(err))

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -55,7 +55,6 @@ func main() {
 	conf.SiSHA = siSHA
 	conf.ShimSHA = shimSHA
 
-	log.SetDefaultLogger(log.Shim)
 	log.Log(log.Shim).Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s arch=%s coreSHA=%s siSHA=%s shimSHA=%s", version, date, false, goVersion, arch, coreSHA, siSHA, shimSHA))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -149,7 +149,7 @@ func GetNamespaceGuaranteedFromAnnotation(namespaceObj *v1.Namespace) *si.Resour
 	var namespaceGuaranteedMap map[string]string
 	err := json.Unmarshal([]byte(namespaceGuaranteed), &namespaceGuaranteedMap)
 	if err != nil {
-		log.Logger().Warn("Unable to process namespace.guaranteed annotation",
+		log.Log(log.ShimUtils).Warn("Unable to process namespace.guaranteed annotation",
 			zap.String("namespace", namespaceObj.Name),
 			zap.String("namespace.guaranteed is", namespaceGuaranteed))
 		return nil

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -53,34 +53,34 @@ const (
 
 // Defined loggers: when adding new loggers, ids must be sequential, and all must be added to the loggers slice in the same order
 var (
-	Shim                     = &LoggerHandle{id: 1, name: "shim"}
-	Kubernetes               = &LoggerHandle{id: 2, name: "kubernetes"}
-	Test                     = &LoggerHandle{id: 3, name: "test"}
-	Admission                = &LoggerHandle{id: 4, name: "admission"}
-	AdmissionClient          = &LoggerHandle{id: 5, name: "admission.client"}
-	AdmissionConf            = &LoggerHandle{id: 6, name: "admission.conf"}
-	AdmissionWebhook         = &LoggerHandle{id: 7, name: "admission.webhook"}
-	AdmissionUtils           = &LoggerHandle{id: 8, name: "admission.utils"}
-	ShimAppMgmt              = &LoggerHandle{id: 9, name: "shim.appmgmt"}
-	ShimAppMgmtGeneral       = &LoggerHandle{id: 10, name: "shim.appmgmt.general"}
-	ShimAppMgmtSparkOperator = &LoggerHandle{id: 11, name: "shim.appmgmt.sparkoperator"}
-	ShimContext              = &LoggerHandle{id: 12, name: "shim.context"}
-	ShimFSM                  = &LoggerHandle{id: 13, name: "shim.fsm"}
-	ShimCacheApplication     = &LoggerHandle{id: 14, name: "shim.cache.application"}
-	ShimCacheNode            = &LoggerHandle{id: 15, name: "shim.cache.node"}
-	ShimCacheTask            = &LoggerHandle{id: 16, name: "shim.cache.task"}
-	ShimCacheExternal        = &LoggerHandle{id: 17, name: "shim.cache.external"}
-	ShimCachePlaceholder     = &LoggerHandle{id: 18, name: "shim.cache.placeholder"}
-	ShimRMCallback           = &LoggerHandle{id: 19, name: "shim.rmcallback"}
-	ShimClient               = &LoggerHandle{id: 20, name: "shim.client"}
-	ShimResources            = &LoggerHandle{id: 21, name: "shim.resources"}
-	ShimUtils                = &LoggerHandle{id: 22, name: "shim.utils"}
-	ShimConfig               = &LoggerHandle{id: 23, name: "shim.config"}
-	ShimDispatcher           = &LoggerHandle{id: 24, name: "shim.dispatcher"}
-	ShimScheduler            = &LoggerHandle{id: 25, name: "shim.scheduler"}
-	ShimSchedulerPlugin      = &LoggerHandle{id: 26, name: "shim.scheduler.plugin"}
-	ShimPredicates           = &LoggerHandle{id: 27, name: "shim.predicates"}
-	ShimFramework            = &LoggerHandle{id: 28, name: "shim.framework"}
+	Shim                     = &LoggerHandle{id: 0, name: "shim"}
+	Kubernetes               = &LoggerHandle{id: 1, name: "kubernetes"}
+	Test                     = &LoggerHandle{id: 2, name: "test"}
+	Admission                = &LoggerHandle{id: 3, name: "admission"}
+	AdmissionClient          = &LoggerHandle{id: 4, name: "admission.client"}
+	AdmissionConf            = &LoggerHandle{id: 5, name: "admission.conf"}
+	AdmissionWebhook         = &LoggerHandle{id: 6, name: "admission.webhook"}
+	AdmissionUtils           = &LoggerHandle{id: 7, name: "admission.utils"}
+	ShimAppMgmt              = &LoggerHandle{id: 8, name: "shim.appmgmt"}
+	ShimAppMgmtGeneral       = &LoggerHandle{id: 9, name: "shim.appmgmt.general"}
+	ShimAppMgmtSparkOperator = &LoggerHandle{id: 10, name: "shim.appmgmt.sparkoperator"}
+	ShimContext              = &LoggerHandle{id: 11, name: "shim.context"}
+	ShimFSM                  = &LoggerHandle{id: 12, name: "shim.fsm"}
+	ShimCacheApplication     = &LoggerHandle{id: 13, name: "shim.cache.application"}
+	ShimCacheNode            = &LoggerHandle{id: 14, name: "shim.cache.node"}
+	ShimCacheTask            = &LoggerHandle{id: 15, name: "shim.cache.task"}
+	ShimCacheExternal        = &LoggerHandle{id: 16, name: "shim.cache.external"}
+	ShimCachePlaceholder     = &LoggerHandle{id: 17, name: "shim.cache.placeholder"}
+	ShimRMCallback           = &LoggerHandle{id: 18, name: "shim.rmcallback"}
+	ShimClient               = &LoggerHandle{id: 19, name: "shim.client"}
+	ShimResources            = &LoggerHandle{id: 20, name: "shim.resources"}
+	ShimUtils                = &LoggerHandle{id: 21, name: "shim.utils"}
+	ShimConfig               = &LoggerHandle{id: 22, name: "shim.config"}
+	ShimDispatcher           = &LoggerHandle{id: 23, name: "shim.dispatcher"}
+	ShimScheduler            = &LoggerHandle{id: 24, name: "shim.scheduler"}
+	ShimSchedulerPlugin      = &LoggerHandle{id: 25, name: "shim.scheduler.plugin"}
+	ShimPredicates           = &LoggerHandle{id: 26, name: "shim.predicates"}
+	ShimFramework            = &LoggerHandle{id: 27, name: "shim.framework"}
 )
 
 // this tracks all the known logger handles, used to preallocate the real logger instances when configuration changes
@@ -101,17 +101,6 @@ type loggerConfig struct {
 // tracks the currently used set of loggers; replaced completely whenever configuration changes
 var currentLoggerConfig = atomic.Pointer[loggerConfig]{}
 
-// tracks the default logger handle, which is used for legacy log.Logger() calls
-var defaultLogger = atomic.Pointer[LoggerHandle]{}
-
-// Logger retrieves the global logger.
-//
-// Deprecated: Use Log(loggerHandle) instead.
-func Logger() *zap.Logger {
-	once.Do(initLogger)
-	return Log(defaultLogger.Load())
-}
-
 // RootLogger retrieves the root logger, used to pass the configured logger to the scheduler core on startup
 func RootLogger() *zap.Logger {
 	once.Do(initLogger)
@@ -121,11 +110,11 @@ func RootLogger() *zap.Logger {
 // Log retrieves a named logger
 func Log(handle *LoggerHandle) *zap.Logger {
 	once.Do(initLogger)
-	if handle == nil || handle.id == 0 {
-		handle = defaultLogger.Load()
-	}
 	conf := currentLoggerConfig.Load()
-	return conf.loggers[handle.id-1]
+	if handle == nil {
+		return conf.loggers[0]
+	}
+	return conf.loggers[handle.id]
 }
 
 // createLogger creates a new, named logger that has log levels filtered based on the given configuration.
@@ -175,7 +164,6 @@ func parentLogger(name string) string {
 }
 
 func initLogger() {
-	defaultLogger.Store(Shim)
 	outputPaths := []string{"stdout"}
 
 	zapConfigs = &zap.Config{
@@ -222,14 +210,8 @@ func initLogger() {
 
 func GetZapConfigs() *zap.Config {
 	// force init
-	_ = Log(nil)
+	_ = Log(Shim)
 	return zapConfigs
-}
-
-// SetDefaultLogger allows customization of the default logger
-func SetDefaultLogger(handle *LoggerHandle) {
-	once.Do(initLogger)
-	defaultLogger.Store(handle)
 }
 
 // UpdateLoggingConfig is used to reconfigure logging. This uses config keys of the form log.{logger}.level={level}.

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -44,8 +44,13 @@ func TestLoggerIds(t *testing.T) {
 	for i := 0; i < len(loggers); i++ {
 		handle := loggers[i]
 		assert.Assert(t, handle != nil, "nil handle for index", i)
-		assert.Equal(t, handle.id, i+1, "wrong id", handle.name)
+		assert.Equal(t, handle.id, i, "wrong id", handle.name)
 	}
+}
+
+func TestNilLogger(t *testing.T) {
+	log := Log(nil)
+	assert.Check(t, log != nil, "nil logger")
 }
 
 func BenchmarkScopedLoggerDebug(b *testing.B) {

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -218,7 +218,6 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 
 // NewSchedulerPlugin initializes a new plugin and returns it
 func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
-	log.SetDefaultLogger(log.Shim)
 	log.Log(log.ShimSchedulerPlugin).Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s arch=%s coreSHA=%s siSHA=%s shimSHA=%s", conf.BuildVersion, conf.BuildDate, conf.IsPluginVersion, conf.GoVersion, conf.Arch, conf.CoreSHA, conf.SiSHA, conf.ShimSHA))
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())


### PR DESCRIPTION
### What is this PR for?
Remove the obsolete log.Logger() function from the shim and simplify the logging implementation since backwards compatibility is no longer needed.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1843

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
