### PR TITLE
[YUNIKORN-1351] alway prefer annotations above labels

### DIFF
--- a/pkg/admission/metadata/usergroup.go
+++ b/pkg/admission/metadata/usergroup.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/apache/yunikorn-k8shim/pkg/admission/common"
 	"github.com/apache/yunikorn-k8shim/pkg/admission/conf"
+	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 )
 
@@ -127,7 +128,7 @@ func (u *UserGroupAnnotationHandler) GetPatchForWorkload(req *admissionv1.Admiss
 }
 
 func (u *UserGroupAnnotationHandler) GetPatchForPod(annotations map[string]string, user string, groups []string) (*common.PatchOperation, error) {
-	patchOp, err := u.getPatchOperation(annotations, "/metadata/annotations", user, groups)
+	patchOp, err := u.getPatchOperation(annotations, constants.AnnotationPatchPath, user, groups)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +153,7 @@ func (u *UserGroupAnnotationHandler) getPatchOperation(annotations map[string]st
 	newAnnotations[common.UserInfoAnnotation] = string(jsonBytes)
 
 	return &common.PatchOperation{
-		Op:    "add",
+		Op:    constants.AddPatchOp,
 		Path:  path,
 		Value: newAnnotations,
 	}, nil

--- a/pkg/admission/metadata/usergroup_test.go
+++ b/pkg/admission/metadata/usergroup_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/apache/yunikorn-k8shim/pkg/admission/common"
 	"github.com/apache/yunikorn-k8shim/pkg/admission/conf"
+	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 )
 
 const (
@@ -163,7 +164,7 @@ func TestGetPatchForWorkload(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Equal(t, 1, len(patch))
 			patchOp := patch[0]
-			assert.Equal(t, patchOp.Op, "add")
+			assert.Equal(t, patchOp.Op, constants.AddPatchOp)
 			assert.Equal(t, patchOp.Path, testCase.path)
 			verifyUserGroupAnnotation(t, patchOp.Value)
 		})
@@ -175,8 +176,8 @@ func TestGetPatchForPod(t *testing.T) {
 	patchOp, err := ah.GetPatchForPod(annotation, "yunikorn", []string{"users", "dev"})
 	assert.NilError(t, err)
 	assert.Assert(t, patchOp != nil)
-	assert.Equal(t, patchOp.Op, "add")
-	assert.Equal(t, patchOp.Path, "/metadata/annotations")
+	assert.Equal(t, patchOp.Op, constants.AddPatchOp)
+	assert.Equal(t, patchOp.Path, constants.AnnotationPatchPath)
 	verifyUserGroupAnnotation(t, patchOp.Value)
 }
 

--- a/pkg/admission/util.go
+++ b/pkg/admission/util.go
@@ -29,42 +29,86 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 )
 
-func updatePodLabel(pod *v1.Pod, namespace string, generateUniqueAppIds bool, defaultQueueName string) map[string]string {
-	existingLabels := pod.Labels
-	result := make(map[string]string)
-	for k, v := range existingLabels {
-		result[k] = v
+func getNewApplicationInfo(pod *v1.Pod, namespace string, generateUniqueAppIds bool, defaultQueueName string) (map[string]string, map[string]string) {
+	newLabels := make(map[string]string)
+	newAnnotations := make(map[string]string)
+
+	appID, isAppIdFromLabel := getApplicationIDFromPod(pod)
+	disableStateAware, isDisableStateAwareFromLabel := getDisableStateAwareFromPod(pod)
+
+	// for undefined configuration, am_conf will add 'root.default' as default queue name
+	// if a custom name is configured for default queue, it will be used instead of root.default
+	queueName, isQueueNameFromLabel := utils.GetQueueNameFromPod(pod, defaultQueueName)
+
+	if isAppIdFromLabel || isDisableStateAwareFromLabel || isQueueNameFromLabel {
+		log.Log(log.Admission).Warn("Pod contains label for Yunikorn configuration. This is deprecated and will be ignored in a future release. Please migrate to annotation-based configuration.",
+			zap.Bool("applicationId from label", isAppIdFromLabel),
+			zap.Bool("disableStateAware from label", isDisableStateAwareFromLabel),
+			zap.Bool("queue name from label", isQueueNameFromLabel))
 	}
 
-	sparkAppID := utils.GetPodLabelValue(pod, constants.SparkLabelAppID)
-	appID := utils.GetPodLabelValue(pod, constants.LabelApplicationID)
-	if sparkAppID == "" && appID == "" {
+	if appID == "" {
 		// if app id not exist, generate one
 		// for each namespace, we group unnamed pods to one single app - if GenerateUniqueAppId is not set
 		// if GenerateUniqueAppId:
 		//		application ID convention: ${NAMESPACE}-${POD_UID}
 		// else
 		// 		application ID convention: ${AUTO_GEN_PREFIX}-${NAMESPACE}-${AUTO_GEN_SUFFIX}
-		generatedID := utils.GenerateApplicationID(namespace, generateUniqueAppIds, string(pod.UID))
-		result[constants.LabelApplicationID] = generatedID
+		appID = utils.GenerateApplicationID(namespace, generateUniqueAppIds, string(pod.UID))
 
 		// if we generate an app ID, disable state-aware scheduling for this app
-		if _, ok := existingLabels[constants.LabelDisableStateAware]; !ok {
-			result[constants.LabelDisableStateAware] = "true"
+		// skip it if disableStateAware has already been set in the pod
+		if disableStateAware == "" {
+			disableStateAware = "true"
 		}
 	}
 
-	// if existing label exist, it takes priority over everything else
-	if _, ok := existingLabels[constants.LabelQueueName]; !ok {
-		// if defaultQueueName is "", skip adding default queue name to the pod labels
-		if defaultQueueName != "" {
-			// for undefined configuration, am_conf will add 'root.default' to retain existing behavior
-			// if a custom name is configured for default queue, it will be used instead of root.default
-			result[constants.LabelQueueName] = defaultQueueName
-		}
+	// we're looking forward to deprecate the labels and move everything to annotations
+	// but for backforward compatibility, we still add to labels
+	newLabels = updateLabelIfNotPresentInPod(pod, newLabels, constants.LabelApplicationID, appID)
+	newAnnotations = updateAnnotationIfNotPresentInPod(pod, newAnnotations, constants.AnnotationApplicationID, appID)
+
+	// skip adding empty disableStateAware to the pod
+	if disableStateAware != "" {
+		newLabels = updateLabelIfNotPresentInPod(pod, newLabels, constants.LabelDisableStateAware, disableStateAware)
+		newAnnotations = updateAnnotationIfNotPresentInPod(pod, newAnnotations, constants.AnnotationDisableStateAware, disableStateAware)
 	}
 
-	return result
+	// skip adding empty queue name to the pod
+	if queueName != "" {
+		newLabels = updateLabelIfNotPresentInPod(pod, newLabels, constants.LabelQueueName, queueName)
+		newAnnotations = updateAnnotationIfNotPresentInPod(pod, newAnnotations, constants.AnnotationQueueName, queueName)
+	}
+
+	return newLabels, newAnnotations
+}
+
+func updateLabelIfNotPresentInPod(pod *v1.Pod, labelMap map[string]string, label string, value string) map[string]string {
+	existingLabels := pod.Labels
+
+	if existingLabels == nil {
+		labelMap[label] = value
+	}
+
+	// skip update label if it has already been set in the pod
+	if _, ok := existingLabels[label]; !ok {
+		labelMap[label] = value
+	}
+	return labelMap
+}
+
+func updateAnnotationIfNotPresentInPod(pod *v1.Pod, annotationMap map[string]string, annotation string, value string) map[string]string {
+	existingAnnotations := pod.Annotations
+
+	if existingAnnotations == nil {
+		annotationMap[annotation] = value
+	}
+
+	// skip update annotation if it has already been set in the pod
+	if _, ok := existingAnnotations[annotation]; !ok {
+		annotationMap[annotation] = value
+	}
+	return annotationMap
 }
 
 func updatePodAnnotation(pod *v1.Pod, key string, value string) map[string]string {
@@ -83,4 +127,28 @@ func convert2Namespace(obj interface{}) *v1.Namespace {
 	}
 	log.Log(log.AdmissionUtils).Warn("cannot convert to *v1.Namespace", zap.Stringer("type", reflect.TypeOf(obj)))
 	return nil
+}
+
+func getApplicationIDFromPod(pod *v1.Pod) (value string, isFromLabel bool) {
+	// if existing annotation exist, it takes priority over everything else
+	if value := utils.GetPodAnnotationValue(pod, constants.AnnotationApplicationID); value != "" {
+		return value, false
+	} else if value := utils.GetPodLabelValue(pod, constants.LabelApplicationID); value != "" {
+		return value, true
+	}
+	// application ID can be defined in Spark label
+	if value := utils.GetPodLabelValue(pod, constants.SparkLabelAppID); value != "" {
+		return value, true
+	}
+	return "", false
+}
+
+func getDisableStateAwareFromPod(pod *v1.Pod) (value string, isFromLabel bool) {
+	// if existing annotation exist, it takes priority over everything else
+	if value := utils.GetPodAnnotationValue(pod, constants.AnnotationDisableStateAware); value != "" {
+		return value, false
+	} else if value := utils.GetPodLabelValue(pod, constants.LabelDisableStateAware); value != "" {
+		return value, true
+	}
+	return "", false
 }

--- a/pkg/cache/metadata.go
+++ b/pkg/cache/metadata.go
@@ -68,6 +68,7 @@ func getAppMetadata(pod *v1.Pod) (ApplicationMetadata, bool) {
 			zap.String("name", pod.Name))
 		return ApplicationMetadata{}, false
 	}
+	queueName, _ := utils.GetQueueNameFromPod(pod, constants.ApplicationDefaultQueue)
 
 	// tags will at least have namespace info
 	// labels or annotations from the pod can be added when needed
@@ -117,7 +118,7 @@ func getAppMetadata(pod *v1.Pod) (ApplicationMetadata, bool) {
 
 	return ApplicationMetadata{
 		ApplicationID:              appID,
-		QueueName:                  utils.GetQueueNameFromPod(pod),
+		QueueName:                  queueName,
 		User:                       user,
 		Groups:                     groups,
 		Tags:                       tags,

--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -94,7 +94,10 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup TaskGrou
 				constants.LabelQueueName:       app.GetQueue(),
 				constants.LabelPlaceholderFlag: "true",
 			}),
-			Annotations:     annotations,
+			Annotations: utils.MergeMaps(annotations, map[string]string{
+				constants.AnnotationApplicationID: app.GetApplicationID(),
+				constants.AnnotationQueueName:     app.GetQueue(),
+			}),
 			OwnerReferences: ownerRefs,
 		},
 		Spec: v1.PodSpec{

--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -109,11 +109,19 @@ func TestNewPlaceholder(t *testing.T) {
 	assert.Equal(t, holder.pod.Name, "ph-name")
 	assert.Equal(t, holder.pod.Namespace, namespace)
 	assert.Equal(t, len(holder.pod.Labels), 5, "unexpected number of labels")
+	assert.Equal(t, len(holder.pod.Annotations), 7, "unexpected number of annotations")
+	assert.Equal(t, holder.pod.Labels["labelKey0"], "labelKeyValue0")
+	assert.Equal(t, holder.pod.Labels["labelKey1"], "labelKeyValue1")
 	assert.Equal(t, holder.pod.Labels[constants.LabelApplicationID], appID)
 	assert.Equal(t, holder.pod.Labels[constants.LabelQueueName], queue)
-	assert.Equal(t, holder.pod.Labels["placeholder"], "true")
-	assert.Equal(t, len(holder.pod.Annotations), 5, "unexpected number of annotations")
+	assert.Equal(t, holder.pod.Labels[constants.LabelPlaceholderFlag], "true")
+	assert.Equal(t, holder.pod.Annotations["annotationKey0"], "annotationValue0")
+	assert.Equal(t, holder.pod.Annotations["annotationKey1"], "annotationValue1")
+	assert.Equal(t, holder.pod.Annotations["annotationKey2"], "annotationValue2")
 	assert.Equal(t, holder.pod.Annotations[constants.AnnotationTaskGroupName], app.taskGroups[0].Name)
+	assert.Equal(t, holder.pod.Annotations[constants.AnnotationApplicationID], appID)
+	assert.Equal(t, holder.pod.Annotations[constants.AnnotationQueueName], queue)
+	assert.Equal(t, holder.pod.Annotations[constants.AnnotationPlaceholderFlag], "true")
 	assert.Equal(t, common.GetPodResource(holder.pod).Resources[siCommon.CPU].Value, int64(500))
 	assert.Equal(t, common.GetPodResource(holder.pod).Resources[siCommon.Memory].Value, int64(1024*1000*1000))
 	assert.Equal(t, common.GetPodResource(holder.pod).Resources["pods"].Value, int64(1))
@@ -149,12 +157,18 @@ func TestNewPlaceholderWithLabelsAndAnnotations(t *testing.T) {
 		"queue":         "root.default",
 	})
 
-	assert.Equal(t, len(holder.pod.Annotations), 6)
+	assert.Equal(t, len(holder.pod.Annotations), 8)
 	assert.Equal(t, holder.pod.Annotations["annotationKey0"], "annotationValue0")
 	assert.Equal(t, holder.pod.Annotations["annotationKey1"], "annotationValue1")
 	assert.Equal(t, holder.pod.Annotations["annotationKey2"], "annotationValue2")
+	assert.Equal(t, holder.pod.Annotations[constants.AnnotationTaskGroupName], app.taskGroups[0].Name)
+	assert.Equal(t, holder.pod.Annotations[constants.AnnotationApplicationID], appID)
+	assert.Equal(t, holder.pod.Annotations[constants.AnnotationQueueName], queue)
+	assert.Equal(t, holder.pod.Annotations[constants.AnnotationPlaceholderFlag], "true")
+
 	var taskGroupsDef []TaskGroup
 	err = json.Unmarshal([]byte(holder.pod.Annotations[siCommon.DomainYuniKorn+"task-groups"]), &taskGroupsDef)
+
 	assert.NilError(t, err, "taskGroupsDef unmarshal failed")
 	var priority *int32
 	assert.Equal(t, priority, holder.pod.Spec.Priority)

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -42,6 +42,7 @@ const RootQueue = "root"
 const AnnotationQueueName = DomainYuniKorn + "queue"
 const AnnotationParentQueue = DomainYuniKorn + "parentqueue"
 const LabelDisableStateAware = "disableStateAware"
+const AnnotationDisableStateAware = DomainYuniKorn + "disable-state-aware"
 const ApplicationDefaultQueue = "root.default"
 const DefaultPartition = "default"
 const AppTagNamespace = "namespace"
@@ -109,9 +110,13 @@ const AnnotationGenerateAppID = DomainYuniKorn + "namespace.generateAppId"
 // false: do not do anything
 const AnnotationEnableYuniKorn = DomainYuniKorn + "namespace.enableYuniKorn"
 
-// Admission Controller pod label update constants
+// Admission Controller pod update constants
 const AutoGenAppPrefix = "yunikorn"
 const AutoGenAppSuffix = "autogen"
+const AddPatchOp = "add"
+const AnnotationPatchPath = "/metadata/annotations"
+const LabelPatchPath = "/metadata/labels"
+const SchedulerNamePatchPath = "/spec/schedulerName"
 
 // Compression Algorithms for schedulerConfig
 const GzipSuffix = "gz"

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -102,14 +102,16 @@ func IsAssignedPod(pod *v1.Pod) bool {
 	return len(pod.Spec.NodeName) != 0
 }
 
-func GetQueueNameFromPod(pod *v1.Pod) string {
-	queueName := constants.ApplicationDefaultQueue
-	if an := GetPodLabelValue(pod, constants.LabelQueueName); an != "" {
-		queueName = an
-	} else if qu := GetPodAnnotationValue(pod, constants.AnnotationQueueName); qu != "" {
-		queueName = qu
+func GetQueueNameFromPod(pod *v1.Pod, defaultQueueName string) (value string, isFromLabel bool) {
+	queueName := defaultQueueName
+	isFromLabel = false
+	if value := GetPodAnnotationValue(pod, constants.AnnotationQueueName); value != "" {
+		queueName = value
+	} else if value := GetPodLabelValue(pod, constants.LabelQueueName); value != "" {
+		isFromLabel = true
+		queueName = value
 	}
-	return queueName
+	return queueName, isFromLabel
 }
 
 // GenerateApplicationID generates an appID based on the namespace value

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -812,6 +812,7 @@ func TestGetQueueNameFromPod(t *testing.T) {
 		name          string
 		pod           *v1.Pod
 		expectedQueue string
+		isFromLabel   bool
 	}{
 		{
 			name: "With queue label",
@@ -821,6 +822,7 @@ func TestGetQueueNameFromPod(t *testing.T) {
 				},
 			},
 			expectedQueue: queueInLabel,
+			isFromLabel:   true,
 		},
 		{
 			name: "With queue annotation",
@@ -830,6 +832,7 @@ func TestGetQueueNameFromPod(t *testing.T) {
 				},
 			},
 			expectedQueue: queueInAnnotation,
+			isFromLabel:   false,
 		},
 		{
 			name: "With queue label and annotation",
@@ -839,7 +842,8 @@ func TestGetQueueNameFromPod(t *testing.T) {
 					Annotations: map[string]string{constants.AnnotationQueueName: queueInAnnotation},
 				},
 			},
-			expectedQueue: queueInLabel,
+			expectedQueue: queueInAnnotation,
+			isFromLabel:   false,
 		},
 		{
 			name: "Without queue label and annotation",
@@ -847,13 +851,15 @@ func TestGetQueueNameFromPod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{},
 			},
 			expectedQueue: constants.ApplicationDefaultQueue,
+			isFromLabel:   false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			queue := GetQueueNameFromPod(tc.pod)
+			queue, isFromLabel := GetQueueNameFromPod(tc.pod, constants.ApplicationDefaultQueue)
 			assert.Equal(t, queue, tc.expectedQueue)
+			assert.Equal(t, isFromLabel, tc.isFromLabel)
 		})
 	}
 }


### PR DESCRIPTION
### What is this PR for?
Since we're looking for deprecated labels and move everything to annotation in the future.
This PR change newly added labels to annotations in admission controller when mutating the pods. 
This PR also fix existing mismatch to align the logic of "fetching annotations from Pods takes precedence over labels."

Below are the detailed change list:
1. Get queue name from annotation first. (GetQueueNameFromPod)
2. Get isStateAwareDisabled from annotation first  (isStateAwareDisabled)
3. Move lables applicationId/queue in newPlaceholder to annotation (newPlaceholder)
4. Add new annotation 'yunikorn.apache.org/disable-state-aware' to replace equivalent label.
5. Rename updateLabels to updateApplicationInfo in AdmissionController
6. Rename util.updatePodLabel to util.getAnnotationsForApplicationInfoUpdate


### What type of PR is it?

* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1351
### How should this be tested?
### Screenshots (if appropriate)
Before vs After result. (Pod with existing applicationId, queue labels.)
![YUNIKORN-1351  Before vs After (Pod with labels)](https://github.com/apache/yunikorn-k8shim/assets/26764036/773b9646-135b-4324-a8a6-9553b1be01f7)

Before vs After result. (Pod with no label.)
![YUNIKORN-1351  Before vs After (Pod without labels)](https://github.com/apache/yunikorn-k8shim/assets/26764036/54efe3df-0620-43c8-8825-854b735de4bf)


### Questions:
* [ ] - The original functions admission_controller.updateLabels(), util.updatePodLabel() can't reflect the behaviors anymore, so I renamed it. Please let me know if we have better name for those two functions.
* [ ] - When state aware annotation set but can't be converted to boolean, I'll return false without check label's value. The reason is we're not expecting the state aware policy be set in label. ([refer this test code](https://github.com/apache/yunikorn-k8shim/compare/master...chenyulin0719:yunikorn-k8shim:YUNIKORN-1351#diff-8965c48e09eaf9638694b621a5881ab8ef9d195d813cabb4816e33967e4e1ee2R681))
* [ ] - There will be another [PR ](https://github.com/apache/yunikorn-site/pull/337)to update this [doc](https://yunikorn.apache.org/docs/user_guide/labels_and_annotations_in_yunikorn/)
