### PR TITLE
Fix wrong interface in comment

### DIFF
--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -56,12 +56,12 @@ func NewManager(apiProvider client.APIProvider, podEventHandler *PodEventHandler
 	}
 }
 
-// this implements AppManagementService interface
+// this implements AppManager interface
 func (os *Manager) Name() string {
 	return "general"
 }
 
-// this implements AppManagementService interface
+// this implements AppManager interface
 func (os *Manager) ServiceInit() error {
 	os.apiProvider.AddEventHandler(
 		&client.ResourceEventHandlers{
@@ -74,14 +74,14 @@ func (os *Manager) ServiceInit() error {
 	return nil
 }
 
-// this implements AppManagementService interface
+// this implements AppManager interface
 func (os *Manager) Start() error {
 	// generic app manager leverages the shared context,
 	// no other service, go routine is required to be started
 	return nil
 }
 
-// this implements AppManagementService interface
+// this implements AppManager interface
 func (os *Manager) Stop() {
 	// noop
 }


### PR DESCRIPTION
### What is this PR for?
the comment in general.go
`// this implements AppManagementService interface`
should all be
`// this implements AppManager interface`

since `Name()` `ServiceInit()` `Start()` `Stop()` implement in general.go are all defined in interface `AppManager`

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2004

### How should this be tested?
only change comment, no need to test

### Screenshots (if appropriate)
N/A

### Questions:
N/A
