### PR TITLE
[YUNIKORN-2160] Fix Pod state in UserGroupLimit e2e test

### DIFF
--- a/test/e2e/user_group_limit/user_group_limit_test.go
+++ b/test/e2e/user_group_limit/user_group_limit_test.go
@@ -417,7 +417,9 @@ func deploySleepPod(usergroup *si.UserGroupInformation, queuePath string, expect
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
 	} else {
 		ginkgo.By(fmt.Sprintf("The sleep pod %s can't be scheduled %s", sleepPod.Name, reason))
-		err = kClient.WaitForPodUnschedulable(sleepPod, 60*time.Second)
+		// Since Pending is the initial state of PodPhase, sleep for 5 seconds, then check whether the pod is still in Pending state.
+		time.Sleep(5 * time.Second)
+		err = kClient.WaitForPodPending(sleepPod.Namespace, sleepPod.Name, 60*time.Second)
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
 	}
 	return sleepPod


### PR DESCRIPTION
### What is this PR for?
The PodCondition for pods pending due to exceeding the user/group limit was changed after YUNIKORN-1936. The e2e test should change the way to validate unscheduled pods.
- Change validation function from WaitForPodUnschedulable() to WaitForPodPending().
- Sleep 5 seconds before check Pending pods becasue Pending is the initial PodPhase state after accepted.(5 sec is based on the the recent e2e test in CI and my local env.(~3 sec to unscheduled))

<img width="1432" alt="image" src="https://github.com/apache/yunikorn-k8shim/assets/26764036/5f1a703e-fd05-42dc-a4a8-b84add2c2a1b">


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2160

### How should this be tested?
Upgrade to the latest yunikorn-core, and run e2e tests under user_group_limit.
(The issue will only occur in core version after YUNIKORN-1936.  I'm not sure whether I should upgrade yunikorn-core in this PR, please let me know if it's ok to upgrade.)

### Screenshots (if appropriate)

### Questions:
* [ ] - Should I upgrade yunikorn-core version in this PR?
