### PR TITLE
[YUNIKORN-2637] finalizePods should ignore pods like registerPods

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -1690,7 +1690,7 @@ func (ctx *Context) finalizeNodes(existingNodes []*v1.Node) error {
 }
 
 func (ctx *Context) registerPods() ([]*v1.Pod, error) {
-	log.Log(log.ShimContext).Info("Starting node registration...")
+	log.Log(log.ShimContext).Info("Starting pod registration...")
 
 	// list all pods via the informer
 	pods, err := ctx.apiProvider.GetAPIs().PodInformer.Lister().List(labels.Everything())
@@ -1705,14 +1705,16 @@ func (ctx *Context) registerPods() ([]*v1.Pod, error) {
 	})
 
 	// add all pods to the context
-	for _, pod := range pods {
-		// skip terminated pods
+	for i, pod := range pods {
+		// skip terminated pods: we do not add or finalise them later
 		if utils.IsPodTerminated(pod) {
+			pods[i] = nil
 			continue
 		}
 		ctx.AddPod(pod)
 	}
 
+	log.Log(log.ShimContext).Info("Finished pod registration...")
 	return pods, nil
 }
 
@@ -1727,13 +1729,21 @@ func (ctx *Context) finalizePods(existingPods []*v1.Pod) error {
 	// convert the pod list into a map
 	podMap := make(map[types.UID]*v1.Pod)
 	for _, pod := range pods {
+		// if the pod is terminated finalising should remove it if it was running in register
+		if utils.IsPodTerminated(pod) {
+			continue
+		}
 		podMap[pod.UID] = pod
 	}
 
-	// find any existing nodes that no longer exist
+	// find any existing pods that no longer exist
 	for _, pod := range existingPods {
+		// skip if the pod was already terminated during register
+		if pod == nil {
+			continue
+		}
 		if _, ok := podMap[pod.UID]; !ok {
-			// node no longer exists, delete it
+			// pod no longer exists, delete it
 			log.Log(log.ShimContext).Info("Removing pod which went away during initialization",
 				zap.String("namespace", pod.Namespace),
 				zap.String("name", pod.Name),

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -2328,3 +2328,67 @@ func foreignPod(podName, memory, cpu string) *v1.Pod {
 		},
 	}
 }
+
+func TestRegisterPods(t *testing.T) {
+	context := initContextForTest()
+
+	pods, err := context.registerPods()
+	assert.NilError(t, err, "register pods with empty setup should not fail")
+	assert.Equal(t, len(pods), 0, "should have returned an empty pod list")
+
+	var api *client.MockedAPIProvider
+	switch context.apiProvider.(type) {
+	case *client.MockedAPIProvider:
+		api = context.apiProvider.(*client.MockedAPIProvider)
+	default:
+		t.Fatalf("api type not recognized")
+	}
+	pod1 := newPodHelper("yunikorn-test-00001", namespace, "UID-00001", "node-1", "yunikorn-test-00001", v1.PodRunning)
+	pod2 := newPodHelper("yunikorn-test-00002", namespace, "UID-00002", "node-1", "yunikorn-test-00002", v1.PodRunning)
+	pod3 := newPodHelper("yunikorn-test-00003", namespace, "UID-00003", "node-1", "yunikorn-test-00003", v1.PodSucceeded)
+	pod4 := newPodHelper("yunikorn-test-00004", namespace, "UID-00004", "node-1", "yunikorn-test-00004", v1.PodRunning)
+
+	api.GetPodListerMock().AddPod(pod1)
+	api.GetPodListerMock().AddPod(pod2)
+	api.GetPodListerMock().AddPod(pod3)
+	api.GetPodListerMock().AddPod(pod4)
+
+	pods, err = context.registerPods()
+	assert.NilError(t, err, "register pods should not have failed")
+	assert.Assert(t, assertListerPods(pods, 3), "should have returned 3 running pods in the list")
+
+	assert.Assert(t, context.schedulerCache.GetPod(string(pod1.UID)) != nil, "expected to find pod 1 in cache")
+	assert.Assert(t, context.schedulerCache.GetPod(string(pod2.UID)) != nil, "expected to find pod 2 in cache")
+	assert.Assert(t, context.schedulerCache.GetPod(string(pod3.UID)) == nil, "not expected to find pod 3 in cache")
+	assert.Assert(t, context.schedulerCache.GetPod(string(pod4.UID)) != nil, "expected to find pod 4 in cache")
+
+	// prep for finalising the pods
+	// new pod added (should be ignored)
+	pod5 := newPodHelper("yunikorn-test-00005", namespace, "UID-00005", "node-1", "yunikorn-test-00005", v1.PodRunning)
+	api.GetPodListerMock().AddPod(pod5)
+	// update pod 1 is now marked as terminated (will be removed)
+	pod1.Status = v1.PodStatus{
+		Phase: v1.PodSucceeded,
+	}
+	api.GetPodListerMock().AddPod(pod1)
+	// remove pod 4 as if it was removed from K8s (will be removed)
+	api.GetPodListerMock().DeletePod(pod4)
+
+	err = context.finalizePods(pods)
+	assert.NilError(t, err, "finalize pods should not have failed")
+	assert.Assert(t, context.schedulerCache.GetPod(string(pod1.UID)) == nil, "not expected to find pod 1 in cache")
+	assert.Assert(t, context.schedulerCache.GetPod(string(pod2.UID)) != nil, "expected to find pod 2 in cache")
+	assert.Assert(t, context.schedulerCache.GetPod(string(pod3.UID)) == nil, "not expected to find pod 3 in cache")
+	assert.Assert(t, context.schedulerCache.GetPod(string(pod4.UID)) == nil, "not expected to find pod 4 in cache")
+	assert.Assert(t, context.schedulerCache.GetPod(string(pod5.UID)) == nil, "not expected to find pod 5 in cache")
+}
+
+func assertListerPods(pods []*v1.Pod, count int) bool {
+	counted := 0
+	for _, pod := range pods {
+		if pod != nil {
+			counted++
+		}
+	}
+	return count == counted
+}


### PR DESCRIPTION
### What is this PR for?
If a pod was in a terminal state during registration it is skipped. The same principal should apply to finalisePods:
* only check pods that were added in registerPods.
* remove finished pods in the finalizePods call if they were registered.
* new pods are not added in finalizePods

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-2637

### How should this be tested?
Unit tests now cover the code path
e2e tests coverage is not possible as we cannot time the pod removal well enough