### PR TITLE
[YUNIKORN-2616] Remove unused bool return from PreemptionPredicates()

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -681,7 +681,7 @@ func (ctx *Context) IsPodFitNodeViaPreemption(name, node string, allocations []s
 			}
 
 			// check predicates for a match
-			if index, _ := ctx.predManager.PreemptionPredicates(pod, targetNode, victims, startIndex); index != -1 {
+			if index := ctx.predManager.PreemptionPredicates(pod, targetNode, victims, startIndex); index != -1 {
 				return index, true
 			}
 		}

--- a/pkg/cache/scheduler_callback_test.go
+++ b/pkg/cache/scheduler_callback_test.go
@@ -573,8 +573,8 @@ func (m *mockPredicateManager) Predicates(_ *v1.Pod, _ *framework.NodeInfo, _ bo
 	return "", nil
 }
 
-func (m *mockPredicateManager) PreemptionPredicates(_ *v1.Pod, _ *framework.NodeInfo, _ []*v1.Pod, _ int) (index int, ok bool) {
-	return 0, true
+func (m *mockPredicateManager) PreemptionPredicates(_ *v1.Pod, _ *framework.NodeInfo, _ []*v1.Pod, _ int) (index int) {
+	return 0
 }
 
 func initCallbackTest(t *testing.T, podAssigned, placeholder bool) (*AsyncRMCallback, *Context) {

--- a/pkg/plugin/predicates/predicate_manager_test.go
+++ b/pkg/plugin/predicates/predicate_manager_test.go
@@ -70,8 +70,7 @@ func TestPreemptionPredicatesEmpty(t *testing.T) {
 	node.SetNode(&v1.Node{})
 	victims := make([]*v1.Pod, 0)
 	index := predicateManager.PreemptionPredicates(pod, node, victims, 0)
-	assert.Check(t, index == -1, "check should have failed")
-	assert.Equal(t, index, -1, "wrong index")
+	assert.Equal(t, index, -1, "should not find any victim index after preemption check")
 }
 
 func TestPreemptionPredicates(t *testing.T) {
@@ -116,8 +115,7 @@ func TestPreemptionPredicates(t *testing.T) {
 
 	// all but 1 existing pod should need removing
 	index := predicateManager.PreemptionPredicates(pod, node, victims, 1)
-	assert.Check(t, index != -1, "check failed")
-	assert.Equal(t, index, 2, "wrong index")
+	assert.Equal(t, index, 2, "wrong victim index")
 
 	// try again, but with too many resources requested
 	pod = newResourcePod(framework.Resource{MilliCPU: 1500, Memory: 15000000})
@@ -125,8 +123,7 @@ func TestPreemptionPredicates(t *testing.T) {
 	pod.UID = "largepod"
 
 	index = predicateManager.PreemptionPredicates(pod, node, victims, 1)
-	assert.Check(t, index == -1, "check should have failed")
-	assert.Equal(t, index, -1, "wrong index")
+	assert.Equal(t, index, -1, "should not find any victim index after preemption check")
 }
 
 func TestEventsToRegister(t *testing.T) {

--- a/pkg/plugin/predicates/predicate_manager_test.go
+++ b/pkg/plugin/predicates/predicate_manager_test.go
@@ -69,8 +69,8 @@ func TestPreemptionPredicatesEmpty(t *testing.T) {
 	node := framework.NewNodeInfo()
 	node.SetNode(&v1.Node{})
 	victims := make([]*v1.Pod, 0)
-	index, ok := predicateManager.PreemptionPredicates(pod, node, victims, 0)
-	assert.Check(t, !ok, "check should have failed")
+	index := predicateManager.PreemptionPredicates(pod, node, victims, 0)
+	assert.Check(t, index == -1, "check should have failed")
 	assert.Equal(t, index, -1, "wrong index")
 }
 
@@ -115,8 +115,8 @@ func TestPreemptionPredicates(t *testing.T) {
 	node.AddPod(victims[3])
 
 	// all but 1 existing pod should need removing
-	index, ok := predicateManager.PreemptionPredicates(pod, node, victims, 1)
-	assert.Check(t, ok, "check failed")
+	index := predicateManager.PreemptionPredicates(pod, node, victims, 1)
+	assert.Check(t, index != -1, "check failed")
 	assert.Equal(t, index, 2, "wrong index")
 
 	// try again, but with too many resources requested
@@ -124,8 +124,8 @@ func TestPreemptionPredicates(t *testing.T) {
 	pod.Name = "largepod"
 	pod.UID = "largepod"
 
-	index, ok = predicateManager.PreemptionPredicates(pod, node, victims, 1)
-	assert.Check(t, !ok, "check should have failed")
+	index = predicateManager.PreemptionPredicates(pod, node, victims, 1)
+	assert.Check(t, index == -1, "check should have failed")
 	assert.Equal(t, index, -1, "wrong index")
 }
 


### PR DESCRIPTION
### What is this PR for?
The predicate manager method PreemptionPredicates() returns two values an int and boolean. The boolean is false if the integer is -1 and true for 0 or llarger. There is no need for the boolean as the -1 already indicates the same

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [x] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2616

### How should this be tested?
Github CI

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
