### PR TITLE
[YUNIKORN-2340] Upgrade actions versions in Github Action workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: .go_version
       - name: Check license
@@ -43,11 +43,11 @@ jobs:
         plugin: ['', '--plugin']
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: .go_version
       - name: Set hugepage
@@ -57,7 +57,7 @@ jobs:
           sudo sysctl -a | grep vm.nr_hugepages
       - name: Cache and Restore e2e required tools
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             tools

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: .go_version
       - name: Unit tests


### PR DESCRIPTION
### What is this PR for?
Bump below actions verions to surpress the "Node.js 16 actions are deprecated." warning message:

1. actions/checkout (v3 -> v4)
2. actions/cache (v3 -> v4)
3. actions/setup-go (v3 -> v5)   ([Only support node js 20 in v5](https://github.com/actions/setup-go/releases))

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
- Update other yunikorn repo's action version.

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2340

### How should this be tested?
Tested in Github action.  Create a pull request to master branch and check the Actions result.
ex: https://github.com/chenyulin0719/yunikorn-k8shim/actions/runs/7694299691

### Screenshots (if appropriate)
After:
<img width="1455" alt="image" src="https://github.com/apache/yunikorn-k8shim/assets/26764036/892574bb-a9a5-4fb6-b532-fb6b97823823">


Before:

<img width="1456" alt="image" src="https://github.com/apache/yunikorn-k8shim/assets/26764036/95b07edb-c478-4e3b-8d5b-29560f0547eb">


### Questions:
NA
