### PR TITLE
[YUNIKORN-1875] Support for Compressed Encoded configMap BinaryData, gzip compression support

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -112,3 +112,6 @@ const AnnotationEnableYuniKorn = "yunikorn.apache.org/namespace.enableYuniKorn"
 // Admission Controller pod label update constants
 const AutoGenAppPrefix = "yunikorn"
 const AutoGenAppSuffix = "autogen"
+
+// Compression Algorithms for schedulerConfig
+const GzipSuffix = "gzip"

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -19,10 +19,14 @@
 package conf
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -456,12 +460,42 @@ func DumpConfiguration() {
 	}
 }
 
+func Decompress(key string, value []byte) (string, string) {
+	var uncompressedData string
+	decodedValue := make([]byte, base64.StdEncoding.DecodedLen(len(value)))
+	n, err := base64.StdEncoding.Decode(decodedValue, value)
+	if err != nil {
+		log.Log(log.ShimConfig).Error("failed to decode schedulerConfig entry", zap.Error(err))
+	}
+	decodedValue = decodedValue[:n]
+	splitKey := strings.Split(key, ".")
+	compressionAlgo := splitKey[len(splitKey)-1]
+	if strings.EqualFold(compressionAlgo, constants.GzipSuffix) {
+		reader := bytes.NewReader(decodedValue)
+		gzReader, err := gzip.NewReader(reader)
+		if err != nil {
+			log.Log(log.ShimConfig).Error("failed to decompress decoded schedulerConfig entry", zap.Error(err))
+		}
+		decompressedBytes, err := io.ReadAll(gzReader)
+		if err != nil {
+			log.Log(log.ShimConfig).Error("failed to decompress decoded schedulerConfig entry", zap.Error(err))
+		}
+		uncompressedData = string(decompressedBytes)
+	}
+	strippedKey, _ := strings.CutSuffix(key, "."+compressionAlgo)
+	return strippedKey, uncompressedData
+}
+
 func FlattenConfigMaps(configMaps []*v1.ConfigMap) map[string]string {
 	result := make(map[string]string)
 	for _, configMap := range configMaps {
 		if configMap != nil {
 			for k, v := range configMap.Data {
 				result[k] = v
+			}
+			for k, v := range configMap.BinaryData {
+				strippedKey, uncompressedData := Decompress(k, v)
+				result[strippedKey] = uncompressedData
 			}
 		}
 	}


### PR DESCRIPTION
### What is this PR for?
A config map on K8s can only be 1MB. Thus a larger config map could be sent by compressing, encoding, and storing in configMap.BinaryData.

This commit makes Yunikorn support gzip compressed 64bit encoded BinaryData.


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
[YUNIKORN-1875](https://issues.apache.org/jira/browse/YUNIKORN-1875?jql=project%20%3D%20YUNIKORN)

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
