### PR TITLE
[YUNIKORN-2070] E2e tests for gang_scheduling failed due to containers init were OOM-Killed

### DIFF
--- a/test/e2e/gang_scheduling/gang_scheduling_test.go
+++ b/test/e2e/gang_scheduling/gang_scheduling_test.go
@@ -71,7 +71,7 @@ var _ = Describe("", func() {
 
 		minResource = map[string]resource.Quantity{
 			v1.ResourceCPU.String():    resource.MustParse("10m"),
-			v1.ResourceMemory.String(): resource.MustParse("10M"),
+			v1.ResourceMemory.String(): resource.MustParse("20M"),
 		}
 		jobNames = []string{}
 		appID = "appid-" + common.RandSeq(5)


### PR DESCRIPTION
### What is this PR for?
To prevent the OOM-Killed error in gang_scheduling e2e test.
This PR changed placeholder's memory limit from 10M to 20M.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
Need several trial run to check the solution is valid.

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2070

### How should this be tested?
Existing E2E test should pass, and no OOM-Killed error happened in gang_scheduling e2e test.

### Screenshots (if appropriate)

### Questions:
NA
