### PR TITLE
[YUNIKORN-1908] Support GPU in placeholders

### DIFF
--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -79,6 +79,9 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup interfac
 		}
 	}
 
+	// prepare the resource lists
+	requests := utils.GetPlaceholderResourceRequests(taskGroup.MinResource)
+	limits := utils.GetPlaceholderResourceLimits(taskGroup.MinResource)
 	placeholderPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      placeholderName,
@@ -103,7 +106,8 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup interfac
 					Image:           conf.GetSchedulerConf().PlaceHolderImage,
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Resources: v1.ResourceRequirements{
-						Requests: utils.GetPlaceholderResourceRequest(taskGroup.MinResource),
+						Requests: requests,
+						Limits:   limits,
 					},
 				},
 			},

--- a/pkg/common/utils/gang_utils.go
+++ b/pkg/common/utils/gang_utils.go
@@ -32,11 +32,6 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 )
 
-const (
-	k8sDomain       = "kubernetes.io"
-	hugepagesPrefix = "hugepages-"
-)
-
 func FindAppTaskGroup(appTaskGroups []*interfaces.TaskGroup, groupName string) (*interfaces.TaskGroup, error) {
 	if groupName == "" {
 		// task has no group defined
@@ -99,11 +94,12 @@ func GetPlaceholderResourceLimits(resources map[string]resource.Quantity) v1.Res
 
 // allowOverCommit returns true if the resource can be over committed.
 // This comes down to only allow the standard resources cpu, memory and ephemeral-storage to be over committed.
+// We deviate from the K8s checks as opaque resources are no longer supported. Opaque resources were the only
+// resources in the "kubernetes.io" domain.
 // We slip in the "pods" resource on task groups but that does not cause an issue.
 func allowOverCommit(name string) bool {
-	return (!strings.Contains(name, "/") ||
-		strings.Contains(name, k8sDomain)) &&
-		!strings.HasPrefix(name, hugepagesPrefix)
+	return !strings.Contains(name, "/") &&
+		!strings.HasPrefix(name, v1.ResourceHugePagesPrefix)
 }
 
 func GetSchedulingPolicyParam(pod *v1.Pod) *interfaces.SchedulingPolicyParameters {

--- a/pkg/common/utils/gang_utils.go
+++ b/pkg/common/utils/gang_utils.go
@@ -32,6 +32,11 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 )
 
+const (
+	k8sDomain       = "kubernetes.io"
+	hugepagesPrefix = "hugepages-"
+)
+
 func FindAppTaskGroup(appTaskGroups []*interfaces.TaskGroup, groupName string) (*interfaces.TaskGroup, error) {
 	if groupName == "" {
 		// task has no group defined
@@ -54,24 +59,51 @@ func FindAppTaskGroup(appTaskGroups []*interfaces.TaskGroup, groupName string) (
 	return nil, fmt.Errorf("taskGroup %s is not defined in the application", groupName)
 }
 
-// the placeholder name is the pod name, pod name can not be longer than 63 chars,
+// GeneratePlaceholderName creates the placeholder name for a pod, pod name can not be longer than 63 chars,
 // taskGroup name and appID will be truncated if they go over 20/28 chars respectively,
 // each taskGroup is assigned with an incremental index starting from 0.
 func GeneratePlaceholderName(taskGroupName, appID string, index int32) string {
 	// taskGroup name no longer than 20 chars
 	// appID no longer than 28 chars
 	// total length no longer than 20 + 28 + 5 + 10 = 63
-	shortTaskGroupName := fmt.Sprintf("%.20s", taskGroupName)
-	shortAppID := fmt.Sprintf("%.28s", appID)
-	return "tg-" + shortTaskGroupName + "-" + shortAppID + fmt.Sprintf("-%d", index)
+	return fmt.Sprintf("tg-%.20s-%.28s-%d", taskGroupName, appID, index)
 }
 
-func GetPlaceholderResourceRequest(resources map[string]resource.Quantity) v1.ResourceList {
+// GetPlaceholderResourceRequests converts the map of resources requested into a list of resources for the request
+// specification that can be added to a pod. No checks on what is requested.
+func GetPlaceholderResourceRequests(resources map[string]resource.Quantity) v1.ResourceList {
 	resourceReq := v1.ResourceList{}
 	for k, v := range resources {
+		if k == "" {
+			continue
+		}
 		resourceReq[v1.ResourceName(k)] = v
 	}
 	return resourceReq
+}
+
+// GetPlaceholderResourceLimits converts the map of resources requested into a list of resources for the limit
+// specification that can be added to a pod. This only adds the minimal required resources that do not support
+// over commit. The following resources do support over commit: all standard kubernetes resources (except hugepages*)
+// All non-over committable, i.e. extended, resources MUST have a limit set to the same value as the request.
+func GetPlaceholderResourceLimits(resources map[string]resource.Quantity) v1.ResourceList {
+	resourceLim := v1.ResourceList{}
+	for k, v := range resources {
+		if k == "" || allowOverCommit(k) {
+			continue
+		}
+		resourceLim[v1.ResourceName(k)] = v
+	}
+	return resourceLim
+}
+
+// allowOverCommit returns true if the resource can be over committed.
+// This comes down to only allow the standard resources cpu, memory and ephemeral-storage to be over committed.
+// We slip in the "pods" resource on task groups but that does not cause an issue.
+func allowOverCommit(name string) bool {
+	return (!strings.Contains(name, "/") ||
+		strings.Contains(name, k8sDomain)) &&
+		!strings.HasPrefix(name, hugepagesPrefix)
 }
 
 func GetSchedulingPolicyParam(pod *v1.Pod) *interfaces.SchedulingPolicyParameters {

--- a/pkg/common/utils/gang_utils_test.go
+++ b/pkg/common/utils/gang_utils_test.go
@@ -142,8 +142,7 @@ func Test_allowOverCommit(t *testing.T) {
 		want    bool
 	}{
 		{"standard", "memory", true},
-		{"qualified", "kubernetes.io/memory", true},
-		{"hugepages qualified", "kubernetes.io/hugepages-huge", true}, // weird special case as per the K8s docs
+		{"pod as resource", "pods", true},
 		{"hugepages", "hugepages-small", false},
 		{"extended", "nvidia.com/gpu", false},
 	}
@@ -164,7 +163,6 @@ func Test_GetPlaceholderResourceRequest(t *testing.T) {
 		{"empty", map[string]resource.Quantity{}, v1.ResourceList{}},
 		{"base", map[string]resource.Quantity{"pods": resource.MustParse("1")}, v1.ResourceList{"pods": resource.MustParse("1")}},
 		{"hugepages", map[string]resource.Quantity{"hugepages-huge": resource.MustParse("2")}, v1.ResourceList{"hugepages-huge": resource.MustParse("2")}},
-		{"k8s qualified", map[string]resource.Quantity{"kubernetes.io/pods": resource.MustParse("3")}, v1.ResourceList{"kubernetes.io/pods": resource.MustParse("3")}},
 		{"mixed", map[string]resource.Quantity{"pods": resource.MustParse("4"), "nvidia.com/gpu": resource.MustParse("5")}, v1.ResourceList{"pods": resource.MustParse("4"), "nvidia.com/gpu": resource.MustParse("5")}},
 	}
 	for _, tt := range tests {
@@ -186,7 +184,6 @@ func Test_GetPlaceholderResourceLimits(t *testing.T) {
 		{"empty", map[string]resource.Quantity{}, v1.ResourceList{}},
 		{"base", map[string]resource.Quantity{"pods": resource.MustParse("1")}, v1.ResourceList{}},
 		{"hugepages", map[string]resource.Quantity{"hugepages-huge": resource.MustParse("2")}, v1.ResourceList{"hugepages-huge": resource.MustParse("2")}},
-		{"k8s qualified", map[string]resource.Quantity{"kubernetes.io/pods": resource.MustParse("3")}, v1.ResourceList{}},
 		{"mixed", map[string]resource.Quantity{"pods": resource.MustParse("4"), "nvidia.com/gpu": resource.MustParse("5")}, v1.ResourceList{"nvidia.com/gpu": resource.MustParse("5")}},
 	}
 	for _, tt := range tests {

--- a/pkg/common/utils/gang_utils_test.go
+++ b/pkg/common/utils/gang_utils_test.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"math"
+	"reflect"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -129,6 +130,69 @@ func TestGetSchedulingPolicyParams(t *testing.T) {
 			}
 			if schedulingPolicyParams.GetGangSchedulingStyle() != tt.expectedStyle {
 				t.Errorf("%d:got %s,want %s", testID, schedulingPolicyParams.GetGangSchedulingStyle(), tt.expectedStyle)
+			}
+		})
+	}
+}
+
+func Test_allowOverCommit(t *testing.T) {
+	tests := []struct {
+		name    string
+		resName string
+		want    bool
+	}{
+		{"standard", "memory", true},
+		{"qualified", "kubernetes.io/memory", true},
+		{"hugepages qualified", "kubernetes.io/hugepages-huge", true}, // weird special case as per the K8s docs
+		{"hugepages", "hugepages-small", false},
+		{"extended", "nvidia.com/gpu", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, allowOverCommit(tt.resName), tt.want, "incorrect overcommit status")
+		})
+	}
+}
+
+func Test_GetPlaceholderResourceRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		resMap map[string]resource.Quantity
+		want   v1.ResourceList
+	}{
+		{"nil", nil, v1.ResourceList{}},
+		{"empty", map[string]resource.Quantity{}, v1.ResourceList{}},
+		{"base", map[string]resource.Quantity{"pods": resource.MustParse("1")}, v1.ResourceList{"pods": resource.MustParse("1")}},
+		{"hugepages", map[string]resource.Quantity{"hugepages-huge": resource.MustParse("2")}, v1.ResourceList{"hugepages-huge": resource.MustParse("2")}},
+		{"k8s qualified", map[string]resource.Quantity{"kubernetes.io/pods": resource.MustParse("3")}, v1.ResourceList{"kubernetes.io/pods": resource.MustParse("3")}},
+		{"mixed", map[string]resource.Quantity{"pods": resource.MustParse("4"), "nvidia.com/gpu": resource.MustParse("5")}, v1.ResourceList{"pods": resource.MustParse("4"), "nvidia.com/gpu": resource.MustParse("5")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetPlaceholderResourceRequests(tt.resMap); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPlaceholderResourceRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_GetPlaceholderResourceLimits(t *testing.T) {
+	tests := []struct {
+		name   string
+		resMap map[string]resource.Quantity
+		want   v1.ResourceList
+	}{
+		{"nil", nil, v1.ResourceList{}},
+		{"empty", map[string]resource.Quantity{}, v1.ResourceList{}},
+		{"base", map[string]resource.Quantity{"pods": resource.MustParse("1")}, v1.ResourceList{}},
+		{"hugepages", map[string]resource.Quantity{"hugepages-huge": resource.MustParse("2")}, v1.ResourceList{"hugepages-huge": resource.MustParse("2")}},
+		{"k8s qualified", map[string]resource.Quantity{"kubernetes.io/pods": resource.MustParse("3")}, v1.ResourceList{}},
+		{"mixed", map[string]resource.Quantity{"pods": resource.MustParse("4"), "nvidia.com/gpu": resource.MustParse("5")}, v1.ResourceList{"nvidia.com/gpu": resource.MustParse("5")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetPlaceholderResourceLimits(tt.resMap); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPlaceholderResourceRequest() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### What is this PR for?
Extended resources and huge pages can not over commit. The pod validator checks for a Limit setting in the pod spec. The pod fails validation without it. Placeholder creation must make sure that the pods pass the validator.
Set limits for all extended resources and hugepages-* as they cannot be over committed.

Clean up of duplicated task group definition in the test.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-1908

### How should this be tested?
Unit test added
e2e test for placeholders should be extended but we do not have GPU nodes in kind, follow up jira logged to

