### PR TITLE
[YUNIKORN-2668] Temporarily disable TestUpdateAllocation_NewTask_AssumePodFails

### DIFF
--- a/pkg/cache/scheduler_callback_test.go
+++ b/pkg/cache/scheduler_callback_test.go
@@ -85,6 +85,7 @@ func TestUpdateAllocation_NewTask_TaskNotFound(t *testing.T) {
 }
 
 func TestUpdateAllocation_NewTask_AssumePodFails(t *testing.T) {
+	t.Skip("disabled until YUNIKORN-2629 is resolved") // test can randomly trigger a deadlock, resulting in a failed build
 	callback, context := initCallbackTest(t, false, false)
 	defer dispatcher.UnregisterAllEventHandlers()
 	defer dispatcher.Stop()


### PR DESCRIPTION
### What is this PR for?
Mark the test case `TestUpdateAllocation_NewTask_AssumePodFails` as skipped so it does not cause failed builds.

It must be re-enabled in YUNIKORN-2629.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2668

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
