### PR TITLE
[YUNIKORN-2557]Update the doc for e2e-tests

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -34,6 +34,8 @@ Below is the structure of the project.
 This project requires Go to be installed. On OS X with Homebrew you can just run `brew install go`.
 OR follow this doc for deploying go https://golang.org/doc/install
 
+Before we run the e2e tests, we need to set up the environment and install the relates tools using the command `make tools`. It will install the related tools including ginkgo, golangci-lint, helm, kind, kubectl, shellcheck and so on. At the same time it will link the path of the tools under the `./tools/` folder.
+
 ## Understanding the Command Line Arguments
 * `yk-namespace` - namespace under which YuniKorn is deployed. [Required]
 * `kube-config` - path to kube config file, needed for k8s client [Required]


### PR DESCRIPTION
YUNIKORN-2557

### What is this PR for?
When I want to run the e2e-tests for the first time, it is a time consuming process to install the tools one by one, then learn from the failure to figure out I need to link the path of each tool to the tools/ folder as pre-requisite step. And there is an easy way to run the command `make tools` to set up everything we need before we run the e2e-tests.

So it is great to update the doc for e2e-tests to set up the environment in an easy way.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2557

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
