### PR TITLE
[YUNIKORN-2189] Change the log level of "adding node to cache" from WARN to INFO

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -143,7 +143,7 @@ func (ctx *Context) addNode(obj interface{}) {
 	}
 
 	// add node to secondary scheduler cache
-	log.Log(log.ShimContext).Warn("adding node to cache", zap.String("NodeName", node.Name))
+	log.Log(log.ShimContext).Info("adding node to cache", zap.String("NodeName", node.Name))
 	ctx.schedulerCache.AddNode(node)
 
 	// add node to internal cache


### PR DESCRIPTION
### What is this PR for?
change log level [`adding node to cache`](https://github.com/apache/yunikorn-k8shim/blob/master/pkg/cache/context.go#L146) from WARN to INFO. 
the other logs having similar output are using INFO level.
https://github.com/apache/yunikorn-core/blob/master/pkg/scheduler/partition.go#L542
https://github.com/apache/yunikorn-k8shim/blob/master/pkg/cache/nodes.go#L103

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2189

### How should this be tested?
only change log level.

### Screenshots (if appropriate)
N/A

### Questions:
N/A