### PR TITLE
[YUNIKORN-592] test: move the testing function into the relevant test code file

### DIFF
--- a/pkg/cache/context_recovery_test.go
+++ b/pkg/cache/context_recovery_test.go
@@ -26,6 +26,7 @@ import (
 
 	"gotest.tools/v3/assert"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -35,6 +36,19 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/yunikorn-k8shim/pkg/dispatcher"
 )
+
+type K8sResource struct {
+	ResourceName v1.ResourceName
+	Value        int64
+}
+
+func NewK8sResourceList(resources ...K8sResource) map[v1.ResourceName]resource.Quantity {
+	resourceList := make(map[v1.ResourceName]resource.Quantity)
+	for _, r := range resources {
+		resourceList[r.ResourceName] = *resource.NewQuantity(r.Value, resource.DecimalSI)
+	}
+	return resourceList
+}
 
 func TestNodeRecoveringState(t *testing.T) {
 	apiProvider4test := client.NewMockedAPIProvider(false)
@@ -50,11 +64,11 @@ func TestNodeRecoveringState(t *testing.T) {
 			UID:       "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: utils.NewK8sResourceList(
-				utils.K8sResource{
+			Capacity: NewK8sResourceList(
+				K8sResource{
 					ResourceName: v1.ResourceMemory,
 					Value:        1024,
-				}, utils.K8sResource{
+				}, K8sResource{
 					ResourceName: v1.ResourceCPU,
 					Value:        10,
 				}),
@@ -68,11 +82,11 @@ func TestNodeRecoveringState(t *testing.T) {
 			UID:       "uid_0002",
 		},
 		Status: v1.NodeStatus{
-			Capacity: utils.NewK8sResourceList(
-				utils.K8sResource{
+			Capacity: NewK8sResourceList(
+				K8sResource{
 					ResourceName: v1.ResourceMemory,
 					Value:        1024,
-				}, utils.K8sResource{
+				}, K8sResource{
 					ResourceName: v1.ResourceCPU,
 					Value:        10,
 				}),
@@ -119,11 +133,11 @@ func TestNodesRecovery(t *testing.T) {
 				UID:       types.UID("uid_000" + strconv.Itoa(i)),
 			},
 			Status: v1.NodeStatus{
-				Capacity: utils.NewK8sResourceList(
-					utils.K8sResource{
+				Capacity: NewK8sResourceList(
+					K8sResource{
 						ResourceName: v1.ResourceMemory,
 						Value:        1024,
-					}, utils.K8sResource{
+					}, K8sResource{
 						ResourceName: v1.ResourceCPU,
 						Value:        10,
 					}),

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -30,8 +30,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 	podv1 "k8s.io/kubernetes/pkg/api/v1/pod"
 
 	"github.com/apache/yunikorn-k8shim/pkg/appmgmt/interfaces"
@@ -190,19 +188,6 @@ func GetNamespaceQuotaFromAnnotation(namespaceObj *v1.Namespace) *si.Resource {
 	}
 }
 
-type K8sResource struct {
-	ResourceName v1.ResourceName
-	Value        int64
-}
-
-func NewK8sResourceList(resources ...K8sResource) map[v1.ResourceName]resource.Quantity {
-	resourceList := make(map[v1.ResourceName]resource.Quantity)
-	for _, r := range resources {
-		resourceList[r.ResourceName] = *resource.NewQuantity(r.Value, resource.DecimalSI)
-	}
-	return resourceList
-}
-
 func WaitForCondition(eval func() bool, interval time.Duration, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {
@@ -215,53 +200,6 @@ func WaitForCondition(eval func() bool, interval time.Duration, timeout time.Dur
 		}
 
 		time.Sleep(interval)
-	}
-}
-
-func PodForTest(podName, memory, cpu string) *v1.Pod {
-	containers := make([]v1.Container, 0)
-	c1Resources := make(map[v1.ResourceName]resource.Quantity)
-	c1Resources[v1.ResourceMemory] = resource.MustParse(memory)
-	c1Resources[v1.ResourceCPU] = resource.MustParse(cpu)
-	containers = append(containers, v1.Container{
-		Name: "container-01",
-		Resources: v1.ResourceRequirements{
-			Requests: c1Resources,
-		},
-	})
-
-	return &v1.Pod{
-		TypeMeta: apis.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: apis.ObjectMeta{
-			Name: podName,
-		},
-		Spec: v1.PodSpec{
-			Containers: containers,
-		},
-	}
-}
-
-func NodeForTest(nodeID, memory, cpu string) *v1.Node {
-	resourceList := make(map[v1.ResourceName]resource.Quantity)
-	resourceList[v1.ResourceName("memory")] = resource.MustParse(memory)
-	resourceList[v1.ResourceName("cpu")] = resource.MustParse(cpu)
-	return &v1.Node{
-		TypeMeta: apis.TypeMeta{
-			Kind:       "Node",
-			APIVersion: "v1",
-		},
-		ObjectMeta: apis.ObjectMeta{
-			Name:      nodeID,
-			Namespace: "default",
-			UID:       "uid_0001",
-		},
-		Spec: v1.NodeSpec{},
-		Status: v1.NodeStatus{
-			Allocatable: resourceList,
-		},
 	}
 }
 


### PR DESCRIPTION
### What is this PR for?
Move the testing function into the relevant test code file.

- `K8sResource`, `NewK8sResourceList` move to `pkg/cache/context_recovery_test.go`
- `PodForTest`, `NodeForTest` move to `pkg/cache/node_coordinator_test.go`
- Remove  `K8sResource`, `NewK8sResourceList`, `PodForTest`, `NodeForTest`  from `pkg/common/utils/utils.go` production code.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [x] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
[YUNIKORN-592](https://issues.apache.org/jira/browse/YUNIKORN-592)

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
