### PR TITLE
[YUNIKORN-2640] Remove config from Clients

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -46,7 +46,6 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
-	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	schedulerconf "github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/dispatcher"
 	"github.com/apache/yunikorn-k8shim/pkg/locking"
@@ -94,7 +93,7 @@ func NewContextWithBootstrapConfigMaps(apis client.APIProvider, bootstrapConfigM
 	ctx := &Context{
 		applications: make(map[string]*Application),
 		apiProvider:  apis,
-		namespace:    conf.GetSchedulerConf().Namespace,
+		namespace:    schedulerconf.GetSchedulerConf().Namespace,
 		configMaps:   bootstrapConfigMaps,
 		lock:         &locking.RWMutex{},
 		klogger:      klog.NewKlogr(),

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -46,6 +46,7 @@ import (
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/yunikorn-k8shim/pkg/common/utils"
+	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	schedulerconf "github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/dispatcher"
 	"github.com/apache/yunikorn-k8shim/pkg/locking"
@@ -93,7 +94,7 @@ func NewContextWithBootstrapConfigMaps(apis client.APIProvider, bootstrapConfigM
 	ctx := &Context{
 		applications: make(map[string]*Application),
 		apiProvider:  apis,
-		namespace:    apis.GetAPIs().GetConf().Namespace,
+		namespace:    conf.GetSchedulerConf().Namespace,
 		configMaps:   bootstrapConfigMaps,
 		lock:         &locking.RWMutex{},
 		klogger:      klog.NewKlogr(),

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -114,7 +114,6 @@ func NewAPIFactory(scheduler api.SchedulerAPI, informerFactory informers.SharedI
 
 	return &APIFactory{
 		clients: &Clients{
-			conf:                  configs,
 			KubeClient:            kubeClient,
 			SchedulerAPI:          scheduler,
 			InformerFactory:       informerFactory,

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 
 	"github.com/apache/yunikorn-k8shim/pkg/common/test"
-	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/locking"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
@@ -66,20 +65,6 @@ const (
 func NewMockedAPIProvider(showError bool) *MockedAPIProvider {
 	return &MockedAPIProvider{
 		clients: &Clients{
-			conf: &conf.SchedulerConf{
-				ClusterID:            "yk-test-cluster",
-				ClusterVersion:       "0.1",
-				PolicyGroup:          "queues",
-				Interval:             0,
-				KubeConfig:           "",
-				VolumeBindTimeout:    0,
-				TestMode:             true,
-				EventChannelCapacity: 0,
-				DispatchTimeout:      0,
-				KubeQPS:              0,
-				KubeBurst:            0,
-				Namespace:            "yunikorn",
-			},
 			KubeClient:            NewKubeClientMock(showError),
 			SchedulerAPI:          test.NewSchedulerAPIMock(),
 			PodInformer:           test.NewMockedPodInformer(),

--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -29,7 +29,6 @@ import (
 	storageInformerV1 "k8s.io/client-go/informers/storage/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 
-	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/api"
 )
@@ -38,9 +37,6 @@ import (
 // that can be shared by callers when talking to K8s api-server,
 // or the scheduler core.
 type Clients struct {
-	// configs
-	conf *conf.SchedulerConf
-
 	// client apis
 	KubeClient   KubeClient
 	SchedulerAPI api.SchedulerAPI
@@ -61,10 +57,6 @@ type Clients struct {
 
 	// volume binder handles PV/PVC related operations
 	VolumeBinder volumebinding.SchedulerVolumeBinder
-}
-
-func (c *Clients) GetConf() *conf.SchedulerConf {
-	return c.conf
 }
 
 func (c *Clients) WaitForSync() {


### PR DESCRIPTION
### What is this PR for?

The config (`conf.SchedulerConf`) [0] references to a global singleton object [1][2]. Also, in the code base `clients#GetConf()` is used 3 times [3] and `conf.GetSchedulerConf()` is used 61 times.
So this PR removes config from Clients.

### What type of PR is it?
* [x] - Improvement

### Todos
N/A

### What is the Jira issue?
[[YUNIKORN-2640]](https://issues.apache.org/jira/browse/YUNIKORN-2640)

### How should this be tested?
It has been checked locally by make test.
### Screenshots (if appropriate)
N/A
### Questions:
N/A
