### PR TITLE
[YUNIKORN-2271] Incorrect handling of GPU only resources

### DIFF
--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -19,12 +19,13 @@
 package common
 
 import (
-	"github.com/apache/yunikorn-k8shim/pkg/log"
-	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
-	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	
+	"github.com/apache/yunikorn-k8shim/pkg/log"
+	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
+	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
 // resource builder is a helper struct to construct si resources

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -22,7 +22,7 @@ import (
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	
+
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -19,14 +19,12 @@
 package common
 
 import (
-	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
-
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // resource builder is a helper struct to construct si resources
@@ -67,21 +65,6 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 	// max(sum(Containers requirement), InitContainers requirement)
 	if pod.Spec.InitContainers != nil {
 		checkInitContainerRequest(pod, podResource)
-	}
-
-	// iterate the pod resources when resource is zero, remove it from the pod resource
-	for k, v := range podResource.Resources {
-		if v.Value == 0 {
-			delete(podResource.Resources, k)
-		}
-	}
-
-	// A QosBestEffort pod does not request any cpu/mem resources, just a single pod
-	// But with other resources requested, it is not the best effort pod
-	if qos.GetPodQOS(pod) == v1.PodQOSBestEffort && (len(podResource.Resources) == 1) {
-		return &si.Resource{
-			Resources: map[string]*si.Quantity{"pods": {Value: 1}},
-		}
 	}
 
 	// K8s pod EnableOverHead from:

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -325,8 +325,10 @@ func TestBestEffortPod(t *testing.T) {
 	resources[v1.ResourceCPU] = resource.MustParse("0")
 
 	res = GetPodResource(pod)
-	assert.Equal(t, len(res.Resources), 1)
+	assert.Equal(t, len(res.Resources), 3)
 	assert.Equal(t, res.Resources["pods"].GetValue(), int64(1))
+	assert.Equal(t, res.Resources[siCommon.CPU].GetValue(), int64(0))
+	assert.Equal(t, res.Resources[siCommon.Memory].GetValue(), int64(0))
 }
 
 func TestGPUOnlyResources(t *testing.T) {
@@ -363,8 +365,9 @@ func TestGPUOnlyResources(t *testing.T) {
 
 	c1Resources[v1.ResourceName("nvidia.com/gpu")] = resource.MustParse("0")
 	res = GetPodResource(pod)
-	assert.Equal(t, len(res.Resources), 1)
+	assert.Equal(t, len(res.Resources), 2)
 	assert.Equal(t, res.Resources["pods"].GetValue(), int64(1))
+	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(0))
 }
 
 func TestNodeResource(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
https://github.com/apache/yunikorn-k8shim/blob/a118ba6c4d84804e2a407f9d91196ece4690cf09/pkg/common/resource.go#L61-L63
 
this code seems to have a bug. When I define resource like this:

request:
  nvidia.com/gpu: 1
limit:
  nvidia.com/gpu: 1
 
this is considered as QoS best effort and returned with just

Resources:
  pod:1
but I think this is a valid configuration that a pod only specifies GPU resource without memory or CPU. It seems this is the K8s upstream code: qos.GetPodQOS() causes this..




### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
