### PR TITLE
[YUNIKORN-1992] Use standard .gz extension for compressed configmap entries

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -114,4 +114,4 @@ const AutoGenAppPrefix = "yunikorn"
 const AutoGenAppSuffix = "autogen"
 
 // Compression Algorithms for schedulerConfig
-const GzipSuffix = "gzip"
+const GzipSuffix = "gz"

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -1154,7 +1154,7 @@ func TestGzipCompressedConfigMap(t *testing.T) {
 	base64.StdEncoding.Encode(encodedConfigString, b.Bytes())
 	confMap := conf.FlattenConfigMaps([]*v1.ConfigMap{
 		{Data: map[string]string{}},
-		{Data: map[string]string{conf.CMSvcClusterID: "new"}, BinaryData: map[string][]byte{"queues.yaml.gzip": encodedConfigString}},
+		{Data: map[string]string{conf.CMSvcClusterID: "new"}, BinaryData: map[string][]byte{"queues.yaml.gz": encodedConfigString}},
 	})
 	config := GetCoreSchedulerConfigFromConfigMap(confMap)
 	assert.DeepEqual(t, configs.DefaultSchedulerConfig, config)

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -94,7 +94,7 @@ func TestDecompress(t *testing.T) {
 	assert.Equal(t, configs.DefaultSchedulerConfig, decodedConfigString)
 }
 
-func TestDecompressUnkownKey(t *testing.T) {
+func TestDecompressUnknownKey(t *testing.T) {
 	encodedConfigString := make([]byte, base64.StdEncoding.EncodedLen(len([]byte(configs.DefaultSchedulerConfig))))
 	base64.StdEncoding.Encode(encodedConfigString, []byte(configs.DefaultSchedulerConfig))
 	key, decodedConfigString := Decompress("queues.yaml.bin", encodedConfigString)


### PR DESCRIPTION
### What is this PR for?
Use .gz instead of .gzip as an extension on configmap entries to match standard naming conventions.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1992

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
