### PR TITLE
[YUNIKORN-2369] AM: Add token suffix when using unique applicationId feature

### DIFF
--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -545,6 +545,14 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			},
 			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
 		}, "testns-podUid", "", true},
+		{"Unique autogen token found with generateUnique", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "testns",
+				UID:       "podUid",
+				Labels:    map[string]string{constants.LabelApplicationID: "testns-uniqueautogen"},
+			},
+			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
+		}, "testns-podUid", "testns-podUid", true},
 		{"Non-yunikorn schedulerName", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{constants.LabelApplicationID: appIDInLabel},
@@ -643,6 +651,9 @@ func TestGenerateApplicationID(t *testing.T) {
 
 	assert.Equal(t, "longlonglonglonglonglonglo-pod-uid",
 		GenerateApplicationID(strings.Repeat("long", 100), true, "pod-uid"))
+
+	assert.Equal(t, "namespace-uniqueautogen",
+		GenerateApplicationID("namespace", true, ""))
 }
 
 func TestMergeMaps(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Workaround missing pod UID in admission controller lifecycle by setting a suffix of "-uniqueautogen" when the unique applicationId feature is in use. This suffix will be detected and replaced by the scheduler since the pod UID will exist at that point.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2369

### How should this be tested?
Added unit test cases for both generation and replacement.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
