### PR TITLE
[YUNIKORN-2205] remove the warning of processing nonexistent "namespa…

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -179,19 +179,18 @@ func PodUnderCondition(pod *v1.Pod, condition *v1.PodCondition) bool {
 // get namespace guaranteed resource from namespace annotation
 func GetNamespaceGuaranteedFromAnnotation(namespaceObj *v1.Namespace) *si.Resource {
 	// retrieve guaranteed resource info from annotations
-	namespaceGuaranteed := GetNameSpaceAnnotationValue(namespaceObj, constants.NamespaceGuaranteed)
-	if namespaceGuaranteed == "" {
-		return nil
+	if guaranteed := GetNameSpaceAnnotationValue(namespaceObj, constants.NamespaceGuaranteed); guaranteed != "" {
+		var namespaceGuaranteedMap map[string]string
+		err := json.Unmarshal([]byte(guaranteed), &namespaceGuaranteedMap)
+		if err != nil {
+			log.Log(log.ShimUtils).Warn("Unable to process namespace.guaranteed annotation",
+				zap.String("namespace", namespaceObj.Name),
+				zap.String("namespace.guaranteed is", guaranteed))
+			return nil
+		}
+		return common.GetResource(namespaceGuaranteedMap)
 	}
-	var namespaceGuaranteedMap map[string]string
-	err := json.Unmarshal([]byte(namespaceGuaranteed), &namespaceGuaranteedMap)
-	if err != nil {
-		log.Log(log.ShimUtils).Warn("Unable to process namespace.guaranteed annotation",
-			zap.String("namespace", namespaceObj.Name),
-			zap.String("namespace.guaranteed is", namespaceGuaranteed))
-		return nil
-	}
-	return common.GetResource(namespaceGuaranteedMap)
+	return nil
 }
 
 func GetNamespaceQuotaFromAnnotation(namespaceObj *v1.Namespace) *si.Resource {

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -180,6 +180,9 @@ func PodUnderCondition(pod *v1.Pod, condition *v1.PodCondition) bool {
 func GetNamespaceGuaranteedFromAnnotation(namespaceObj *v1.Namespace) *si.Resource {
 	// retrieve guaranteed resource info from annotations
 	namespaceGuaranteed := GetNameSpaceAnnotationValue(namespaceObj, constants.NamespaceGuaranteed)
+	if namespaceGuaranteed == "" {
+		return nil
+	}
 	var namespaceGuaranteedMap map[string]string
 	err := json.Unmarshal([]byte(namespaceGuaranteed), &namespaceGuaranteedMap)
 	if err != nil {

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -283,6 +283,21 @@ func TestGetNamespaceGuaranteedFromAnnotation(t *testing.T) {
 				},
 			},
 		}, nil},
+		{&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+				Annotations: map[string]string{
+					constants.NamespaceGuaranteed: "error",
+				},
+			},
+		}, nil},
+		{&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+		}, nil},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("namespace: %v", tc.namespace), func(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
The warning message is printed when "namespace.guaranteed" does not exist. This PR checking if the "namespaceGuaranteed" value is empty and returning early to avoid the warning message. This ensures that the warning is not displayed when the expected behavior occurs. 


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2205