### PR TITLE
[YUNIKORN-2651]Update the unchecked error for make lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,8 @@ linters-settings:
     local-prefixes: github.com/apache/yunikorn
   govet:
     check-shadowing: true
+  goconst:
+    min-occurrences: 5
   funlen:
     lines: 120
     statements: 80

--- a/pkg/admission/conf/am_conf.go
+++ b/pkg/admission/conf/am_conf.go
@@ -118,7 +118,10 @@ func NewAdmissionControllerConf(configMaps []*v1.ConfigMap) *AdmissionController
 }
 
 func (acc *AdmissionControllerConf) RegisterHandlers(configMaps informersv1.ConfigMapInformer) {
-	configMaps.Informer().AddEventHandler(&configMapUpdateHandler{conf: acc})
+	_, err := configMaps.Informer().AddEventHandler(&configMapUpdateHandler{conf: acc})
+	if err != nil {
+		log.Log(log.AdmissionConf).Error("Error adding event handler", zap.Error(err))
+	}
 }
 
 func (acc *AdmissionControllerConf) GetNamespace() string {

--- a/pkg/admission/conf/am_conf.go
+++ b/pkg/admission/conf/am_conf.go
@@ -20,6 +20,7 @@ package conf
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -120,7 +121,8 @@ func NewAdmissionControllerConf(configMaps []*v1.ConfigMap) *AdmissionController
 func (acc *AdmissionControllerConf) RegisterHandlers(configMaps informersv1.ConfigMapInformer) {
 	_, err := configMaps.Informer().AddEventHandler(&configMapUpdateHandler{conf: acc})
 	if err != nil {
-		log.Log(log.AdmissionConf).Error("Error adding event handler", zap.Error(err))
+		log.Log(log.AdmissionConf).Fatal("Failed to create Register handler", zap.Error(err))
+		os.Exit(1)
 	}
 }
 

--- a/pkg/admission/conf/am_conf.go
+++ b/pkg/admission/conf/am_conf.go
@@ -20,7 +20,6 @@ package conf
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -118,12 +117,13 @@ func NewAdmissionControllerConf(configMaps []*v1.ConfigMap) *AdmissionController
 	return acc
 }
 
-func (acc *AdmissionControllerConf) RegisterHandlers(configMaps informersv1.ConfigMapInformer) {
+func (acc *AdmissionControllerConf) RegisterHandlers(configMaps informersv1.ConfigMapInformer) error {
 	_, err := configMaps.Informer().AddEventHandler(&configMapUpdateHandler{conf: acc})
 	if err != nil {
-		log.Log(log.AdmissionConf).Fatal("Failed to create Register handler", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to create register handlers: %w", err)
 	}
+
+	return nil
 }
 
 func (acc *AdmissionControllerConf) GetNamespace() string {

--- a/pkg/admission/namespace_cache.go
+++ b/pkg/admission/namespace_cache.go
@@ -19,6 +19,8 @@
 package admission
 
 import (
+	"os"
+
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	informersv1 "k8s.io/client-go/informers/core/v1"
@@ -61,7 +63,8 @@ func NewNamespaceCache(namespaces informersv1.NamespaceInformer) *NamespaceCache
 	if namespaces != nil {
 		_, err := namespaces.Informer().AddEventHandler(&namespaceUpdateHandler{cache: nsc})
 		if err != nil {
-			log.Log(log.AdmissionConf).Error("Error adding namespace event handler", zap.Error(err))
+			log.Log(log.AdmissionConf).Fatal("Failed to create namespace cache", zap.Error(err))
+			os.Exit(1)
 		}
 	}
 	return nsc

--- a/pkg/admission/namespace_cache.go
+++ b/pkg/admission/namespace_cache.go
@@ -19,6 +19,7 @@
 package admission
 
 import (
+	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -58,7 +59,10 @@ func NewNamespaceCache(namespaces informersv1.NamespaceInformer) *NamespaceCache
 		nameSpaces: make(map[string]nsFlags),
 	}
 	if namespaces != nil {
-		namespaces.Informer().AddEventHandler(&namespaceUpdateHandler{cache: nsc})
+		_, err := namespaces.Informer().AddEventHandler(&namespaceUpdateHandler{cache: nsc})
+		if err != nil {
+			log.Log(log.AdmissionConf).Error("Error adding namespace event handler", zap.Error(err))
+		}
 	}
 	return nsc
 }

--- a/pkg/admission/namespace_cache.go
+++ b/pkg/admission/namespace_cache.go
@@ -19,9 +19,8 @@
 package admission
 
 import (
-	"os"
+	"fmt"
 
-	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -56,18 +55,17 @@ type nsFlags struct {
 }
 
 // NewNamespaceCache creates a new cache and registers the handler for the cache with the Informer.
-func NewNamespaceCache(namespaces informersv1.NamespaceInformer) *NamespaceCache {
+func NewNamespaceCache(namespaces informersv1.NamespaceInformer) (*NamespaceCache, error) {
 	nsc := &NamespaceCache{
 		nameSpaces: make(map[string]nsFlags),
 	}
 	if namespaces != nil {
 		_, err := namespaces.Informer().AddEventHandler(&namespaceUpdateHandler{cache: nsc})
 		if err != nil {
-			log.Log(log.AdmissionConf).Fatal("Failed to create namespace cache", zap.Error(err))
-			os.Exit(1)
+			return nil, fmt.Errorf("failed to create namespace cache: %w", err)
 		}
 	}
-	return nsc
+	return nsc, nil
 }
 
 // enableYuniKorn returns the value for the enableYuniKorn flag (tri-state UNSET, TRUE or FALSE) for the namespace.

--- a/pkg/admission/namespace_cache_test.go
+++ b/pkg/admission/namespace_cache_test.go
@@ -35,7 +35,8 @@ import (
 const testNS = "test-ns"
 
 func TestFlags(t *testing.T) {
-	cache := NewNamespaceCache(nil)
+	cache, nsErr := NewNamespaceCache(nil)
+	assert.NilError(t, nsErr)
 	cache.nameSpaces["notset"] = nsFlags{
 		enableYuniKorn: UNSET,
 		generateAppID:  UNSET,
@@ -69,7 +70,8 @@ func TestNamespaceHandlers(t *testing.T) {
 	kubeClient := client.NewKubeClientMock(false)
 
 	informers := NewInformers(kubeClient, "default")
-	cache := NewNamespaceCache(informers.Namespace)
+	cache, nsErr := NewNamespaceCache(informers.Namespace)
+	assert.NilError(t, nsErr)
 	informers.Start()
 	defer informers.Stop()
 

--- a/pkg/admission/priority_class_cache.go
+++ b/pkg/admission/priority_class_cache.go
@@ -19,6 +19,8 @@
 package admission
 
 import (
+	"fmt"
+
 	"go.uber.org/zap"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	informersv1 "k8s.io/client-go/informers/scheduling/v1"
@@ -37,7 +39,7 @@ type PriorityClassCache struct {
 }
 
 // NewPriorityClassCache creates a new cache and registers the handler for the cache with the Informer.
-func NewPriorityClassCache(priorityClasses informersv1.PriorityClassInformer) *PriorityClassCache {
+func NewPriorityClassCache(priorityClasses informersv1.PriorityClassInformer) (*PriorityClassCache, error) {
 	pcc := &PriorityClassCache{
 		priorityClasses: make(map[string]bool),
 	}
@@ -45,9 +47,10 @@ func NewPriorityClassCache(priorityClasses informersv1.PriorityClassInformer) *P
 		_, err := priorityClasses.Informer().AddEventHandler(&priorityClassUpdateHandler{cache: pcc})
 		if err != nil {
 			log.Log(log.AdmissionConf).Error("Error adding event handler", zap.Error(err))
+			return nil, fmt.Errorf("failed to create a new cache and register the handler: %w", err)
 		}
 	}
-	return pcc
+	return pcc, nil
 }
 
 // isPreemptSelfAllowed returns the preemption value. Only returns false if configured.

--- a/pkg/admission/priority_class_cache.go
+++ b/pkg/admission/priority_class_cache.go
@@ -19,6 +19,7 @@
 package admission
 
 import (
+	"go.uber.org/zap"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	informersv1 "k8s.io/client-go/informers/scheduling/v1"
 	"k8s.io/client-go/tools/cache"
@@ -41,7 +42,10 @@ func NewPriorityClassCache(priorityClasses informersv1.PriorityClassInformer) *P
 		priorityClasses: make(map[string]bool),
 	}
 	if priorityClasses != nil {
-		priorityClasses.Informer().AddEventHandler(&priorityClassUpdateHandler{cache: pcc})
+		_, err := priorityClasses.Informer().AddEventHandler(&priorityClassUpdateHandler{cache: pcc})
+		if err != nil {
+			log.Log(log.AdmissionConf).Error("Error adding event handler", zap.Error(err))
+		}
 	}
 	return pcc
 }

--- a/pkg/admission/priority_class_cache.go
+++ b/pkg/admission/priority_class_cache.go
@@ -21,7 +21,6 @@ package admission
 import (
 	"fmt"
 
-	"go.uber.org/zap"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	informersv1 "k8s.io/client-go/informers/scheduling/v1"
 	"k8s.io/client-go/tools/cache"
@@ -46,7 +45,6 @@ func NewPriorityClassCache(priorityClasses informersv1.PriorityClassInformer) (*
 	if priorityClasses != nil {
 		_, err := priorityClasses.Informer().AddEventHandler(&priorityClassUpdateHandler{cache: pcc})
 		if err != nil {
-			log.Log(log.AdmissionConf).Error("Error adding event handler", zap.Error(err))
 			return nil, fmt.Errorf("failed to create a new cache and register the handler: %w", err)
 		}
 	}

--- a/pkg/admission/priority_class_cache_test.go
+++ b/pkg/admission/priority_class_cache_test.go
@@ -35,7 +35,8 @@ import (
 const testPC = "test-pc"
 
 func TestIsPreemptSelfAllowed(t *testing.T) {
-	cache := NewPriorityClassCache(nil)
+	cache, pcErr := NewPriorityClassCache(nil)
+	assert.NilError(t, pcErr)
 	cache.priorityClasses["yes"] = true
 	cache.priorityClasses["no"] = false
 
@@ -49,7 +50,8 @@ func TestPriorityClassHandlers(t *testing.T) {
 	kubeClient := client.NewKubeClientMock(false)
 
 	informers := NewInformers(kubeClient, "default")
-	cache := NewPriorityClassCache(informers.PriorityClass)
+	cache, pcErr := NewPriorityClassCache(informers.PriorityClass)
+	assert.NilError(t, pcErr)
 	informers.Start()
 	defer informers.Stop()
 

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -171,28 +171,33 @@ func (s *APIFactory) AddEventHandler(handlers *ResourceEventHandlers) {
 
 func (s *APIFactory) addEventHandlers(
 	handlerType Type, handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	var err error
 	switch handlerType {
 	case PodInformerHandlers:
-		s.GetAPIs().PodInformer.Informer().
+		_, err = s.GetAPIs().PodInformer.Informer().
 			AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
 	case NodeInformerHandlers:
-		s.GetAPIs().NodeInformer.Informer().
+		_, err = s.GetAPIs().NodeInformer.Informer().
 			AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
 	case ConfigMapInformerHandlers:
-		s.GetAPIs().ConfigMapInformer.Informer().
+		_, err = s.GetAPIs().ConfigMapInformer.Informer().
 			AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
 	case StorageInformerHandlers:
-		s.GetAPIs().StorageInformer.Informer().
+		_, err = s.GetAPIs().StorageInformer.Informer().
 			AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
 	case PVInformerHandlers:
-		s.GetAPIs().PVInformer.Informer().
+		_, err = s.GetAPIs().PVInformer.Informer().
 			AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
 	case PVCInformerHandlers:
-		s.GetAPIs().PVCInformer.Informer().
+		_, err = s.GetAPIs().PVCInformer.Informer().
 			AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
 	case PriorityClassInformerHandlers:
-		s.GetAPIs().PriorityClassInformer.Informer().
+		_, err = s.GetAPIs().PriorityClassInformer.Informer().
 			AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
+	}
+
+	if err != nil {
+		log.Log(log.AdmissionConf).Error("Error adding event handler", zap.Error(err))
 	}
 }
 

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -54,7 +54,7 @@ func (t Type) String() string {
 
 type APIProvider interface {
 	GetAPIs() *Clients
-	AddEventHandler(handlers *ResourceEventHandlers)
+	AddEventHandler(handlers *ResourceEventHandlers) error
 	Start()
 	Stop()
 	WaitForSync()
@@ -144,7 +144,7 @@ func (s *APIFactory) IsTestingMode() bool {
 	return s.testMode
 }
 
-func (s *APIFactory) AddEventHandler(handlers *ResourceEventHandlers) {
+func (s *APIFactory) AddEventHandler(handlers *ResourceEventHandlers) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	// register all handlers
@@ -168,8 +168,9 @@ func (s *APIFactory) AddEventHandler(handlers *ResourceEventHandlers) {
 
 	log.Log(log.ShimClient).Info("registering event handler", zap.Stringer("type", handlers.Type))
 	if err := s.addEventHandlers(handlers.Type, h, 0); err != nil {
-		log.Log(log.AdmissionConf).Fatal("Failed to initialize event handlers", zap.Error(err))
+		return fmt.Errorf("failed to initialize event handlers: %w", err)
 	}
+	return nil
 }
 
 func (s *APIFactory) addEventHandlers(

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -19,6 +19,7 @@
 package client
 
 import (
+	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -219,16 +220,18 @@ func (m *MockedAPIProvider) IsTestingMode() bool {
 	return true
 }
 
-func (m *MockedAPIProvider) AddEventHandler(handlers *ResourceEventHandlers) {
+func (m *MockedAPIProvider) AddEventHandler(handlers *ResourceEventHandlers) error {
 	m.Lock()
 	defer m.Unlock()
 
 	if !m.running {
-		return
+		return fmt.Errorf("mocked API provider is not running")
 	}
 
 	m.eventHandler <- handlers
 	log.Log(log.Test).Info("registering event handler", zap.Stringer("type", handlers.Type))
+
+	return nil
 }
 
 func (m *MockedAPIProvider) RunEventHandler() {

--- a/pkg/cmd/admissioncontroller/main.go
+++ b/pkg/cmd/admissioncontroller/main.go
@@ -67,7 +67,11 @@ func main() {
 		log.Log(log.Admission).Fatal("Failed to register handlers", zap.Error(hadlerErr))
 		return
 	}
-	pcCache := admission.NewPriorityClassCache(informers.PriorityClass)
+	pcCache, pcErr := admission.NewPriorityClassCache(informers.PriorityClass)
+	if pcErr != nil {
+		log.Log(log.Admission).Fatal("Failed to create new priority calss cache", zap.Error(pcErr))
+		return
+	}
 	nsCache, nsErr := admission.NewNamespaceCache(informers.Namespace)
 	if nsErr != nil {
 		log.Log(log.Admission).Fatal("Failed to create namespace cache", zap.Error(nsErr))

--- a/pkg/cmd/admissioncontroller/main.go
+++ b/pkg/cmd/admissioncontroller/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 	pcCache, pcErr := admission.NewPriorityClassCache(informers.PriorityClass)
 	if pcErr != nil {
-		log.Log(log.Admission).Fatal("Failed to create new priority calss cache", zap.Error(pcErr))
+		log.Log(log.Admission).Fatal("Failed to create new priority class cache", zap.Error(pcErr))
 		return
 	}
 	nsCache, nsErr := admission.NewNamespaceCache(informers.Namespace)

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -162,10 +162,6 @@ func (fc *MockScheduler) waitAndAssertApplicationState(t *testing.T, appID, expe
 	}
 }
 
-func (fc *MockScheduler) removeApplication(appId string) error {
-	return fc.context.RemoveApplication(appId)
-}
-
 func (fc *MockScheduler) waitAndAssertTaskState(t *testing.T, appID, taskID, expectedState string) {
 	app := fc.context.GetApplication(appID)
 	assert.Equal(t, app != nil, true)


### PR DESCRIPTION
### What is this PR for?
There are many different errors  or warnings for `make lint`. 

This PR tries to solve the unchecked error which relates to 5 files,  goconst error and unused error in `yunikorn-k8shim` repo.
* There are 11 `errcheck` looks like below:
pkg/admission/conf/am_conf.go:121:39: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandler` is not checked (errcheck)
        configMaps.Informer().AddEventHandler(&configMapUpdateHandler{conf: acc})
                                           ^
pkg/admission/namespace_cache.go:61:40: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandler` is not checked (errcheck)
                namespaces.Informer().AddEventHandler(&namespaceUpdateHandler{cache: nsc})
                                                     ^
pkg/admission/priority_class_cache.go:44:45: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandler` is not checked (errcheck)
                priorityClasses.Informer().AddEventHandler(&priorityClassUpdateHandler{cache: pcc})
                                                          ^
test/e2e/framework/helpers/k8s/k8s_utils.go:719:46: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandler` is not checked (errcheck)
        configMapInformer.Informer().AddEventHandler(eventHandler)
                                                    ^
pkg/client/apifactory.go:177:35: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandlerWithResyncPeriod` is not checked (errcheck)
                        AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
                                                       ^
pkg/client/apifactory.go:180:35: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandlerWithResyncPeriod` is not checked (errcheck)
                        AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
                                                       ^
pkg/client/apifactory.go:183:35: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandlerWithResyncPeriod` is not checked (errcheck)
                        AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
                                                       ^
pkg/client/apifactory.go:186:35: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandlerWithResyncPeriod` is not checked (errcheck)
                        AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
                                                       ^
pkg/client/apifactory.go:189:35: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandlerWithResyncPeriod` is not checked (errcheck)
                        AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
                                                       ^
pkg/client/apifactory.go:192:35: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandlerWithResyncPeriod` is not checked (errcheck)
                        AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
                                                       ^
pkg/client/apifactory.go:195:35: Error return value of `(k8s.io/client-go/tools/cache.SharedInformer).AddEventHandlerWithResyncPeriod` is not checked (errcheck)
                        AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
                                                       ^

* There are 4 `goconst` errors as below:
pkg/common/si_helper_test.go:71:13: string `pod-resource-test-00001` has 3 occurrences, make it a constant (goconst)
        podName := "pod-resource-test-00001"
                   ^
pkg/common/si_helper_test.go:72:15: string `important` has 3 occurrences, make it a constant (goconst)
        namespace := "important"
                     ^
pkg/cache/application_test.go:562:13: string `task02` has 3 occurrences, make it a constant (goconst)
        taskID2 := "task02"
                   ^
pkg/shim/scheduler_test.go:42:16: string `
partitions:
  - name: default
    queues:
      - name: root
        submitacl: "*"
        queues:
          - name: a
            resources:
              guaranteed:
                memory: 100000000
                vcore: 10
              max:
                memory: 150000000
                vcore: 20
` has 3 occurrences, make it a constant (goconst)
        configData := `
                      ^
* There is 1 `unused` error as below :
pkg/shim/scheduler_mock_test.go:165:26: func `(*MockScheduler).removeApplication` is unused (unused)
func (fc *MockScheduler) removeApplication(appId string) error {
                         ^

Actions:
* log out the errors for these 11 `unchecked` errors in 5 files.
* When the error exists for `RegisterHandler` and `NewNamespaceCache`, this error should be viewed as fatal, pass the error message back to main(), and we should propagate it to stop k8shime. At same time, update the unit test for `NewNamespaceCache` func.
* add `min-occurrences = 5` in .golangci.yml file to increase the threshold
* delete the function `func (fc *MockScheduler) removeApplication(appId string) error{}`


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2651

### How should this be tested?
It should pass all CI test.
`make test` passed locally.

### Screenshots (if appropriate)
<img width="869" alt="截屏2024-05-25 下午11 58 16" src="https://github.com/apache/yunikorn-k8shim/assets/141538510/c0c7b75b-a250-4827-842b-08bb92c991c5">

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
