### PR TITLE
[YUNIKORN-2093] Remove unnecessary e2e_test condition in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,6 @@ ifeq ($(VERSION),)
 VERSION := latest
 endif
 
-# Test selection
-ifeq ($(E2E_TEST),)
-E2E_TEST :=
-endif
-
 # Kernel (OS) Name
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 


### PR DESCRIPTION
### What is this PR for?
Remove the following snippets from the Makefile, because when E2E_TEST is empty, ginkgo will run all e2e tests.

```shell 
# Test selection

ifeq ($(E2E_TEST),)
E2E_TEST :=
endif
```

### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
[YUNIKORN-2093](https://issues.apache.org/jira/browse/YUNIKORN-2093)

