### PR TITLE
[YUNIKORN-2170] Update Spark version to 3.3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ HELM_ARCHIVE_BASE=$(OS)-$(EXEC_ARCH)
 export SPARK_VERSION=3.3.3
 export SPARK_HOME=$(BASE_DIR)$(TOOLS_DIR)/spark
 export SPARK_SUBMIT_CMD=$(SPARK_HOME)/bin/spark-submit
-export SPARK_PYTHON_IMAGE=docker.io/apache/spark-py:v$(SPARK_VERSION)
+export SPARK_PYTHON_IMAGE=docker.io/apache/spark-py:v3.3.1
 
 FLAG_PREFIX=github.com/apache/yunikorn-k8shim/pkg/conf
 

--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,11 @@ HELM_ARCHIVE_BASE=$(OS)-$(EXEC_ARCH)
 
 # spark
 export SPARK_VERSION=3.3.3
+# sometimes the image is not avaiable with $SPARK_VERSION, the minor version must match
+export SPARK_PYTHON_VERSION=3.3.1
 export SPARK_HOME=$(BASE_DIR)$(TOOLS_DIR)/spark
 export SPARK_SUBMIT_CMD=$(SPARK_HOME)/bin/spark-submit
-export SPARK_PYTHON_IMAGE=docker.io/apache/spark-py:v3.3.1
+export SPARK_PYTHON_IMAGE=docker.io/apache/spark-py:v$(SPARK_PYTHON_VERSION)
 
 FLAG_PREFIX=github.com/apache/yunikorn-k8shim/pkg/conf
 

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ HELM_ARCHIVE=helm-$(HELM_VERSION)-$(OS)-$(EXEC_ARCH).tar.gz
 HELM_ARCHIVE_BASE=$(OS)-$(EXEC_ARCH)
 
 # spark
-export SPARK_VERSION=3.3.1
+export SPARK_VERSION=3.3.3
 export SPARK_HOME=$(BASE_DIR)$(TOOLS_DIR)/spark
 export SPARK_SUBMIT_CMD=$(SPARK_HOME)/bin/spark-submit
 export SPARK_PYTHON_IMAGE=docker.io/apache/spark-py:v$(SPARK_VERSION)


### PR DESCRIPTION
Spark 3.3.1 has been archived and downloading is slow from archive.apache.org.

### What is this PR for?
Update Spark version to 3.3.3 so that it's downloaded faster from mirrors during CI build.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2170

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
