### PR TITLE
[YUNIKORN-2077] Cleanup scheduler event interface in shim

### DIFF
--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -52,7 +52,7 @@ func main() {
 	if serviceContext.RMProxy != nil {
 		ss := shim.NewShimScheduler(serviceContext.RMProxy, conf.GetSchedulerConf(), configMaps)
 		if err := ss.Run(); err != nil {
-			log.Log(log.Shim).Fatal("Unable tto start scheduler", zap.Error(err))
+			log.Log(log.Shim).Fatal("Unable to start scheduler", zap.Error(err))
 		}
 
 		signalChan := make(chan os.Signal, 1)

--- a/pkg/common/events/events.go
+++ b/pkg/common/events/events.go
@@ -65,18 +65,6 @@ type TaskEvent interface {
 }
 
 // --------------------------------------
-// scheduler events
-// --------------------------------------
-type SchedulerEvent interface {
-	// the type of this event
-	GetEvent() string
-
-	// an event can have multiple arguments, these arguments will be passed to
-	// state machines' callbacks when doing state transition
-	GetArgs() []interface{}
-}
-
-// --------------------------------------
 // scheduler node events
 // --------------------------------------
 

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -40,7 +40,6 @@ const (
 	EventTypeApp EventType = iota
 	EventTypeTask
 	EventTypeNode
-	EventTypeScheduler
 )
 
 var (
@@ -194,8 +193,6 @@ func Start() {
 					getEventHandler(EventTypeApp)(v)
 				case events.SchedulerNodeEvent:
 					getEventHandler(EventTypeNode)(v)
-				case events.SchedulerEvent:
-					getEventHandler(EventTypeScheduler)(v)
 				default:
 					log.Log(log.ShimDispatcher).Fatal("unsupported event",
 						zap.Any("event", v))


### PR DESCRIPTION
### What is this PR for?
The scheduler state machine was removed from shim after [YUNIKORN-2074](https://issues.apache.org/jira/browse/YUNIKORN-2074), and the interface for creating scheduler event could be removed too.

- SchedulerEvent (events.go)
- EventTypeScheduler (dispatcher.go)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2077

### How should this be tested?
All existing e2e test should pass.

### Screenshots (if appropriate)
NA

### Questions:
NA
