### PR TITLE
[YUNIKORN-2098] Change go lint SHA detection (following)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Fetch all branches and tags
+        run: git fetch --all
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -46,6 +48,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Fetch all branches and tags
+        run: git fetch --all
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Fetch all branches and tags
+        run: git fetch --all
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ $(SPARK_SUBMIT_CMD):
 lint: $(GOLANGCI_LINT_BIN)
 	@echo "running golangci-lint"
 	@git show-ref 
-	@git symbolic-ref -q HEAD && REV="origin/HEAD"; \
+	@REV="origin/HEAD"; \
 	echo "REV1 is $${REV}" ; \
 	git rev-parse $${REV} || REV="HEAD^"; \
 	echo "REV2 is $${REV}" ; \

--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,7 @@ lint: $(GOLANGCI_LINT_BIN)
 	@echo "running golangci-lint"
 	@git show-ref 
 	@REV="origin/HEAD"; \
-	echo "REV1 is $${REV}" ; \
 	git rev-parse $${REV} || REV="HEAD^"; \
-	echo "REV2 is $${REV}" ; \
 	headSHA=$$(git rev-parse --short=12 $${REV}) ; \
 	echo "checking against commit sha $${headSHA}" ; \
 	"${GOLANGCI_LINT_BIN}" run --new-from-rev=$${headSHA}

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,10 @@ $(SPARK_SUBMIT_CMD):
 lint: $(GOLANGCI_LINT_BIN)
 	@echo "running golangci-lint"
 	@git show-ref 
-	@git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^" ; \
+	@git symbolic-ref -q HEAD && REV="origin/HEAD"; \
+	echo "REV1 is $${REV}" ; \
+	git rev-parse $${REV} || REV="HEAD^"; \
+	echo "REV2 is $${REV}" ; \
 	headSHA=$$(git rev-parse --short=12 $${REV}) ; \
 	echo "checking against commit sha $${headSHA}" ; \
 	"${GOLANGCI_LINT_BIN}" run --new-from-rev=$${headSHA}

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ $(SPARK_SUBMIT_CMD):
 .PHONY: lint
 lint: $(GOLANGCI_LINT_BIN)
 	@echo "running golangci-lint"
+	@git show-ref 
 	@git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^" ; \
 	headSHA=$$(git rev-parse --short=12 $${REV}) ; \
 	echo "checking against commit sha $${headSHA}" ; \


### PR DESCRIPTION
### What is this PR for?
Currently, we will always use the "ORIGIN/HEAD" ref.(In Github Action env) Fallback to "HEAD^" when "ORIGIN/HEAD" doesn't exist.
Also print what git ref the ci have. 

I get `fatal: Needed a single revision` on my fork github action ci.
https://github.com/doupache/yunikorn-k8shim/actions/runs/6713607756/job/18245448950
<img width="1021" alt="image" src="https://github.com/apache/yunikorn-k8shim/assets/143783826/11bfee53-fb8f-4812-ab27-d5cd3bed34c2">




![image](https://github.com/apache/yunikorn-k8shim/assets/143783826/c41606cb-9350-4b45-ba87-0fead4f24cf0)
![image](https://github.com/apache/yunikorn-k8shim/assets/143783826/bcbebc02-5531-4967-92d3-184a191b1ed3)


CI in the forked repo doesn't seem to have the "ORIGIN/HEAD" ref.
I keep getting the 'fatal: Needed a single revision' error, similar to [YUNIKORN-285](https://issues.apache.org/jira/browse/YUNIKORN-285)

### What type of PR is it?
* [x] - Bug Fix

### What is the Jira issue?
[YUNIKORN-2098](https://issues.apache.org/jira/browse/YUNIKORN-2098)

