### PR TITLE
[YUNIKORN-2067] Test_With_Spark_Jobs e2e test wait for app state Running after Spark job completed

### DIFF
--- a/test/e2e/spark_jobs_scheduling/spark_jobs_scheduling_test.go
+++ b/test/e2e/spark_jobs_scheduling/spark_jobs_scheduling_test.go
@@ -144,8 +144,12 @@ var _ = Describe("", func() {
 
 		// Verify that all the spark jobs are scheduled and are in running state.
 		for _, id := range appIds {
-			By(fmt.Sprintf("Verify if app: %s is in running state", id))
-			err = restClient.WaitForAppStateTransition("default", "root."+sparkNS, id, yunikorn.States().Application.Running, 360)
+			By(fmt.Sprintf("Verify driver pod for application %s has been created.", id))
+			err = kClient.WaitForPodBySelector(sparkNS, fmt.Sprintf("spark-app-selector=%s, spark-role=driver", id), 180*time.Second)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			By(fmt.Sprintf("Verify driver pod for application %s was completed.", id))
+			err = kClient.WaitForPodBySelectorSucceeded(sparkNS, fmt.Sprintf("spark-app-selector=%s, spark-role=driver", id), 360*time.Second)
 			Ω(err).NotTo(HaveOccurred())
 		}
 	})


### PR DESCRIPTION
### What is this PR for?

- Remove the check of Spark application status(Running) in YuniKorn core using RestClient. 
- Instead, use KubeCtl client to varify spark driver pod status(Success).

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2067

### How should this be tested?
All existing E2E test should pass. 

### Screenshots (if appropriate)

### Questions:
NA
