### PR TITLE
[YUNIKORN-2083] Shim: Handle missing applicationID cleanly in standard mode

### DIFF
--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -591,9 +591,9 @@ func TestListApplication(t *testing.T) {
 		// Application 4
 		{
 			description:    "running in default queue and namespace01, without label and annotation",
-			applicationID:  appName[3],
+			applicationID:  "yunikorn-namespace01-autogen",
 			input:          podCase[4].InjectPod(),
-			expectedOutput: false,
+			expectedOutput: true,
 		},
 		// Application 5
 		{
@@ -615,7 +615,7 @@ func TestListApplication(t *testing.T) {
 	am := NewManager(mockedAPIProvider, NewPodEventHandler(amProtocol, true))
 	pods, err := am.ListPods()
 	assert.NilError(t, err)
-	assert.Equal(t, len(pods), 3)
+	assert.Equal(t, len(pods), 4)
 	for _, pod := range pods {
 		name := utils.GetApplicationIDFromPod(pod)
 		expected := expectOutput[name]

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -133,10 +133,6 @@ func (ctx *Context) IsPluginMode() bool {
 	return ctx.pluginMode
 }
 
-func (ctx *Context) SetPluginMode(pluginMode bool) {
-	ctx.pluginMode = pluginMode
-}
-
 func (ctx *Context) addNode(obj interface{}) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -1473,8 +1473,10 @@ func TestAddApplicationsWithTags(t *testing.T) {
 }
 
 func TestPendingPodAllocations(t *testing.T) {
+	utils.SetPluginMode(true)
+	defer utils.SetPluginMode(false)
+
 	context := initContextForTest()
-	context.SetPluginMode(true)
 
 	node1 := v1.Node{
 		ObjectMeta: apis.ObjectMeta{

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -52,9 +52,10 @@ const (
 	EnvNamespace  = "NAMESPACE"
 
 	// prefixes
-	PrefixService    = "service."
-	PrefixLog        = "log."
-	PrefixKubernetes = "kubernetes."
+	PrefixService             = "service."
+	PrefixLog                 = "log."
+	PrefixKubernetes          = "kubernetes."
+	PrefixAdmissionController = "admissionController."
 
 	// service
 	CMSvcClusterID                    = PrefixService + "clusterId"
@@ -73,19 +74,24 @@ const (
 	CMKubeQPS   = PrefixKubernetes + "qps"
 	CMKubeBurst = PrefixKubernetes + "burst"
 
+	// admissioncontroller
+	PrefixAMFiltering               = PrefixAdmissionController + "filtering."
+	AMFilteringGenerateUniqueAppIds = PrefixAMFiltering + "generateUniqueAppId"
+
 	// defaults
-	DefaultNamespace              = "default"
-	DefaultClusterID              = "mycluster"
-	DefaultPolicyGroup            = "queues"
-	DefaultSchedulingInterval     = time.Second
-	DefaultVolumeBindTimeout      = 10 * time.Second
-	DefaultEventChannelCapacity   = 1024 * 1024
-	DefaultDispatchTimeout        = 300 * time.Second
-	DefaultOperatorPlugins        = "general"
-	DefaultDisableGangScheduling  = false
-	DefaultEnableConfigHotRefresh = true
-	DefaultKubeQPS                = 1000
-	DefaultKubeBurst              = 1000
+	DefaultNamespace                       = "default"
+	DefaultClusterID                       = "mycluster"
+	DefaultPolicyGroup                     = "queues"
+	DefaultSchedulingInterval              = time.Second
+	DefaultVolumeBindTimeout               = 10 * time.Second
+	DefaultEventChannelCapacity            = 1024 * 1024
+	DefaultDispatchTimeout                 = 300 * time.Second
+	DefaultOperatorPlugins                 = "general"
+	DefaultDisableGangScheduling           = false
+	DefaultEnableConfigHotRefresh          = true
+	DefaultKubeQPS                         = 1000
+	DefaultKubeBurst                       = 1000
+	DefaultAMFilteringGenerateUniqueAppIds = false
 )
 
 var (
@@ -124,6 +130,7 @@ type SchedulerConf struct {
 	PlaceHolderImage         string        `json:"placeHolderImage"`
 	InstanceTypeNodeLabelKey string        `json:"instanceTypeNodeLabelKey"`
 	Namespace                string        `json:"namespace"`
+	GenerateUniqueAppIds     bool          `json:"generateUniqueAppIds"`
 	sync.RWMutex
 }
 
@@ -151,6 +158,7 @@ func (conf *SchedulerConf) Clone() *SchedulerConf {
 		PlaceHolderImage:         conf.PlaceHolderImage,
 		InstanceTypeNodeLabelKey: conf.InstanceTypeNodeLabelKey,
 		Namespace:                conf.Namespace,
+		GenerateUniqueAppIds:     conf.GenerateUniqueAppIds,
 	}
 }
 
@@ -208,6 +216,7 @@ func handleNonReloadableConfig(old *SchedulerConf, new *SchedulerConf) {
 	checkNonReloadableBool(CMSvcDisableGangScheduling, &old.DisableGangScheduling, &new.DisableGangScheduling)
 	checkNonReloadableString(CMSvcPlaceholderImage, &old.PlaceHolderImage, &new.PlaceHolderImage)
 	checkNonReloadableString(CMSvcNodeInstanceTypeNodeLabelKey, &old.InstanceTypeNodeLabelKey, &new.InstanceTypeNodeLabelKey)
+	checkNonReloadableBool(AMFilteringGenerateUniqueAppIds, &old.GenerateUniqueAppIds, &new.GenerateUniqueAppIds)
 }
 
 const warningNonReloadable = "ignoring non-reloadable configuration change (restart required to update)"
@@ -337,6 +346,7 @@ func CreateDefaultConfig() *SchedulerConf {
 		UserLabelKey:             constants.DefaultUserLabel,
 		PlaceHolderImage:         constants.PlaceholderContainerImage,
 		InstanceTypeNodeLabelKey: constants.DefaultNodeInstanceTypeNodeLabelKey,
+		GenerateUniqueAppIds:     DefaultAMFilteringGenerateUniqueAppIds,
 	}
 }
 
@@ -366,6 +376,9 @@ func parseConfig(config map[string]string, prev *SchedulerConf) (*SchedulerConf,
 	// kubernetes
 	parser.intVar(&conf.KubeQPS, CMKubeQPS)
 	parser.intVar(&conf.KubeBurst, CMKubeBurst)
+
+	// admission controller
+	parser.boolVar(&conf.GenerateUniqueAppIds, AMFilteringGenerateUniqueAppIds)
 
 	if len(parser.errors) > 0 {
 		return nil, parser.errors

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -73,7 +73,7 @@ func NewShimScheduler(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, b
 func NewShimSchedulerForPlugin(scheduler api.SchedulerAPI, informerFactory informers.SharedInformerFactory, configs *conf.SchedulerConf, bootstrapConfigMaps []*v1.ConfigMap) *KubernetesShim {
 	apiFactory := client.NewAPIFactory(scheduler, informerFactory, configs, false)
 	context := cache.NewContextWithBootstrapConfigMaps(apiFactory, bootstrapConfigMaps)
-	context.SetPluginMode(true)
+	utils.SetPluginMode(true)
 	rmCallback := callback.NewAsyncRMCallback(context)
 	appManager := appmgmt.NewAMService(context, apiFactory)
 	return newShimSchedulerInternal(context, apiFactory, appManager, rmCallback)


### PR DESCRIPTION
### What is this PR for?
If a Pod with `schedulerName: yunikorn` is encountered with missing applicationID metadata, generate an applicationID using the same algorithm as the admission controller would have. This allows these Pods to be scheduled successfully.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2083

### How should this be tested?
Updated unit tests to handle new logic (both plugin / standard mode). Also manually created a Pod with the necessary conditions and verified that it scheduled properly and was assigned the appropriate applicationID by YuniKorn.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
