### PR TITLE
[YUNIKORN-2665] Gang app originator pod changes after restart

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -1103,7 +1103,8 @@ func (ctx *Context) addTask(request *AddTaskRequest) *Task {
 
 			// Is this task the originator of the application?
 			// If yes, then make it as "first pod/owner/driver" of the application and set the task as originator
-			if app.GetOriginatingTask() == nil {
+			// At any cost, placeholder cannot become originator
+			if !request.Metadata.Placeholder && app.GetOriginatingTask() == nil {
 				for _, ownerReference := range app.getPlaceholderOwnerReferences() {
 					referenceID := string(ownerReference.UID)
 					if request.Metadata.TaskID == referenceID {

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -2308,6 +2308,8 @@ func TestOriginatorPodAfterRestart(t *testing.T) {
 
 	app := context.getApplication("spark-app-01")
 	assert.Equal(t, app.originatingTask.taskID, "UID-00001")
+	assert.Equal(t, len(app.GetPlaceHolderTasks()), 2)
+	assert.Equal(t, len(app.GetAllocatedTasks()), 0)
 }
 
 func initAssumePodTest(binder *test.VolumeBinderMock) *Context {

--- a/pkg/cache/metadata.go
+++ b/pkg/cache/metadata.go
@@ -124,7 +124,7 @@ func getAppMetadata(pod *v1.Pod) (ApplicationMetadata, bool) {
 	// When app created for the first time, app owner references has been set based on the real driver pod.
 	// Same owner references would be used for all placeholders. During recovery, when processing any placeholder pod,
 	// don't derive the owner references unlike real driver pod. Just use owner references as is because it has been copied from app owner references itself.
-	if utils.GetPlaceholderFlagFromPodSpec(pod) == true {
+	if utils.GetPlaceholderFlagFromPodSpec(pod) {
 		ownerReferences = pod.GetOwnerReferences()
 	} else {
 		ownerReferences = getOwnerReference(pod)

--- a/pkg/cache/metadata.go
+++ b/pkg/cache/metadata.go
@@ -120,7 +120,16 @@ func getAppMetadata(pod *v1.Pod) (ApplicationMetadata, bool) {
 		tags[constants.AnnotationTaskGroups] = pod.Annotations[constants.AnnotationTaskGroups]
 	}
 
-	ownerReferences := getOwnerReference(pod)
+	var ownerReferences []metav1.OwnerReference
+	// When app created for the first time, app owner references has been set based on the real driver pod.
+	// Same owner references would be used for all placeholders. During recovery, when processing any placeholder pod,
+	// don't derive the owner references unlike real driver pod. Just use owner references as is because it has been copied from app owner references itself.
+	if utils.GetPlaceholderFlagFromPodSpec(pod) == true {
+		ownerReferences = pod.GetOwnerReferences()
+	} else {
+		ownerReferences = getOwnerReference(pod)
+	}
+
 	schedulingPolicyParams := GetSchedulingPolicyParam(pod)
 	tags[constants.AnnotationSchedulingPolicyParam] = pod.Annotations[constants.AnnotationSchedulingPolicyParam]
 	creationTime := pod.CreationTimestamp.Unix()


### PR DESCRIPTION
### What is this PR for?
  
During recovery, ensure gang app originator remains same. Ordering of pods shouldn't have any impact on originator selection.

### What type of PR is it?
* [ ] - Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2665

### How should this be tested?
unit test added

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
