### PR TITLE
[YUNIKORN-2586] Set GOROOT to avoid tool failure when using newer go compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ ifeq ($(GO),)
 GO := go
 endif
 
-GO_EXE_PATH := $(shell "$(GO)" env GOROOT)/bin
+GOROOT := $(shell "$(GO)" env GOROOT)
+export GOROOT := $(GOROOT)
+GO_EXE_PATH := $(GOROOT)/bin
 
 # Check if this GO tools version used is at least the version of go specified in
 # the go.mod file. The version in go.mod should be in sync with other repos.


### PR DESCRIPTION
### What is this PR for?
Compiling with newer go compilers (tested on go 1.22.2) fails when generating 3rd party licenses. This was traced back to GOROOT not being set. Set it in the Makefile to avoid this issue.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2586

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
