### PR TITLE
[YUNIKORN-2082] Make autogenerated applicationIDs reproducible

### DIFF
--- a/pkg/admission/util_test.go
+++ b/pkg/admission/util_test.go
@@ -19,7 +19,6 @@
 package admission
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -227,55 +226,4 @@ func TestDefaultQueueName(t *testing.T) {
 	} else {
 		t.Fatal("UpdatePodLabelForAdmissionController is not as expected")
 	}
-}
-
-func TestGenerateAppID(t *testing.T) {
-	defaultConf := createConfig()
-
-	appID := generateAppID("this-is-a-namespace", defaultConf.GetGenerateUniqueAppIds())
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-this-is-a-namespace", constants.AutoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 36)
-
-	appID = generateAppID("short", defaultConf.GetGenerateUniqueAppIds())
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-short", constants.AutoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 22)
-
-	appID = generateAppID(strings.Repeat("long", 100), defaultConf.GetGenerateUniqueAppIds())
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-long", constants.AutoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 63)
-
-	// explicitly disable autogen config
-	uniqueDisabled := createConfigWithOverrides(map[string]string{
-		conf.AMFilteringGenerateUniqueAppIds: fmt.Sprintf("%t", false),
-	})
-
-	appID = generateAppID("this-is-a-namespace", uniqueDisabled.GetGenerateUniqueAppIds())
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-this-is-a-namespace", constants.AutoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 36)
-
-	appID = generateAppID("short", uniqueDisabled.GetGenerateUniqueAppIds())
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-short", constants.AutoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 22)
-
-	appID = generateAppID(strings.Repeat("long", 100), uniqueDisabled.GetGenerateUniqueAppIds())
-	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-long", constants.AutoGenAppPrefix)), true)
-	assert.Equal(t, len(appID), 63)
-
-	// enabled autogen config
-	uniqueEnabled := createConfigWithOverrides(map[string]string{
-		conf.AMFilteringGenerateUniqueAppIds: fmt.Sprintf("%t", true),
-	})
-
-	// short namespace name
-	ns := "short"
-	appID = generateAppID(ns, uniqueEnabled.GetGenerateUniqueAppIds())
-	assert.Equal(t, strings.HasPrefix(appID, "short-"), true)
-	assert.Equal(t, len(appID), len("short")+len("-")+len(GetNewUUID()))
-
-	// long namespace name
-	ns = strings.Repeat("long", 100)
-	appID = generateAppID(ns, uniqueEnabled.GetGenerateUniqueAppIds())
-	assert.Equal(t, strings.HasPrefix(appID, "long"), true)
-	assert.Equal(t, strings.HasPrefix(appID, ns[0:26]+"-"), true)
-	assert.Equal(t, len(appID), 63)
 }

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -102,6 +102,20 @@ func GetQueueNameFromPod(pod *v1.Pod) string {
 	return queueName
 }
 
+// GenerateApplicationID generates an appID based on the namespace value
+// if configured to generate unique appID, generate appID as <namespace>-<pod-uid> namespace capped at 26chars
+// if not set or configured as false, appID generated as <autogen-prefix>-<namespace>-<autogen-suffix>
+func GenerateApplicationID(namespace string, generateUniqueAppIds bool, podUID string) string {
+	var generatedID string
+	if generateUniqueAppIds {
+		generatedID = fmt.Sprintf("%.26s-%s", namespace, podUID)
+	} else {
+		generatedID = fmt.Sprintf("%s-%s-%s", constants.AutoGenAppPrefix, namespace, constants.AutoGenAppSuffix)
+	}
+
+	return fmt.Sprintf("%.63s", generatedID)
+}
+
 // GetApplicationIDFromPod returns the applicationID (if present) from a Pod or an empty string if not present.
 // If an applicationID is present, the Pod is managed by YuniKorn. Otherwise, it is managed by an external scheduler.
 func GetApplicationIDFromPod(pod *v1.Pod) string {

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -23,6 +23,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -585,6 +586,26 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			assert.Equal(t, appID, tc.expectedAppID)
 		})
 	}
+}
+
+func TestGenerateApplicationID(t *testing.T) {
+	assert.Equal(t, "yunikorn-this-is-a-namespace-autogen",
+		GenerateApplicationID("this-is-a-namespace", false, "pod-uid"))
+
+	assert.Equal(t, "this-is-a-namespace-pod-uid",
+		GenerateApplicationID("this-is-a-namespace", true, "pod-uid"))
+
+	assert.Equal(t, "yunikorn-short-autogen",
+		GenerateApplicationID("short", false, "pod-uid"))
+
+	assert.Equal(t, "short-pod-uid",
+		GenerateApplicationID("short", true, "pod-uid"))
+
+	assert.Equal(t, "yunikorn-longlonglonglonglonglonglonglonglonglonglonglonglonglo",
+		GenerateApplicationID(strings.Repeat("long", 100), false, "pod-uid"))
+
+	assert.Equal(t, "longlonglonglonglonglonglo-pod-uid",
+		GenerateApplicationID(strings.Repeat("long", 100), true, "pod-uid"))
 }
 
 func TestMergeMaps(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Moved the admission-controller private function generateAppID() to the shim utils package and renamed to GenerateApplicationID() to allow for re-use by the shim. Updated implementation to use the pod UID instead of a random UUID so that the same identifier will always be created for the same Pod.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2082

### How should this be tested?
Updated unit tests.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
