### PR TITLE
[YUNIKORN-2049] Fix incorrect placement rule examples

### DIFF
--- a/deployments/examples/placements/README.md
+++ b/deployments/examples/placements/README.md
@@ -28,12 +28,12 @@ The sleep pod is described in the example file and the partition is provided in 
 
 ## How to adopt the queues in `config.yaml`
 Before deploying the pods, make sure that the data in the `yunikorn-configs` configmap is correct.
-For example, `queue.yaml` in the `yunikorn-configs` configmap should be updated before starting fixed example.
+For example, `queues.yaml` in the `yunikorn-configs` configmap should be updated before starting fixed example.
 `yunikorn-configs` configmap should contains following information.
----
-**_NOTE:_** 
-`queue.yaml` should be __full__ queue config and then legal configuration would be updated to Yunikorn.
----
+
+> **_NOTE:_**
+> `queues.yaml` should be __full__ queue config and then legal configuration would be updated to Yunikorn.
+
 ```
 yunikornDefaults:
   queues.yaml: |

--- a/deployments/examples/placements/fixed/config.yaml
+++ b/deployments/examples/placements/fixed/config.yaml
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Update this queue yaml to the yunikorn-configs configmap before trying this example.
-queue.yaml: |
+# Update the queues.yaml to the yunikorn-configs configmap before trying this example.
+queues.yaml: |
   partitions:
     - name: default
       placementrules:
@@ -27,4 +27,3 @@ queue.yaml: |
         submitacl: '*'
         queues:
         - name: last_resort
-

--- a/deployments/examples/placements/fixed/fixed_example.yaml
+++ b/deployments/examples/placements/fixed/fixed_example.yaml
@@ -20,9 +20,10 @@ kind: Pod
 metadata:
   labels:
     app: sleep
-    applicationId: "prvoided-rule-example01"
+    applicationId: "fixed-rule-example01"
     queue: "my_special_queue"
-    yunikorn.apache.org/username: developer
+  annotations:
+    yunikorn.apache.org/user.info: "{\"user\": \"developer\"}"
   name: task0
 spec:
   schedulerName: yunikorn
@@ -34,4 +35,3 @@ spec:
         requests:
           cpu: "100m"
           memory: "500M"
-

--- a/deployments/examples/placements/provided/config.yaml
+++ b/deployments/examples/placements/provided/config.yaml
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Update this queue yaml to the yunikorn-configs configmap before trying this example.
-queue.yaml: |
+# Update the queues.yaml to the yunikorn-configs configmap before trying this example.
+queues.yaml: |
   partitions:
     - name: default
       placementrules:
@@ -28,4 +28,3 @@ queue.yaml: |
       queues:
       - name: root
         submitacl: '*'
-

--- a/deployments/examples/placements/provided/provided_example.yaml
+++ b/deployments/examples/placements/provided/provided_example.yaml
@@ -22,7 +22,8 @@ metadata:
     app: sleep
     applicationId: "prvoided-rule-example01"
     queue: "my_special_queue"
-    yunikorn.apache.org/username: "developer"
+  annotations:
+    yunikorn.apache.org/user.info: "{\"user\": \"developer\"}"
   name: task0
 spec:
   schedulerName: yunikorn
@@ -34,4 +35,3 @@ spec:
         requests:
           cpu: "100m"
           memory: "500M"
-

--- a/deployments/examples/placements/tag/config.yaml
+++ b/deployments/examples/placements/tag/config.yaml
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Update this queue yaml to the yunikorn-configs configmap before trying this example.
-queue.yaml: |
+# Update the queues.yaml to the yunikorn-configs configmap before trying this example.
+queues.yaml: |
   partitions:
     - name: default
       placementrules:
@@ -26,4 +26,3 @@ queue.yaml: |
       queues:
       - name: root
         submitacl: '*'
-

--- a/deployments/examples/placements/tag/tag_example.yaml
+++ b/deployments/examples/placements/tag/tag_example.yaml
@@ -20,8 +20,9 @@ kind: Pod
 metadata:
   labels:
     app: sleep
-    applicationId: "prvoided-rule-example01"
-    yunikorn.apache.org/username: developer
+    applicationId: "tag-rule-example01"
+  annotations:
+    yunikorn.apache.org/user.info: "{\"user\": \"developer\"}"
   name: task0
 spec:
   schedulerName: yunikorn
@@ -40,8 +41,9 @@ metadata:
   namespace: testing
   labels:
     app: sleep
-    applicationId: "prvoided-rule-example02"
-    yunikorn.apache.org/username: developer
+    applicationId: "tag-rule-example02"
+  annotations:
+    yunikorn.apache.org/user.info: "{\"user\": \"developer\"}"
   name: task1
 spec:
   schedulerName: yunikorn
@@ -53,4 +55,3 @@ spec:
         requests:
           cpu: "100m"
           memory: "500M"
-

--- a/deployments/examples/placements/username/config.yaml
+++ b/deployments/examples/placements/username/config.yaml
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Update this queue yaml to the yunikorn-configs configmap before trying this example.
-queue.yaml: |
+# Update the queues.yaml to the yunikorn-configs configmap before trying this example.
+queues.yaml: |
   partitions:
     - name: default
       placementrules:
@@ -27,4 +27,3 @@ queue.yaml: |
         submitacl: '*'
         queues:
         - name: finance_dot_test
-

--- a/deployments/examples/placements/username/username_example.yaml
+++ b/deployments/examples/placements/username/username_example.yaml
@@ -21,7 +21,8 @@ metadata:
   labels:
     app: sleep
     applicationId: "username-rule-example01"
-    yunikorn.apache.org/username: finance.test
+  annotations:
+    yunikorn.apache.org/user.info: "{\"user\": \"finance.test\"}"
   name: task0
 spec:
   schedulerName: yunikorn
@@ -40,7 +41,8 @@ metadata:
   labels:
     app: sleep
     applicationId: "username-rule-example02"
-    yunikorn.apache.org/username: developer
+  annotations:
+    yunikorn.apache.org/user.info: "{\"user\": \"developer\"}"
   name: task1
 spec:
   schedulerName: yunikorn
@@ -52,4 +54,3 @@ spec:
         requests:
           cpu: "100m"
           memory: "500M"
-


### PR DESCRIPTION
### What is this PR for?
There are some useful placement rule examples under https://github.com/apache/yunikorn-k8shim/tree/master/deployments/examples/placements

while there are some incorrect settings in them:
- `queue.yaml` should be `queues.yaml`
- label `yunikorn.apache.org/username` is legacy and should be switched to annotation `yunikorn.apache.org/user.info`

Correct me if I'm wrong, the backward compatibility for the label `yunikorn.apache.org/username` seems broken. The placement rules examples in the link mentioned will not work with the label, but will only be effective with the annotation (i.e., `yunikorn.apache.org/user.info`).

### What type of PR is it?
* [x] - Documentation

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2049

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
N/A
