### PR TITLE
[YUNIKORN-2558]Remove redundent conditional to install tools

### DIFF
--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -72,11 +72,7 @@ function check_docker() {
 }
 
 function install_tools() {
-  if [ -d "$TOOLS_DIRECTORY" ]; then
-    echo "tools directory exists. Skipping make tools."
-  else
-    make tools
-  fi
+  make tools
 }
 
 function install_cluster() {


### PR DESCRIPTION
### What is this PR for?
The script skips the make tools if the tools folder is existent. That is a bit weird that we don't check all tools in the folder. The script should call make tools anyway, and let make tools do the check and install. 
Action: remove the conditional of install_tools function in run-e2e-tests.sh file .

### What type of PR is it?
* [x] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2558

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
