### PR TITLE
[YUNIKORN-2043] SimplePreemptor e2e test doesn’t really wait for pod’s Killing event

### DIFF
--- a/test/e2e/simple_preemptor/simple_preemptor_test.go
+++ b/test/e2e/simple_preemptor/simple_preemptor_test.go
@@ -21,6 +21,7 @@ package simple_preemptor_test
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -166,7 +167,7 @@ var _ = ginkgo.Describe("SimplePreemptor", func() {
 			gomega.Ω(err).NotTo(gomega.HaveOccurred())
 		}
 		// assert sleeppod2 is killed
-		err := kClient.WaitForPodEvent(dev, "sleepjob2", "Killing", 120)
+		err := kClient.WaitForPodEvent(dev, "sleepjob2", "Killing", 60*time.Second)
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -212,7 +213,7 @@ var _ = ginkgo.Describe("SimplePreemptor", func() {
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
 
 		// assert sleeppod4 is killed
-		err = kClient.WaitForPodEvent(dev, "sleepjob4", "Killing", 1200)
+		err = kClient.WaitForPodEvent(dev, "sleepjob4", "Killing", 60*time.Second)
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
 
 	})


### PR DESCRIPTION
### What is this PR for?
Change 'kClient.WaitForPodEvent' timeout in 'SimplePreemptor e2e test' from 120ns/1200ns to 60 secs.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2043

### How should this be tested?
E2E test result should pass as usaual. 

### Screenshots (if appropriate)
NA

### Questions:
NA
