### PR TITLE
[YUNIKORN-1953] replace priority with priorityclass in placeholder

### DIFF
--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -79,9 +79,9 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup interfac
 		}
 	}
 
-	var priority *int32
+	var priorityClassName string
 	if task := app.GetOriginatingTask(); task != nil {
-		priority = task.GetTaskPod().Spec.Priority
+		priorityClassName = task.GetTaskPod().Spec.PriorityClassName
 	}
 
 	// prepare the resource lists
@@ -116,12 +116,12 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup interfac
 					},
 				},
 			},
-			RestartPolicy: constants.PlaceholderPodRestartPolicy,
-			SchedulerName: constants.SchedulerName,
-			NodeSelector:  taskGroup.NodeSelector,
-			Tolerations:   taskGroup.Tolerations,
-			Affinity:      taskGroup.Affinity,
-			Priority:      priority,
+			RestartPolicy:     constants.PlaceholderPodRestartPolicy,
+			SchedulerName:     constants.SchedulerName,
+			NodeSelector:      taskGroup.NodeSelector,
+			Tolerations:       taskGroup.Tolerations,
+			Affinity:          taskGroup.Affinity,
+			PriorityClassName: priorityClassName,
 		},
 	}
 

--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -128,6 +128,7 @@ func TestNewPlaceholder(t *testing.T) {
 	assert.Equal(t, "secret2", holder.pod.Spec.ImagePullSecrets[1].Name)
 	var priority *int32
 	assert.Equal(t, priority, holder.pod.Spec.Priority)
+	assert.Equal(t, "", holder.pod.Spec.PriorityClassName)
 }
 
 func TestNewPlaceholderWithLabelsAndAnnotations(t *testing.T) {
@@ -152,6 +153,7 @@ func TestNewPlaceholderWithLabelsAndAnnotations(t *testing.T) {
 	assert.NilError(t, err, "taskGroupsDef unmarshal failed")
 	var priority *int32
 	assert.Equal(t, priority, holder.pod.Spec.Priority)
+	assert.Equal(t, "", holder.pod.Spec.PriorityClassName)
 }
 
 func TestNewPlaceholderWithNodeSelectors(t *testing.T) {
@@ -166,6 +168,7 @@ func TestNewPlaceholderWithNodeSelectors(t *testing.T) {
 	assert.Equal(t, holder.pod.Spec.NodeSelector["nodeState"], "healthy")
 	var priority *int32
 	assert.Equal(t, priority, holder.pod.Spec.Priority)
+	assert.Equal(t, "", holder.pod.Spec.PriorityClassName)
 }
 
 func TestNewPlaceholderWithTolerations(t *testing.T) {
@@ -183,6 +186,7 @@ func TestNewPlaceholderWithTolerations(t *testing.T) {
 	assert.Equal(t, tlr.Effect, v1.TaintEffectNoSchedule)
 	var priority *int32
 	assert.Equal(t, priority, holder.pod.Spec.Priority)
+	assert.Equal(t, "", holder.pod.Spec.PriorityClassName)
 }
 
 func TestNewPlaceholderWithAffinity(t *testing.T) {
@@ -202,6 +206,7 @@ func TestNewPlaceholderWithAffinity(t *testing.T) {
 	assert.Equal(t, term[0].LabelSelector.MatchExpressions[0].Values[0], "securityscan")
 	var priority *int32
 	assert.Equal(t, priority, holder.pod.Spec.Priority)
+	assert.Equal(t, "", holder.pod.Spec.PriorityClassName)
 }
 
 func TestNewPlaceholderTaskGroupsDefinition(t *testing.T) {
@@ -220,6 +225,7 @@ func TestNewPlaceholderTaskGroupsDefinition(t *testing.T) {
 	assert.Equal(t, "taskGroupsDef", holder.pod.Annotations[constants.AnnotationTaskGroups])
 	var priority *int32
 	assert.Equal(t, priority, holder.pod.Spec.Priority)
+	assert.Equal(t, "", holder.pod.Spec.PriorityClassName)
 }
 
 func TestNewPlaceholderExtendedResources(t *testing.T) {
@@ -234,16 +240,15 @@ func TestNewPlaceholderExtendedResources(t *testing.T) {
 	assert.Equal(t, holder.pod.Spec.Containers[0].Resources.Limits[hugepages], holder.pod.Spec.Containers[0].Resources.Requests[hugepages], "hugepages: expected same value for request and limit")
 	var priority *int32
 	assert.Equal(t, priority, holder.pod.Spec.Priority)
+	assert.Equal(t, "", holder.pod.Spec.PriorityClassName)
 }
 
-func TestNewPlaceholderWithPriority(t *testing.T) {
+func TestNewPlaceholderWithPriorityClassName(t *testing.T) {
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	app := NewApplication(appID, queue,
 		"bob", testGroups, map[string]string{constants.AppTagNamespace: namespace}, mockedSchedulerAPI)
 	app.setTaskGroups(taskGroups)
 	mockedContext := initContextForTest()
-	priority := int32(10)
-	specPriority := &priority
 	pod1 := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -254,7 +259,7 @@ func TestNewPlaceholderWithPriority(t *testing.T) {
 			UID:  "UID-01",
 		},
 		Spec: v1.PodSpec{
-			Priority: specPriority,
+			PriorityClassName: priorityClassName,
 		},
 	}
 	taskID1 := "task1-01"
@@ -270,5 +275,7 @@ func TestNewPlaceholderWithPriority(t *testing.T) {
 	assert.Equal(t, len(holder.pod.Spec.Containers[0].Resources.Limits), 2, "limit for extended resource not found")
 	assert.Equal(t, holder.pod.Spec.Containers[0].Resources.Limits[gpu], holder.pod.Spec.Containers[0].Resources.Requests[gpu], "gpu: expected same value for request and limit")
 	assert.Equal(t, holder.pod.Spec.Containers[0].Resources.Limits[hugepages], holder.pod.Spec.Containers[0].Resources.Requests[hugepages], "hugepages: expected same value for request and limit")
-	assert.Equal(t, priority, *holder.pod.Spec.Priority)
+	var priority *int32
+	assert.Equal(t, priority, holder.pod.Spec.Priority)
+	assert.Equal(t, priorityClassName, holder.pod.Spec.PriorityClassName)
 }


### PR DESCRIPTION
### What is this PR for?
Placeholder pods can't be created in a job with non-zero value PriorityClass. It got following error in the yunikorn-k8shim:

```
2023-09-02T07:11:57.330Z    ERROR    shim.cache.placeholder    cache/placeholder_manager.go:99    failed to create placeholder pod    {"error": "pods \"tg-group-low-app-low-0\" is forbidden: the integer value of priority (-100) must not be provided in pod spec; priority admission controller computed 0 from the given PriorityClass name"}
```


### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1953

### How should this be tested?
Covered by unit tests.
E2E test will be covered by https://github.com/apache/yunikorn-k8shim/pull/659.