### PR TITLE
[YUNIKORN-2230] Placement rule does not behave as expected

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -102,13 +102,12 @@ func IsAssignedPod(pod *v1.Pod) bool {
 }
 
 func GetQueueNameFromPod(pod *v1.Pod) string {
-	queueName := constants.ApplicationDefaultQueue
-	if an := GetPodLabelValue(pod, constants.LabelQueueName); an != "" {
-		queueName = an
-	} else if qu := GetPodAnnotationValue(pod, constants.AnnotationQueueName); qu != "" {
-		queueName = qu
+	if queueName := GetPodLabelValue(pod, constants.LabelQueueName); queueName != "" {
+		return queueName
+	} else if queueName := GetPodAnnotationValue(pod, constants.AnnotationQueueName); queueName != "" {
+		return queueName
 	}
-	return queueName
+	return ""
 }
 
 // GenerateApplicationID generates an appID based on the namespace value

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -832,7 +832,7 @@ func TestGetQueueNameFromPod(t *testing.T) {
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{},
 			},
-			expectedQueue: constants.ApplicationDefaultQueue,
+			expectedQueue: "",
 		},
 	}
 

--- a/test/e2e/placement_rules/placement_rules_suite_test.go
+++ b/test/e2e/placement_rules/placement_rules_suite_test.go
@@ -1,0 +1,63 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package placement_rules
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
+	"github.com/onsi/gomega"
+
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/configmanager"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/common"
+)
+
+func init() {
+	configmanager.YuniKornTestConfig.ParseFlags()
+}
+
+func TestPlacementRules(t *testing.T) {
+	ginkgo.ReportAfterSuite("TestPlacementRules", func(report ginkgo.Report) {
+		err := common.CreateJUnitReportDir()
+		Ω(err).NotTo(HaveOccurred())
+		err = reporters.GenerateJUnitReportWithConfig(
+			report,
+			filepath.Join(configmanager.YuniKornTestConfig.LogDir, "TEST-placement_rules_junit.xml"),
+			reporters.JunitReportConfig{OmitSpecLabels: true},
+		)
+		Ω(err).NotTo(HaveOccurred())
+	})
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "TestPlacementRules", ginkgo.Label("TestPlacementRules"))
+}
+
+var By = ginkgo.By
+var Describe = ginkgo.Describe
+var It = ginkgo.It
+var BeforeSuite = ginkgo.BeforeSuite
+var AfterSuite = ginkgo.AfterSuite
+var BeforeEach = ginkgo.BeforeEach
+var AfterEach = ginkgo.AfterEach
+
+var Ω = gomega.Ω
+var BeNil = gomega.BeNil
+var Equal = gomega.Equal
+var HaveOccurred = gomega.HaveOccurred

--- a/test/e2e/placement_rules/placement_rules_test.go
+++ b/test/e2e/placement_rules/placement_rules_test.go
@@ -1,0 +1,155 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package placement_rules
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/apache/yunikorn-core/pkg/common/configs"
+	"github.com/apache/yunikorn-k8shim/pkg/admission/conf"
+	tests "github.com/apache/yunikorn-k8shim/test/e2e"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/common"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/k8s"
+	"github.com/apache/yunikorn-k8shim/test/e2e/framework/helpers/yunikorn"
+)
+
+var kClient k8s.KubeCtl
+var restClient yunikorn.RClient
+var annotation = "ann-" + common.RandSeq(10)
+var oldConfigMap = new(v1.ConfigMap)
+
+var _ = BeforeSuite(func() {
+	// Initializing kubectl client
+	kClient = k8s.KubeCtl{}
+	Ω(kClient.SetClient()).To(gomega.BeNil())
+	// Initializing rest client
+	restClient = yunikorn.RClient{}
+	Ω(restClient).NotTo(gomega.BeNil())
+
+	yunikorn.EnsureYuniKornConfigsPresent()
+
+	By("Port-forward the scheduler pod")
+	err := kClient.PortForwardYkSchedulerPod()
+	Ω(err).NotTo(HaveOccurred())
+
+	yunikorn.UpdateConfigMapWrapper(oldConfigMap, "", annotation)
+})
+
+var _ = AfterSuite(func() {
+	yunikorn.RestoreConfigMapWrapper(oldConfigMap, annotation)
+})
+
+var _ = Describe("Placement_rules", func() {
+	var ns string
+
+	BeforeEach(func() {
+		ns = "ns-" + common.RandSeq(10)
+		By(fmt.Sprintf("Creating namespace: %s", ns))
+		var ns1, err1 = kClient.CreateNamespace(ns, nil)
+		Ω(err1).NotTo(HaveOccurred())
+		Ω(ns1.Status.Phase).To(Equal(v1.NamespaceActive))
+	})
+
+	AfterEach(func() {
+		By("Tear down namespace: " + ns)
+		err := kClient.TearDownNamespace(ns)
+		Ω(err).NotTo(HaveOccurred())
+
+		testDescription := ginkgo.CurrentSpecReport()
+		if testDescription.Failed() {
+			tests.LogTestClusterInfoWrapper(testDescription.FailureMessage(), []string{ns})
+			tests.LogYunikornContainer(testDescription.FailureMessage())
+		}
+		// call the healthCheck api to check scheduler health
+		By("Check Yunikorn's health")
+		checks, err := yunikorn.GetFailedHealthChecks()
+		Ω(err).NotTo(HaveOccurred())
+		Ω(checks).To(Equal(""), checks)
+	})
+
+	It("Verify_provied_rule_with_tag_namespace_rule_with_default_queue", func() {
+		By("Update placement rule to ConfigMap with admission controller default queue")
+		yunikorn.UpdateCustomConfigMapWrapper(oldConfigMap, "", "", func(sc *configs.SchedulerConfig) error {
+			sc.Partitions[0].PlacementRules = []configs.PlacementRule{
+				{
+					Name:   "provided",
+					Create: true,
+				},
+				{
+					Name:   "tag",
+					Value:  "namespace",
+					Create: true,
+				}}
+			return nil
+		})
+
+		By("Deploy the sleep pod to the development namespace")
+		initPod, podErr := k8s.InitSleepPod(k8s.SleepPodConfig{NS: ns})
+		Ω(podErr).NotTo(HaveOccurred())
+		sleepRespPod, err := kClient.CreatePod(initPod, ns)
+		Ω(err).NotTo(HaveOccurred())
+		// Wait for pod to move to running state
+		err = kClient.WaitForPodRunning(ns, initPod.Name, 30*time.Second)
+		Ω(err).NotTo(HaveOccurred())
+
+		By("Check application is under default queue")
+		appsInfo, err := restClient.GetAppInfo("default", conf.DefaultFilteringQueueName, sleepRespPod.ObjectMeta.Labels["applicationId"])
+		Ω(err).NotTo(HaveOccurred())
+		Ω(appsInfo).NotTo(BeNil())
+		Ω(appsInfo.QueueName).To(Equal(conf.DefaultFilteringQueueName))
+	})
+
+	It("Verify_provied_rule_with_tag_namespace_rule_without_default_queue", func() {
+		By("Update placement rule to ConfigMap without admission controller default queue")
+		amConf := map[string]string{"admissionController.filtering.defaultQueue": ""}
+		yunikorn.UpdateCustomConfigMapWrapperWithMap(oldConfigMap, "", "", amConf, func(sc *configs.SchedulerConfig) error {
+			sc.Partitions[0].PlacementRules = []configs.PlacementRule{
+				{
+					Name:   "provided",
+					Create: true,
+				},
+				{
+					Name:   "tag",
+					Value:  "namespace",
+					Create: true,
+				}}
+			return nil
+		})
+
+		By("Deploy the sleep pod to the development namespace")
+		initPod, podErr := k8s.InitSleepPod(k8s.SleepPodConfig{NS: ns})
+		Ω(podErr).NotTo(HaveOccurred())
+		sleepRespPod, err := kClient.CreatePod(initPod, ns)
+		Ω(err).NotTo(HaveOccurred())
+		// Wait for pod to move to running state
+		err = kClient.WaitForPodRunning(ns, initPod.Name, 30*time.Second)
+		Ω(err).NotTo(HaveOccurred())
+
+		By("Check application is under queue generated by tag placement rule")
+		appsInfo, err := restClient.GetAppInfo("default", "root."+ns, sleepRespPod.ObjectMeta.Labels["applicationId"])
+		Ω(err).NotTo(HaveOccurred())
+		Ω(appsInfo).NotTo(BeNil())
+		Ω(appsInfo.QueueName).To(Equal("root." + ns))
+	})
+})


### PR DESCRIPTION
### What is this PR for?
Fix issue with the placement rules, specifically the one where the provided rule (when `created` is true) is applied before the tag rule, is not functioning as intended. The root cause lies in the GetQueueNameFromPod function in the shim, which automatically adds a default queue name to a pod if none is specified. As a result, the provided rule (when `created` is true) is consistently applied, preventing the tag rule from being triggered.

### What type of PR is it?
* [x] - Bug Fix

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2230

### How should this be tested?
covered by e2e test

### Screenshots (if appropriate)
N/A

### Questions:
* [x] - There is breaking changes for older versions. This Pull Request removed the default queue name on the shim side. If a user is using YuniKorn without enabling the Admission Controller (which adds a default queue name), pods that do not provide a queue name will be rejected.