### PR TITLE
[YUNIKORN-1928] Remove the unused skip logic for auto scaling container.

### DIFF
--- a/pkg/appmgmt/interfaces/task_sched_state.go
+++ b/pkg/appmgmt/interfaces/task_sched_state.go
@@ -22,7 +22,6 @@ type TaskSchedulingState int8
 
 const (
 	TaskSchedPending TaskSchedulingState = iota
-	TaskSchedSkipped
 	TaskSchedFailed
 	TaskSchedAllocated
 )

--- a/pkg/appmgmt/interfaces/task_sched_state_test.go
+++ b/pkg/appmgmt/interfaces/task_sched_state_test.go
@@ -27,7 +27,6 @@ import (
 func TestTaskSchedulingState(t *testing.T) {
 	assert.Equal(t, len(taskSchedulingStateNames), 4, "wrong length")
 	assert.Equal(t, TaskSchedPending.String(), taskSchedulingStateNames[TaskSchedPending])
-	assert.Equal(t, TaskSchedSkipped.String(), taskSchedulingStateNames[TaskSchedSkipped])
 	assert.Equal(t, TaskSchedFailed.String(), taskSchedulingStateNames[TaskSchedFailed])
 	assert.Equal(t, TaskSchedAllocated.String(), taskSchedulingStateNames[TaskSchedAllocated])
 }

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -1034,21 +1034,6 @@ func (ctx *Context) HandleContainerStateUpdate(request *si.UpdateContainerSchedu
 	// the allocationKey equals to the taskID
 	if task := ctx.getTask(request.ApplicartionID, request.AllocationKey); task != nil {
 		switch request.State {
-		case si.UpdateContainerSchedulingStateRequest_SKIPPED:
-			// auto-scaler scans pods whose pod condition is PodScheduled=false && reason=Unschedulable
-			// if the pod is skipped because the queue quota has been exceed, we do not trigger the auto-scaling
-			task.SetTaskSchedulingState(interfaces.TaskSchedSkipped)
-			if ctx.updatePodCondition(task,
-				&v1.PodCondition{
-					Type:    v1.PodScheduled,
-					Status:  v1.ConditionFalse,
-					Reason:  "SchedulingSkipped",
-					Message: request.Reason,
-				}) {
-				events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
-					v1.EventTypeNormal, "PodUnschedulable", "PodUnschedulable",
-					"Task %s is skipped from scheduling because the queue quota has been exceed", task.alias)
-			}
 		case si.UpdateContainerSchedulingStateRequest_FAILED:
 			task.SetTaskSchedulingState(interfaces.TaskSchedFailed)
 			// set pod condition to Unschedulable in order to trigger auto-scaling

--- a/pkg/plugin/scheduler_plugin.go
+++ b/pkg/plugin/scheduler_plugin.go
@@ -127,8 +127,6 @@ func (sp *YuniKornSchedulerPlugin) PreEnqueue(_ context.Context, pod *v1.Pod) *f
 		case interfaces.TaskSchedFailed:
 			// allow the pod to proceed so that it will be marked unschedulable by PreFilter
 			return nil
-		case interfaces.TaskSchedSkipped:
-			return framework.NewStatus(framework.UnschedulableAndUnresolvable, "Pod doesn't fit within queue")
 		default:
 			return framework.NewStatus(framework.UnschedulableAndUnresolvable, fmt.Sprintf("Pod unschedulable: %s", schedState.String()))
 		}


### PR DESCRIPTION
### What is this PR for?
In shim side we have skip autoscaling logic both for yunikorn mode and plugin mode.

```
switch request.State {
case si.UpdateContainerSchedulingStateRequest_SKIPPED:
    // auto-scaler scans pods whose pod condition is PodScheduled=false && reason=Unschedulable
    // if the pod is skipped because the queue quota has been exceed, we do not trigger the auto-scaling
    task.SetTaskSchedulingState(interfaces.TaskSchedSkipped)
    if ctx.updatePodCondition(task,
       &v1.PodCondition{
          Type:    v1.PodScheduled,
          Status:  v1.ConditionFalse,
          Reason:  "SchedulingSkipped",
          Message: request.Reason,
       }) {
       events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
          v1.EventTypeNormal, "PodUnschedulable", "PodUnschedulable",
          "Task %s is skipped from scheduling because the queue quota has been exceed", task.alias)
    }
```
We need to remove the unused misleading logic.

  


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1928
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
