### PR TITLE
[YUNIKORN-2654]Remove unused code in k8shim context

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -887,29 +887,6 @@ func (ctx *Context) StartPodAllocation(podKey string, nodeID string) bool {
 	return ctx.schedulerCache.StartPodAllocation(podKey, nodeID)
 }
 
-// inform the scheduler that the application is completed,
-// the complete state may further explained to completed_with_errors(failed) or successfully_completed,
-// either way we need to release all allocations (if exists) for this application
-func (ctx *Context) NotifyApplicationComplete(appID string) {
-	if app := ctx.GetApplication(appID); app != nil {
-		log.Log(log.ShimContext).Debug("NotifyApplicationComplete",
-			zap.String("appID", appID),
-			zap.String("currentAppState", app.GetApplicationState()))
-		ev := NewSimpleApplicationEvent(appID, CompleteApplication)
-		dispatcher.Dispatch(ev)
-	}
-}
-
-func (ctx *Context) NotifyApplicationFail(appID string) {
-	if app := ctx.GetApplication(appID); app != nil {
-		log.Log(log.ShimContext).Debug("NotifyApplicationFail",
-			zap.String("appID", appID),
-			zap.String("currentAppState", app.GetApplicationState()))
-		ev := NewSimpleApplicationEvent(appID, FailApplication)
-		dispatcher.Dispatch(ev)
-	}
-}
-
 func (ctx *Context) NotifyTaskComplete(appID, taskID string) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()


### PR DESCRIPTION
### What is this PR for?
The NotifyApplicationComplete and NotifyApplicationFail  function are not called by anything and are unused code.The K8shim does not trigger the application completion or failure. This is triggered by the core when the application no longer has any activity registered.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring
### What is the Jira issue?[
[[YUNIKORN-2654]](https://issues.apache.org/jira/browse/YUNIKORN-2654)
### How should this be tested?
It has been checked locally by make test.
### Screenshots (if appropriate)
N/A

