### PR TITLE
[YUNIKORN-2578] Refactor SchedulerCache.GetPod() remove bool return

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -644,8 +644,8 @@ func (ctx *Context) EventsToRegister(queueingHintFn framework.QueueingHintFn) []
 func (ctx *Context) IsPodFitNode(name, node string, allocate bool) error {
 	ctx.lock.RLock()
 	defer ctx.lock.RUnlock()
-	var pod *v1.Pod
-	if pod = ctx.schedulerCache.GetPod(name); pod == nil {
+	pod := ctx.schedulerCache.GetPod(name)
+	if pod == nil {
 		return ErrorPodNotFound
 	}
 	// if pod exists in cache, try to run predicates

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -343,8 +343,8 @@ func (ctx *Context) ensureAppAndTaskCreated(pod *v1.Pod) {
 
 func (ctx *Context) updateForeignPod(pod *v1.Pod) {
 	podStatusBefore := ""
-	oldPod, ok := ctx.schedulerCache.GetPod(string(pod.UID))
-	if ok {
+	oldPod := ctx.schedulerCache.GetPod(string(pod.UID))
+	if oldPod != nil {
 		podStatusBefore = string(oldPod.Status.Phase)
 	}
 
@@ -439,8 +439,8 @@ func (ctx *Context) deleteForeignPod(pod *v1.Pod) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
-	oldPod, ok := ctx.schedulerCache.GetPod(string(pod.UID))
-	if !ok {
+	oldPod := ctx.schedulerCache.GetPod(string(pod.UID))
+	if oldPod == nil {
 		// if pod is not in scheduler cache, no node updates are needed
 		log.Log(log.ShimContext).Debug("unknown foreign pod deleted, no resource updated needed",
 			zap.String("namespace", pod.Namespace),
@@ -452,7 +452,7 @@ func (ctx *Context) deleteForeignPod(pod *v1.Pod) {
 	//   1. pod is already assigned to a node
 	//   2. pod was not in a terminal state before
 	//   3. pod references a known node
-	if oldPod != nil && !utils.IsPodTerminated(oldPod) {
+	if !utils.IsPodTerminated(oldPod) {
 		if !ctx.schedulerCache.IsPodOrphaned(string(oldPod.UID)) {
 			log.Log(log.ShimContext).Debug("foreign pod deleted, triggering occupied resource update",
 				zap.String("namespace", pod.Namespace),
@@ -645,8 +645,7 @@ func (ctx *Context) IsPodFitNode(name, node string, allocate bool) error {
 	ctx.lock.RLock()
 	defer ctx.lock.RUnlock()
 	var pod *v1.Pod
-	var ok bool
-	if pod, ok = ctx.schedulerCache.GetPod(name); !ok {
+	if pod = ctx.schedulerCache.GetPod(name); pod == nil {
 		return ErrorPodNotFound
 	}
 	// if pod exists in cache, try to run predicates
@@ -672,7 +671,7 @@ func (ctx *Context) IsPodFitNodeViaPreemption(name, node string, allocations []s
 
 	ctx.lock.RLock()
 	defer ctx.lock.RUnlock()
-	if pod, _ := ctx.schedulerCache.GetPod(name); pod != nil {
+	if pod := ctx.schedulerCache.GetPod(name); pod != nil {
 		// if pod exists in cache, try to run predicates
 		if targetNode := ctx.schedulerCache.GetNode(node); targetNode != nil {
 			// need to lock cache here as predicates need a stable view into the cache
@@ -682,7 +681,7 @@ func (ctx *Context) IsPodFitNodeViaPreemption(name, node string, allocations []s
 			// look up each victim in the scheduler cache
 			victims := make([]*v1.Pod, len(allocations))
 			for index, uid := range allocations {
-				victim, _ := ctx.schedulerCache.GetPodNoLock(uid)
+				victim := ctx.schedulerCache.GetPodNoLock(uid)
 				victims[index] = victim
 			}
 
@@ -704,7 +703,7 @@ func (ctx *Context) bindPodVolumes(pod *v1.Pod) error {
 	// during scheduling process as they have directly impact to other scheduling processes.
 	// when assumePodVolumes was called, we caches the value if all pod volumes are bound in schedulerCache,
 	// then here we just need to retrieve that value from cache, to skip bindings if volumes are already bound.
-	if assumedPod, exist := ctx.schedulerCache.GetPod(podKey); exist {
+	if assumedPod := ctx.schedulerCache.GetPod(podKey); assumedPod != nil {
 		if ctx.schedulerCache.ArePodVolumesAllBound(podKey) {
 			log.Log(log.ShimContext).Info("Binding Pod Volumes skipped: all volumes already bound",
 				zap.String("podName", pod.Name))
@@ -782,7 +781,7 @@ func (ctx *Context) bindPodVolumes(pod *v1.Pod) error {
 func (ctx *Context) AssumePod(name, node string) error {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
-	if pod, ok := ctx.schedulerCache.GetPod(name); ok {
+	if pod := ctx.schedulerCache.GetPod(name); pod != nil {
 		// when add assumed pod, we make a copy of the pod to avoid
 		// modifying its original reference. otherwise, it may have
 		// race when some other go-routines accessing it in parallel.
@@ -844,7 +843,7 @@ func (ctx *Context) ForgetPod(name string) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 
-	if pod, ok := ctx.schedulerCache.GetPod(name); ok {
+	if pod := ctx.schedulerCache.GetPod(name); pod != nil {
 		log.Log(log.ShimContext).Debug("forget pod", zap.String("pod", pod.Name))
 		ctx.schedulerCache.ForgetPod(pod)
 		return

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -378,7 +378,7 @@ func (cache *SchedulerCache) NotifyTaskSchedulerAction(taskID string) {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 	// verify that the pod exists in the cache, otherwise ignore
-	if _, ok := cache.GetPodNoLock(taskID); !ok {
+	if pod := cache.GetPodNoLock(taskID); pod == nil {
 		return
 	}
 	cache.addSchedulingTask(taskID)
@@ -635,7 +635,7 @@ func (filter *taskBloomFilter) isTaskMaybePresent(taskID string) bool {
 	return true
 }
 
-func (cache *SchedulerCache) GetPod(uid string) (*v1.Pod, bool) {
+func (cache *SchedulerCache) GetPod(uid string) *v1.Pod {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
 	return cache.GetPodNoLock(uid)
@@ -648,11 +648,11 @@ func (cache *SchedulerCache) IsPodOrphaned(uid string) bool {
 	return ok
 }
 
-func (cache *SchedulerCache) GetPodNoLock(uid string) (*v1.Pod, bool) {
+func (cache *SchedulerCache) GetPodNoLock(uid string) *v1.Pod {
 	if pod, ok := cache.podsMap[uid]; ok {
-		return pod, true
+		return pod
 	}
-	return nil, false
+	return nil
 }
 
 func (cache *SchedulerCache) AssumePod(pod *v1.Pod, allBound bool) {

--- a/pkg/cache/external/scheduler_cache_test.go
+++ b/pkg/cache/external/scheduler_cache_test.go
@@ -112,8 +112,8 @@ func TestAssignedPod(t *testing.T) {
 
 			// verify the pod is added to cache
 			// the pod should be added to the node as well
-			cachedPod, exist := cache.GetPod(podUID1)
-			assert.Equal(t, exist, true)
+			cachedPod := cache.GetPod(podUID1)
+			assert.Check(t, cachedPod != nil)
 			assert.Equal(t, cachedPod.Name, pod.Name)
 			assert.Equal(t, cachedPod.UID, pod.UID)
 		})
@@ -188,8 +188,8 @@ func TestAddUnassignedPod(t *testing.T) {
 
 			// verify the pod is added to cache
 			// the pod should be added to the node as well
-			cachedPod, exist := cache.GetPod(podUID1)
-			assert.Equal(t, exist, true)
+			cachedPod := cache.GetPod(podUID1)
+			assert.Check(t, cachedPod != nil)
 			assert.Equal(t, cachedPod.Name, pod.Name)
 			assert.Equal(t, cachedPod.UID, pod.UID)
 		})
@@ -759,8 +759,8 @@ func TestUpdatePod(t *testing.T) {
 	pod1.ObjectMeta.UID = podUID1
 	cache.UpdatePod(pod1)
 	assert.Equal(t, len(cache.podsMap), 1, "wrong pod count after add of pod1")
-	_, ok := cache.GetPod(podUID1)
-	assert.Check(t, ok, "pod1 not found")
+	pod := cache.GetPod(podUID1)
+	assert.Check(t, pod != nil, "pod1 not found")
 
 	// update of non-existent pod should be equivalent to an add
 	pod2 := podTemplate.DeepCopy()
@@ -768,15 +768,15 @@ func TestUpdatePod(t *testing.T) {
 	pod2.ObjectMeta.UID = podUID2
 	cache.UpdatePod(pod2)
 	assert.Equal(t, len(cache.podsMap), 2, "wrong pod count after add of pod2")
-	_, ok = cache.GetPod(podUID2)
-	assert.Check(t, ok, "pod2 not found")
+	pod = cache.GetPod(podUID2)
+	assert.Check(t, pod != nil, "pod2 not found")
 
 	// normal pod update should succeed
 	pod1Copy := pod1.DeepCopy()
 	pod1Copy.ObjectMeta.Annotations["state"] = "updated"
 	cache.UpdatePod(pod1Copy)
-	found, ok := cache.GetPod(podUID1)
-	assert.Check(t, ok, "pod1 not found")
+	found := cache.GetPod(podUID1)
+	assert.Check(t, found != nil, "pod1 not found")
 	assert.Equal(t, found.GetAnnotations()["state"], "updated", "wrong state after update")
 	cache.RemovePod(pod1Copy)
 
@@ -799,8 +799,8 @@ func TestUpdatePod(t *testing.T) {
 	pod3Copy := pod3.DeepCopy()
 	pod3Copy.Spec.NodeName = "new-node"
 	cache.UpdatePod(pod3Copy)
-	pod3Result, ok := cache.GetPod("Pod-UID-00003")
-	assert.Check(t, ok, "unable to get pod3")
+	pod3Result := cache.GetPod("Pod-UID-00003")
+	assert.Check(t, pod3Result != nil, "unable to get pod3")
 	assert.Equal(t, pod3Result.Spec.NodeName, "new-node", "node name not updated")
 }
 
@@ -823,26 +823,26 @@ func TestRemovePod(t *testing.T) {
 	// add pod1
 	cache.UpdatePod(pod1)
 	assert.Equal(t, len(cache.podsMap), 1, "wrong pod count after add of pod1")
-	_, ok := cache.GetPod(podUID1)
-	assert.Check(t, ok, "pod1 not found")
+	pod := cache.GetPod(podUID1)
+	assert.Check(t, pod != nil, "pod1 not found")
 
 	// remove pod1
 	cache.RemovePod(pod1)
-	_, ok = cache.GetPod(podUID1)
-	assert.Check(t, !ok, "pod1 still found")
+	pod = cache.GetPod(podUID1)
+	assert.Check(t, pod == nil, "pod1 still found")
 	assert.Equal(t, len(cache.podsMap), 0, "wrong pod count after remove of pod1")
 
 	// again, with assigned node
 	pod1.Spec.NodeName = "test-node-remove"
 	cache.UpdatePod(pod1)
 	assert.Equal(t, len(cache.podsMap), 1, "wrong pod count after add of pod1 with node")
-	_, ok = cache.GetPod(podUID1)
-	assert.Check(t, ok, "pod1 not found")
+	pod = cache.GetPod(podUID1)
+	assert.Check(t, pod != nil, "pod1 not found")
 
 	// remove pod1
 	cache.RemovePod(pod1)
-	_, ok = cache.GetPod(podUID1)
-	assert.Check(t, !ok, "pod1 still found")
+	pod = cache.GetPod(podUID1)
+	assert.Check(t, pod == nil, "pod1 still found")
 	assert.Equal(t, len(cache.podsMap), 0, "wrong pod count after remove of pod1 with node")
 
 	// removal of pod added to synthetic node should succeed


### PR DESCRIPTION
### What is this PR for?
SchedulerCache GetPod() and GetPodNoLock() retrun two values:

1. *v1.Pod
2. bool  
The boolean value is redundant as it is false if the pod is not found and a nil is returned for the pod. The boolean is true if the pod has a value. Testing for a nil pod has the same result.

We do not cache a nil pod in the cache for a pod UID


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [x] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2578

### How should this be tested?
make test 
github ci

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
