### PR TITLE
[YUNIKORN-2301] lots of WARN messages when publishing events due to task not found

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -1039,8 +1039,8 @@ func (ctx *Context) PublishEvents(eventRecords []*si.EventRecord) {
 		for _, record := range eventRecords {
 			switch record.Type {
 			case si.EventRecord_REQUEST:
-				appID := record.ObjectID
-				taskID := record.ReferenceID
+				appID := record.ReferenceID
+				taskID := record.ObjectID
 				if task := ctx.getTask(appID, taskID); task != nil {
 					events.GetRecorder().Eventf(task.GetTaskPod().DeepCopy(), nil,
 						v1.EventTypeNormal, "", "", record.Message)

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -1282,8 +1282,8 @@ func TestPublishEventsCorrectly(t *testing.T) {
 	message := "event_related_message"
 	eventRecords = append(eventRecords, &si.EventRecord{
 		Type:        si.EventRecord_REQUEST,
-		ReferenceID: "task_event",
-		ObjectID:    "app_event",
+		ObjectID:    "task_event",
+		ReferenceID: "app_event",
 		Message:     message,
 	})
 	context.PublishEvents(eventRecords)


### PR DESCRIPTION
### What is this PR for?
lots of WARN messages when publishing events due to task not found
```
2023-11-30T16:11:07.057-0800    WARN    shim.context    
cache/context.go:1048   task event is not published because task is not found   
{"appID": "1be9d9ac-4d77-4944-86e9-9d8eba13eb6d", 
"taskID": "job2-qb", 
"event": "type:REQUEST  objectID:\"1be9d9ac-4d77-4944-86e9-9d8eba13eb6d\"  message:\"Application job2-qb does not fit into root.b queue (request resoure map[nvidia.com/gpu:1 pods:1 vcore:1000], headroom map[ephemeral-storage:1079956586496 hugepages-1Gi:0 hugepages-2Mi:0 hugepages-32Mi:0 hugepages-64Ki:0 memory:10000000000 nvidia.com/gpu:0 pods:320 vcore:2000])\"  timestampNano:1701389466504995000  referenceID:\"job2-qb\"  resource:{resources:{key:\"nvidia.com/gpu\"  value:{value:1}}  resources:{key:\"pods\"  value:{value:1}}  resources:{key:\"vcore\"  value:{value:1000}}}"}
```
![image](https://github.com/apache/yunikorn-k8shim/assets/155352474/6fd1b0b1-54d3-4257-bfc9-fb32cb96b4ce)

The correct mapping should be: 
```
appID := record.ReferenceID
taskID := record.ObjectID
```

Thanks for and credit to @yangwwei for finding this out! 

### What type of PR is it?
* [x] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2301

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
