### PR TITLE
[YUNIKORN-2577] Remove named returns from IsPodFitNodeViaPreemption

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -679,10 +679,10 @@ func (ctx *Context) IsPodFitNodeViaPreemption(name, node string, allocations []s
 			defer ctx.schedulerCache.UnlockForReads()
 
 			// look up each victim in the scheduler cache
-			victims := make([]*v1.Pod, 0)
-			for _, uid := range allocations {
+			victims := make([]*v1.Pod, len(allocations))
+			for index, uid := range allocations {
 				victim, _ := ctx.schedulerCache.GetPodNoLock(uid)
-				victims = append(victims, victim)
+				victims[index] = victim
 			}
 
 			// check predicates for a match


### PR DESCRIPTION
### What is this PR for?
IsPodFitNodeViaPreemption has defined named returns but does not use them. They should be removed as the way they are used can cause issues that are hard to debug.

As part of this change we need to further cleanup:  
- The variable ok also gets shadowed multiple times, not just from the named return declaration.
- The if construct around GetPodNoLock() is not needed as it returns a nil for the pod if it returns false. Just adding the result for the pod always has the same effect.

**I did following changes:**
1. remove named returns
2. to avoid shadowing, I try not to use `ok`, instead, those function can represent `ok` by its first return value, whether if it's `index` or `pod`, `-1` and `nil` means `false` respectively.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2577

### How should this be tested?
```
make test
```

### Screenshots (if appropriate)
N/A

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
