### PR TITLE
[YUNIKORN-2438] Shim: Add license files to Docker images

### DIFF
--- a/docker/admission/Dockerfile
+++ b/docker/admission/Dockerfile
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM --platform=$TARGETPLATFORM scratch
-COPY --chown=0:0 LICENSE NOTICE yunikorn-admission-controller /
-COPY --chown=0:0 third-party-licenses /third-party-licenses/
+COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md yunikorn-admission-controller /
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-admission-controller" ]

--- a/docker/admission/Dockerfile
+++ b/docker/admission/Dockerfile
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM --platform=$TARGETPLATFORM scratch
-COPY --chown=0:0 yunikorn-admission-controller /
+COPY --chown=0:0 LICENSE NOTICE yunikorn-admission-controller /
+COPY --chown=0:0 third-party-licenses /third-party-licenses/
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-admission-controller" ]

--- a/docker/plugin/Dockerfile
+++ b/docker/plugin/Dockerfile
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM --platform=$TARGETPLATFORM scratch
-COPY --chown=0:0 yunikorn-scheduler-plugin scheduler-config.yaml /
+COPY --chown=0:0 LICENSE NOTICE yunikorn-scheduler-plugin scheduler-config.yaml /
+COPY --chown=0:0 third-party-licenses /third-party-licenses/
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-scheduler-plugin", "--bind-address=0.0.0.0", "--config=/scheduler-config.yaml" ]

--- a/docker/plugin/Dockerfile
+++ b/docker/plugin/Dockerfile
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM --platform=$TARGETPLATFORM scratch
-COPY --chown=0:0 LICENSE NOTICE yunikorn-scheduler-plugin scheduler-config.yaml /
-COPY --chown=0:0 third-party-licenses /third-party-licenses/
+COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md yunikorn-scheduler-plugin scheduler-config.yaml /
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-scheduler-plugin", "--bind-address=0.0.0.0", "--config=/scheduler-config.yaml" ]

--- a/docker/scheduler/Dockerfile
+++ b/docker/scheduler/Dockerfile
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM --platform=$TARGETPLATFORM scratch
-COPY --chown=0:0 LICENSE NOTICE yunikorn-scheduler /
-COPY --chown=0:0 third-party-licenses /third-party-licenses/
+COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md yunikorn-scheduler /
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-scheduler" ]

--- a/docker/scheduler/Dockerfile
+++ b/docker/scheduler/Dockerfile
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM --platform=$TARGETPLATFORM scratch
-COPY --chown=0:0 yunikorn-scheduler /
+COPY --chown=0:0 LICENSE NOTICE yunikorn-scheduler /
+COPY --chown=0:0 third-party-licenses /third-party-licenses/
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-scheduler" ]

--- a/docker/webtest/Dockerfile
+++ b/docker/webtest/Dockerfile
@@ -18,7 +18,8 @@
 # Imagestage: use scratch base image
 FROM --platform=$TARGETPLATFORM scratch
 COPY --chown=0:0 document/index.html /html/
-COPY --chown=0:0 web-test-server /
+COPY --chown=0:0 LICENSE NOTICE web-test-server /
+COPY --chown=0:0 third-party-licenses /third-party-licenses/
 EXPOSE 9889
 ENV DOCUMENT_ROOT /html
 USER 4444:4444

--- a/docker/webtest/Dockerfile
+++ b/docker/webtest/Dockerfile
@@ -18,8 +18,7 @@
 # Imagestage: use scratch base image
 FROM --platform=$TARGETPLATFORM scratch
 COPY --chown=0:0 document/index.html /html/
-COPY --chown=0:0 LICENSE NOTICE web-test-server /
-COPY --chown=0:0 third-party-licenses /third-party-licenses/
+COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md web-test-server /
 EXPOSE 9889
 ENV DOCUMENT_ROOT /html
 USER 4444:4444

--- a/scripts/third-party-licences.md.tpl
+++ b/scripts/third-party-licences.md.tpl
@@ -1,0 +1,11 @@
+{{ range . }}
+## {{ .Name }}
+
+* Name: {{ .Name }}
+* Version: {{ .Version }}
+* License: [{{ .LicenseName }}]({{ .LicenseURL }})
+
+```
+{{ .LicenseText }}
+```
+{{ end }}


### PR DESCRIPTION
### What is this PR for?
Add infrastructure to bundle NOTICE/LICENSE and third-party license files.

Two new Makefile targets are added:

- go-license-check: Check all dependencies for unauthorized licenses
- go-license-generate: Retrieve license files for 3rd party components and save to build/third-party-licenses/ directory

The generated license files depend on go.mod / go.sum and will be used as input to the Docker image generation.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2438

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
