### PR TITLE
[YUNIKORN-2068] Fix deadlock when evaluating preemption candidates

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -474,7 +474,7 @@ func (ctx *Context) IsPodFitNodeViaPreemption(name, node string, allocations []s
 			// look up each victim in the scheduler cache
 			victims := make([]*v1.Pod, 0)
 			for _, uid := range allocations {
-				if victim, ok := ctx.schedulerCache.GetPod(uid); ok {
+				if victim, ok := ctx.schedulerCache.GetPodNoLock(uid); ok {
 					victims = append(victims, victim)
 				} else {
 					// if pod isn't found, add a placeholder so that the list is still the same size

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -471,10 +471,7 @@ func (cache *SchedulerCache) removePod(pod *v1.Pod) {
 func (cache *SchedulerCache) GetPod(uid string) (*v1.Pod, bool) {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
-	if pod, ok := cache.podsMap[uid]; ok {
-		return pod, true
-	}
-	return nil, false
+	return cache.GetPodNoLock(uid)
 }
 
 func (cache *SchedulerCache) GetPodNoLock(uid string) (*v1.Pod, bool) {

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -477,6 +477,13 @@ func (cache *SchedulerCache) GetPod(uid string) (*v1.Pod, bool) {
 	return nil, false
 }
 
+func (cache *SchedulerCache) GetPodNoLock(uid string) (*v1.Pod, bool) {
+	if pod, ok := cache.podsMap[uid]; ok {
+		return pod, true
+	}
+	return nil, false
+}
+
 func (cache *SchedulerCache) AssumePod(pod *v1.Pod, allBound bool) {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()


### PR DESCRIPTION
### What is this PR for?
Fixes a deadlock that occurs during node evaluation for preemption that causes the scheduler cache read lock to be acquired twice.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2068

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
