### PR TITLE
[YUNIKORN-2525] dispatcher.Stop() waits an extra second unnecessarily

### DIFF
--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -56,6 +56,7 @@ type Dispatcher struct {
 	handlers  map[EventType]map[string]func(interface{})
 	running   atomic.Value
 	lock      sync.RWMutex
+	stopped   sync.WaitGroup
 }
 
 func initDispatcher() {
@@ -211,6 +212,7 @@ func Start() {
 		return
 	}
 	getDispatcher().stopChan = make(chan struct{})
+	getDispatcher().stopped.Add(1)
 	go func() {
 		for {
 			select {
@@ -229,6 +231,7 @@ func Start() {
 			case <-getDispatcher().stopChan:
 				log.Log(log.ShimDispatcher).Info("shutting down event channel")
 				getDispatcher().setRunning(false)
+				getDispatcher().stopped.Done()
 				return
 			}
 		}
@@ -257,13 +260,23 @@ func Stop() {
 	}
 
 	close(getDispatcher().stopChan)
-	maxTimeout := 5
-	for getDispatcher().isRunning() && maxTimeout > 0 {
-		log.Log(log.ShimDispatcher).Info("waiting for dispatcher to be stopped",
-			zap.Int("remainingSeconds", maxTimeout))
-		time.Sleep(1 * time.Second)
-		maxTimeout--
+	stopWait := make(chan struct{})
+	defer close(stopWait)
+
+	go func() {
+		getDispatcher().stopped.Wait()
+		stopWait <- struct{}{}
+	}()
+
+	// wait until the main event loop stops properly
+	select {
+	case <-stopWait:
+		break
+	case <-time.After(5 * time.Second):
+		log.Log(log.ShimDispatcher).Info("dispatcher did not stop in time")
+		break
 	}
+
 	if getDispatcher().isRunning() {
 		log.Log(log.ShimDispatcher).Warn("dispatcher even processing did not stop properly")
 	} else {

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -261,11 +261,10 @@ func Stop() {
 
 	close(getDispatcher().stopChan)
 	stopWait := make(chan struct{})
-	defer close(stopWait)
 
 	go func() {
+		defer close(stopWait)
 		getDispatcher().stopped.Wait()
-		stopWait <- struct{}{}
 	}()
 
 	// wait until the main event loop stops properly


### PR DESCRIPTION
### What is this PR for?
Speed up `dispatcher.Stop()` which also makes unit tests run faster.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2525

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
