### PR TITLE
[YUNIKORN-2312] Cleanup BinPacking e2e test workload before removing namespace

### DIFF
--- a/test/e2e/bin_packing/bin_packing_test.go
+++ b/test/e2e/bin_packing/bin_packing_test.go
@@ -199,7 +199,7 @@ var _ = Describe("", func() {
 			tests.LogYunikornContainer(testDescription.FailureMessage())
 		}
 		By("Tear down namespace: " + ns)
-		err := kClient.DeleteNamespace(ns)
+		err := kClient.TearDownNamespace(ns)
 		Ω(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
### What is this PR for?

In BinPacking e2e test, it creates two jobs without waiting for pod terminated. In AfterEach function, it calls `DeleteNamespace` without cleanup workloads. It's better to cleanup jobs before removing namespace.

https://github.com/apache/yunikorn-k8shim/blob/3e59ddcdd917c292635c6be0ddb8170356ae6511/test/e2e/bin_packing/bin_packing_test.go#L171-L204


### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2312
