### PR TITLE
[YUNIKORN-2094] Add install kind cluster option to run-e2e-test script

### DIFF
--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -243,13 +243,16 @@ echo "  web image          : ${WEBTEST_IMAGE}"
 check_opt "action" "${ACTION}"
 check_opt "kind-cluster-name" "${CLUSTER_NAME}"
 
-# this script only supports 2 actions
+# this script only supports 3 actions
 #   1) test
 #     - install a K8s cluster with kind
 #     - install latest yunikorn
 #     - run e2e tests
 #   2) cleanup
 #     - delete k8s cluster
+#   3) install
+#     - install a K8s cluster with kind
+#     - install latest yunikorn
 if [ "${ACTION}" == "test" ]; then
   # make will fail without go installed but we call it before that...
   check_cmd "${GO}"
@@ -266,6 +269,11 @@ if [ "${ACTION}" == "test" ]; then
   fi
   make e2e_test
   exit_on_error "e2e tests failed"
+elif [ "${ACTION}" == "install" ]; then
+  check_cmd "${GO}"
+  check_opt "kind-node-image-version" "${CLUSTER_VERSION}"
+  check_opt "chart-path" "${CHART_PATH}"
+  install_cluster
 elif [ "${ACTION}" == "cleanup" ]; then
   echo "cleaning up the environment"
   delete_cluster


### PR DESCRIPTION
### What is this PR for?
Currently, the run-e2e-test script supports only two actions: cleanup and test.

It's common for us to want to test specific e2e tests instead of the entire set of e2e tests.

So, let's add a new action to only install the kind cluster. Then, we can run a particular e2e test for a specific folder using:

e.g.

```shell 
make e2e_test E2E_TEST=user_group_limit
```

For even finer granularity:

e.g.

```shell 
ginkgo run -r -v --focus "Verify_maxapplications_with_a_specific_group_limit" \
-- -yk-namespace "yunikorn" \
-kube-config "$HOME/.kube/config"
```

 ### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
[YUNIKORN-2094](https://issues.apache.org/jira/browse/YUNIKORN-2094)
