### PR TITLE
[YUNIKORN-2236] Extended support for zlib and lzw compression to compress long configMap entries

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -118,5 +118,8 @@ const AnnotationEnableYuniKorn = DomainYuniKorn + "namespace.enableYuniKorn"
 const AutoGenAppPrefix = "yunikorn"
 const AutoGenAppSuffix = "autogen"
 
-// Compression Algorithms for schedulerConfig
+// Compression Algorithm constants for schedulerConfig
 const GzipSuffix = "gz"
+const LzwSuffix = "lzw"
+const ZlibSuffix = "zlib"
+const LzwLiteralWidth = 8


### PR DESCRIPTION
### What is this PR for?
Added support for zlib and lzw for configMap entries to offer a wider variety to compress configMaps.

This commit makes Yunikorn support zlib and lzw compressed 64bit encoded BinaryData in configMaps.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
[YUNIKORN-2236](https://issues.apache.org/jira/browse/YUNIKORN-2236)

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
