### PR TITLE
[YUNIKORN-2313] Flaky E2E Test: "Verify_basic_preemption" experiences flakiness due to race condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ module github.com/apache/yunikorn-k8shim
 go 1.20
 
 require (
-	github.com/apache/yunikorn-core v0.0.0-20240105094327-77e19f6aca27
+	github.com/apache/yunikorn-core v0.0.0-20240119185010-bce75ba32684
 	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240102192148-d4b43d6910c9
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/apache/yunikorn-core v0.0.0-20240105094327-77e19f6aca27 h1:o38fyYaBl7YurkVf8Lm8IFpPSxAVjRGBh0tlAN5YohY=
-github.com/apache/yunikorn-core v0.0.0-20240105094327-77e19f6aca27/go.mod h1:lSAZNt47HGygsVG6mJTl0rW7acBl3tbN/Fg2wGJXYs8=
+github.com/apache/yunikorn-core v0.0.0-20240119185010-bce75ba32684 h1:wnIsh9G7Cage+CiZR6ZSBxvyn+voPh8DWXHjeRSKTs8=
+github.com/apache/yunikorn-core v0.0.0-20240119185010-bce75ba32684/go.mod h1:lSAZNt47HGygsVG6mJTl0rW7acBl3tbN/Fg2wGJXYs8=
 github.com/apache/yunikorn-scheduler-interface v0.0.0-20240102192148-d4b43d6910c9 h1:9Nj1XB52J7CjUysHwwu1Jf1HNC7fil5F/LkslwZEkN0=
 github.com/apache/yunikorn-scheduler-interface v0.0.0-20240102192148-d4b43d6910c9/go.mod h1:zDWV5y9Zh9DM1C65RCVXT1nhNNO8kykVW7bzPFamNYw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
### What is this PR for?
The root cause of this issue was found in [[YUNIKORN-2327] Race condition during update Occupied Resource from Shim to Core](https://issues.apache.org/jira/browse/YUNIKORN-2327)  and fixed in [[YUNIKORN-2329] Ensure RMProxy events are processed in-order](https://issues.apache.org/jira/browse/YUNIKORN-2329).

- Update core version to fix the e2e tests.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2313

### How should this be tested?
All the existing e2e test should pass.

### Screenshots (if appropriate)
NA

### Questions:
NA
