### PR TITLE
[YUNIKORN-2630] Release context lock early for config changes

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -603,7 +603,7 @@ func (ctx *Context) deletePriorityClass(obj interface{}) {
 func (ctx *Context) triggerReloadConfig(index int, configMap *v1.ConfigMap) {
 	// hot reload is turned off do nothing
 	// hot reload can be turned off by an update: safety first access under lock to prevent data race
-	if !ctx.apiProvider.GetAPIs().GetConf().IsConfigReloadable() {
+	if !schedulerconf.GetSchedulerConf().IsConfigReloadable() {
 		log.Log(log.ShimContext).Info("hot-refresh disabled, skipping scheduler configuration update")
 		return
 	}
@@ -612,14 +612,13 @@ func (ctx *Context) triggerReloadConfig(index int, configMap *v1.ConfigMap) {
 	if confMap == nil {
 		return
 	}
-	conf := ctx.apiProvider.GetAPIs().GetConf()
 	log.Log(log.ShimContext).Info("reloading scheduler configuration")
 	config := utils.GetCoreSchedulerConfigFromConfigMap(confMap)
 	extraConfig := utils.GetExtraConfigFromConfigMap(confMap)
 
 	request := &si.UpdateConfigurationRequest{
-		RmID:        conf.ClusterID,
-		PolicyGroup: conf.PolicyGroup,
+		RmID:        schedulerconf.GetSchedulerConf().ClusterID,
+		PolicyGroup: schedulerconf.GetSchedulerConf().PolicyGroup,
 		Config:      config,
 		ExtraConfig: extraConfig,
 	}

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -269,6 +269,12 @@ func (conf *SchedulerConf) IsTestMode() bool {
 	return conf.TestMode
 }
 
+func (conf *SchedulerConf) IsConfigReloadable() bool {
+	conf.RLock()
+	defer conf.RUnlock()
+	return conf.EnableConfigHotRefresh
+}
+
 func (conf *SchedulerConf) GetSchedulingInterval() time.Duration {
 	conf.RLock()
 	defer conf.RUnlock()


### PR DESCRIPTION
### What is this PR for?
Release the lock of the context in the shim when processing is done. When the config changes are sent to the core the k8shim should not be locked. The context changes have been finalised at that point.

The core handles its own locking and serialises config changes that come in from the k8shim.

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-2630

### How should this be tested?
Current unit and e2e tests cover the changed paths 