### PR TITLE
[YUNIKORN-2019] Remove redundant informer call in spark.go ServiceInit

### DIFF
--- a/pkg/appmgmt/sparkoperator/spark.go
+++ b/pkg/appmgmt/sparkoperator/spark.go
@@ -65,7 +65,6 @@ func (os *Manager) ServiceInit() error {
 	var factoryOpts []crInformers.SharedInformerOption
 	os.crdInformerFactory = crInformers.NewSharedInformerFactoryWithOptions(
 		crClient, 0, factoryOpts...)
-	os.crdInformerFactory.Sparkoperator().V1beta2().SparkApplications().Informer()
 	os.crdInformer = os.crdInformerFactory.Sparkoperator().V1beta2().SparkApplications().Informer()
 	os.crdInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
 		UpdateFunc: os.updateApplication,


### PR DESCRIPTION
### What is this PR for?
https://github.com/apache/yunikorn-k8shim/blob/c633925c39fd69a9a52031ab2ddab5f00e75abb5/pkg/appmgmt/sparkoperator/spark.go#L68-L69

L68 is a redundant since we do it again in next line.

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2019

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
N/A