### PR TITLE
[YUNIKORN-2377] Fix kubectl: executable file not found in PATH for e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ GO := go
 endif
 
 GO_EXE_PATH := $(shell "$(GO)" env GOROOT)/bin
-export PATH := $(GO_EXE_PATH):$(PATH)
 
 # Check if this GO tools version used is at least the version of go specified in
 # the go.mod file. The version in go.mod should be in sync with other repos.
@@ -58,6 +57,9 @@ TEST_SERVER_BINARY=web-test-server
 
 TOOLS_DIR=tools
 REPO=github.com/apache/yunikorn-k8shim/pkg
+
+# PATH
+export PATH := $(BASE_DIR)/$(TOOLS_DIR):$(GO_EXE_PATH):$(PATH)
 
 # Default values for dev cluster
 ifeq ($(K8S_VERSION),)


### PR DESCRIPTION
### What is this PR for?
* Add yunikorn-k8shim/tools into PATH for e2e_test 

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
[YUNIKORN-2377](https://issues.apache.org/jira/browse/YUNIKORN-2377)

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
