### PR TITLE
[YUNIKORN-2420] Shim: create reproducible binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.crt
 *.key
 *.test
+/build.date


### PR DESCRIPTION

### What is this PR for?
Ensure that binaries produced in the shim use consistent build ID and build date so that builds are reproducible.

The git commit timestamp is used (if possible) for the build date, and cached in the `build.date` file so that it can be included in release tarballs. The go-generated build ID is set to an empty string.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2420

### How should this be tested?
Verified identical build output when generating linux/arm64 binaries from the following platforms:
- linux/amd64
- linux/arm64
- macos/amd64
- macos/arm64

For all 4 platforms (using HOST_ARCH=arm64 and go 1.21.7), the output is as follows:

```
$ sha512sum build/bin/*
4c53b142ebe0661a01ca7ac873f6e12e8552ad63360d218b369022192c1f0bc96638c9e8990560b970614579e41489eeba45042b1e681f753e7b036000450ce0  build/bin/yunikorn-admission-controller
477255b81456c6abd0fb2dd45012015c393b25264a7d71e089a61d77f4b59135924126859a81ba07a7f2da26f96c12cef273f4f584b75eb80973a8347b76234b  build/bin/yunikorn-scheduler
26a4dcd0f810e10b4f008ce578c108805e4fae0b9930748a692a97978b7603c51a5809f54f96e198b7c9c562e2fb262c6d172a685dcc71c633711be384379ef5  build/bin/yunikorn-scheduler-plugin
```

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
