### PR TITLE
[YUNIKORN-1853] de-duplicate build info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,10 +223,11 @@ init:
 
 # Build scheduler binary for dev and test
 .PHONY: build
+FLAG_PREFIX=github.com/apache/yunikorn-k8shim/pkg/conf
 build: init
 	@echo "building scheduler binary"
 	go build -o=${DEV_BIN_DIR}/${BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-X ${FLAG_PREFIX}.buildVersion=${VERSION} -X ${FLAG_PREFIX}.buildDate=${DATE} -X ${FLAG_PREFIX}.isPluginVersion=false -X ${FLAG_PREFIX}.goVersion=${GO_VERSION} -X ${FLAG_PREFIX}.arch=${EXEC_ARCH} -X ${FLAG_PREFIX}.coreSHA=${CORE_SHA} -X ${FLAG_PREFIX}.siSHA=${SI_SHA} -X ${FLAG_PREFIX}.shimSHA=${SHIM_SHA}' \
 	./pkg/cmd/shim/
 	@chmod +x ${DEV_BIN_DIR}/${BINARY}
 
@@ -234,7 +235,7 @@ build: init
 build_plugin: init
 	@echo "building scheduler plugin binary"
 	go build -o=${DEV_BIN_DIR}/${PLUGIN_BINARY} -race -ldflags \
-	'-X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-X ${FLAG_PREFIX}.buildVersion=${VERSION} -X ${FLAG_PREFIX}.buildDate=${DATE} -X ${FLAG_PREFIX}.isPluginVersion=true -X ${FLAG_PREFIX}.goVersion=${GO_VERSION} -X ${FLAG_PREFIX}.arch=${EXEC_ARCH} -X ${FLAG_PREFIX}.coreSHA=${CORE_SHA} -X ${FLAG_PREFIX}.siSHA=${SI_SHA} -X ${FLAG_PREFIX}.shimSHA=${SHIM_SHA}' \
 	./pkg/cmd/schedulerplugin/
 	@chmod +x ${DEV_BIN_DIR}/${PLUGIN_BINARY}
 
@@ -244,7 +245,7 @@ scheduler: init
 	@echo "building binary for scheduler docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${BINARY} -trimpath -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-extldflags "-static" -X ${FLAG_PREFIX}.buildVersion=${VERSION} -X ${FLAG_PREFIX}.buildDate=${DATE} -X ${FLAG_PREFIX}.isPluginVersion=false -X ${FLAG_PREFIX}.goVersion=${GO_VERSION} -X ${FLAG_PREFIX}.arch=${EXEC_ARCH} -X ${FLAG_PREFIX}.coreSHA=${CORE_SHA} -X ${FLAG_PREFIX}.siSHA=${SI_SHA} -X ${FLAG_PREFIX}.shimSHA=${SHIM_SHA}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/shim/
 
@@ -254,7 +255,7 @@ plugin: init
 	@echo "building binary for plugin docker image"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${RELEASE_BIN_DIR}/${PLUGIN_BINARY} -trimpath -ldflags \
-	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH} -X main.coreSHA=${CORE_SHA} -X main.siSHA=${SI_SHA} -X main.shimSHA=${SHIM_SHA}' \
+	'-extldflags "-static" -X ${FLAG_PREFIX}.buildVersion=${VERSION} -X ${FLAG_PREFIX}.buildDate=${DATE} -X ${FLAG_PREFIX}.isPluginVersion=true -X ${FLAG_PREFIX}.goVersion=${GO_VERSION} -X ${FLAG_PREFIX}.arch=${EXEC_ARCH} -X ${FLAG_PREFIX}.coreSHA=${CORE_SHA} -X ${FLAG_PREFIX}.siSHA=${SI_SHA} -X ${FLAG_PREFIX}.shimSHA=${SHIM_SHA}' \
 	-tags netgo -installsuffix netgo \
 	./pkg/cmd/schedulerplugin/
 	
@@ -302,7 +303,7 @@ admission: init
 	@echo "building admission controller binary"
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	go build -a -o=${ADMISSION_CONTROLLER_BIN_DIR}/${POD_ADMISSION_CONTROLLER_BINARY} -trimpath -ldflags \
-    '-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE} -X main.goVersion=${GO_VERSION} -X main.arch=${EXEC_ARCH}' \
+    '-extldflags "-static" -X ${FLAG_PREFIX}.buildVersion=${VERSION} -X ${FLAG_PREFIX}.buildDate=${DATE} -X ${FLAG_PREFIX}.goVersion=${GO_VERSION} -X ${FLAG_PREFIX}.arch=${EXEC_ARCH}' \
     -tags netgo -installsuffix netgo \
     ./pkg/cmd/admissioncontroller
 

--- a/pkg/cmd/schedulerplugin/main.go
+++ b/pkg/cmd/schedulerplugin/main.go
@@ -23,30 +23,10 @@ import (
 
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 
-	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/schedulerplugin"
 )
 
-var (
-	version   string
-	date      string
-	goVersion string
-	arch      string
-	coreSHA   string
-	siSHA     string
-	shimSHA   string
-)
-
 func main() {
-	conf.BuildVersion = version
-	conf.BuildDate = date
-	conf.IsPluginVersion = true
-	conf.GoVersion = goVersion
-	conf.Arch = arch
-	conf.CoreSHA = coreSHA
-	conf.SiSHA = siSHA
-	conf.ShimSHA = shimSHA
-
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(schedulerplugin.SchedulerPluginName, schedulerplugin.NewSchedulerPlugin))
 

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -19,7 +19,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -35,27 +34,8 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/api"
 )
 
-var (
-	version   string
-	date      string
-	goVersion string
-	arch      string
-	coreSHA   string
-	siSHA     string
-	shimSHA   string
-)
-
 func main() {
-	conf.BuildVersion = version
-	conf.BuildDate = date
-	conf.IsPluginVersion = false
-	conf.GoVersion = goVersion
-	conf.Arch = arch
-	conf.CoreSHA = coreSHA
-	conf.SiSHA = siSHA
-	conf.ShimSHA = shimSHA
-
-	log.Log(log.Shim).Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s arch=%s coreSHA=%s siSHA=%s shimSHA=%s", version, date, false, goVersion, arch, coreSHA, siSHA, shimSHA))
+	log.Log(log.Shim).Info(conf.GetBuildInfoString())
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -85,14 +85,14 @@ const (
 )
 
 var (
-	BuildVersion    string
-	BuildDate       string
-	IsPluginVersion bool
-	GoVersion       string
-	Arch            string
-	CoreSHA         string
-	SiSHA           string
-	ShimSHA         string
+	buildVersion    string
+	buildDate       string
+	isPluginVersion string
+	goVersion       string
+	arch            string
+	coreSHA         string
+	siSHA           string
+	shimSHA         string
 )
 
 var once sync.Once
@@ -316,7 +316,7 @@ func CreateDefaultConfig() *SchedulerConf {
 		SchedulerName:            constants.SchedulerName,
 		Namespace:                GetSchedulerNamespace(),
 		ClusterID:                DefaultClusterID,
-		ClusterVersion:           BuildVersion,
+		ClusterVersion:           buildVersion,
 		PolicyGroup:              DefaultPolicyGroup,
 		Interval:                 DefaultSchedulingInterval,
 		KubeConfig:               GetDefaultKubeConfigPath(),
@@ -465,4 +465,24 @@ func FlattenConfigMaps(configMaps []*v1.ConfigMap) map[string]string {
 		}
 	}
 	return result
+}
+
+func GetBuildInfoMap() map[string]string {
+	return map[string]string{
+		"buildVersion":    buildVersion,
+		"buildDate":       buildDate,
+		"isPluginVersion": isPluginVersion,
+		"goVersion":       goVersion,
+		"arch":            arch,
+		"coreSHA":         coreSHA,
+		"siSHA":           siSHA,
+		"shimSHA":         shimSHA,
+	}
+}
+
+func GetBuildInfoString() string {
+	return fmt.Sprintf(
+		"Build info: version=%s date=%s isPluginVersion=%s goVersion=%s arch=%s coreSHA=%s siSHA=%s shimSHA=%s",
+		buildVersion, buildDate, isPluginVersion, goVersion, arch, coreSHA, siSHA, shimSHA,
+	)
 }

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -64,7 +64,7 @@ func TestOverriddenConfigMap(t *testing.T) {
 func assertDefaults(t *testing.T, conf *SchedulerConf) {
 	assert.Equal(t, conf.ClusterID, DefaultClusterID)
 	assert.Equal(t, conf.PolicyGroup, DefaultPolicyGroup)
-	assert.Equal(t, conf.ClusterVersion, BuildVersion)
+	assert.Equal(t, conf.ClusterVersion, buildVersion)
 	assert.Equal(t, conf.EventChannelCapacity, DefaultEventChannelCapacity)
 	assert.Equal(t, conf.DispatchTimeout, DefaultDispatchTimeout)
 	assert.Equal(t, conf.KubeQPS, DefaultKubeQPS)

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -218,7 +218,7 @@ func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.Cycl
 
 // NewSchedulerPlugin initializes a new plugin and returns it
 func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
-	log.Log(log.ShimSchedulerPlugin).Info(fmt.Sprintf("Build info: version=%s date=%s isPluginVersion=%t goVersion=%s arch=%s coreSHA=%s siSHA=%s shimSHA=%s", conf.BuildVersion, conf.BuildDate, conf.IsPluginVersion, conf.GoVersion, conf.Arch, conf.CoreSHA, conf.SiSHA, conf.ShimSHA))
+	log.Log(log.ShimSchedulerPlugin).Info(conf.GetBuildInfoString())
 
 	configMaps, err := client.LoadBootstrapConfigMaps(conf.GetSchedulerNamespace())
 	if err != nil {

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -21,7 +21,6 @@ package shim
 import (
 	"context"
 	"os"
-	"strconv"
 	"sync"
 	"time"
 
@@ -211,15 +210,7 @@ func (ss *KubernetesShim) doScheduling() {
 func (ss *KubernetesShim) registerShimLayer() error {
 	configuration := conf.GetSchedulerConf()
 
-	buildInfoMap := make(map[string]string)
-	buildInfoMap["buildVersion"] = conf.BuildVersion
-	buildInfoMap["buildDate"] = conf.BuildDate
-	buildInfoMap["isPluginVersion"] = strconv.FormatBool(conf.IsPluginVersion)
-	buildInfoMap["goVersion"] = conf.GoVersion
-	buildInfoMap["arch"] = conf.Arch
-	buildInfoMap["coreSHA"] = conf.CoreSHA
-	buildInfoMap["siSHA"] = conf.SiSHA
-	buildInfoMap["shimSHA"] = conf.ShimSHA
+	buildInfoMap := conf.GetBuildInfoMap()
 
 	configMaps, err := ss.context.LoadConfigMaps()
 	if err != nil {


### PR DESCRIPTION
### What is this PR for?

Set build information directly to `pkg/conf`, so we don't need to define variables in each main file.

### What type of PR is it?
* [ ] - Bug Fix
* [X] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-1853

### How should this be tested?

```
> curl -s http://localhost:9080/ws/v1/clusters | jq .
[
  {
    "startTime": 1688646403139158300,
    "rmBuildInformation": [
      {
        "arch": "amd64",
        "buildDate": "2023-07-06T20:20:55+0800",
        "buildVersion": "latest",
        "coreSHA": "148f221ab4f1",
        "goVersion": "1.20",
        "isPluginVersion": "false",
        "rmId": "mycluster",
        "shimSHA": "1e34d5f14c65",
        "siSHA": "bcadd461d275"
      }
    ],
    "partition": "default",
    "clusterName": "kubernetes"
  }
]
```

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
