### PR TITLE
[YUNIKORN-2465] Remove Task objects from the shim upon pod completion

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -428,7 +428,6 @@ func (ctx *Context) DeletePod(obj interface{}) {
 func (ctx *Context) deleteYuniKornPod(pod *v1.Pod) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
-
 	if taskMeta, ok := getTaskMetadata(pod); ok {
 		if app := ctx.getApplication(taskMeta.ApplicationID); app != nil {
 			ctx.notifyTaskComplete(taskMeta.ApplicationID, taskMeta.TaskID)
@@ -1150,7 +1149,7 @@ func (ctx *Context) RemoveTask(appID, taskID string) {
 		log.Log(log.ShimContext).Debug("Attempted to remove task from non-existent application", zap.String("appID", appID))
 		return
 	}
-	app.removeTask(taskID)
+	app.RemoveTask(taskID)
 }
 
 func (ctx *Context) getTask(appID string, taskID string) *Task {

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -304,6 +304,24 @@ func (fc *MockScheduler) GetActiveNodeCountInCore(partition string) int {
 	return len(coreNodes)
 }
 
+func (fc *MockScheduler) waitForApplicationStateInCore(appID, partition, expectedState string) error {
+	return utils.WaitForCondition(func() bool {
+		app := fc.coreContext.Scheduler.GetClusterContext().GetApplication(appID, partition)
+		if app == nil {
+			log.Log(log.Test).Info("Application not found in the scheduler core", zap.String("appID", appID))
+			return false
+		}
+		current := app.CurrentState()
+		if current != expectedState {
+			log.Log(log.Test).Info("waiting for app state in core",
+				zap.String("expected", expectedState),
+				zap.String("actual", current))
+			return false
+		}
+		return true
+	}, time.Second, 5*time.Second)
+}
+
 func (fc *MockScheduler) GetPodBindStats() client.BindStats {
 	return fc.apiProvider.GetPodBindStats()
 }

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -91,6 +91,19 @@ partitions:
 	cluster.waitAndAssertApplicationState(t, "app0001", cache.ApplicationStates().Running)
 	cluster.waitAndAssertTaskState(t, "app0001", "task0001", cache.TaskStates().Bound)
 	cluster.waitAndAssertTaskState(t, "app0001", "task0002", cache.TaskStates().Bound)
+
+	// complete pods
+	task1Upd := task1.DeepCopy()
+	task1Upd.Status.Phase = v1.PodSucceeded
+	cluster.UpdatePod(task1, task1Upd)
+	cluster.waitAndAssertTaskState(t, "app0001", "task0001", cache.TaskStates().Completed)
+	cluster.waitAndAssertApplicationState(t, "app0001", cache.ApplicationStates().Running)
+	task2Upd := task2.DeepCopy()
+	task2Upd.Status.Phase = v1.PodSucceeded
+	cluster.UpdatePod(task2, task2Upd)
+	cluster.waitAndAssertTaskState(t, "app0001", "task0002", cache.TaskStates().Completed)
+	err = cluster.waitForApplicationStateInCore("app0001", partitionName, "Completing")
+	assert.NilError(t, err)
 }
 
 func TestRejectApplications(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Remove completed Tasks from the Application to reduce memory pressure for long running applications.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2465

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
