### PR TITLE
[YUNIKORN-2392] Ensure scheduling tasks are accessed under lock

### DIFF
--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -375,8 +375,10 @@ func (cache *SchedulerCache) removePriorityClass(priorityClass *schedulingv1.Pri
 // NotifyTaskSchedulerAction registers the fact that a task has been evaluated for scheduling, and consequently the
 // scheduler plugin should move it to the activeQ if requested to do so.
 func (cache *SchedulerCache) NotifyTaskSchedulerAction(taskID string) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
 	// verify that the pod exists in the cache, otherwise ignore
-	if _, ok := cache.GetPod(taskID); !ok {
+	if _, ok := cache.GetPodNoLock(taskID); !ok {
 		return
 	}
 	cache.addSchedulingTask(taskID)


### PR DESCRIPTION
### What is this PR for?
Fix race condition when accessing SchedulerCache.schedulingTasks.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2392

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
