### PR TITLE
[YUNIKORN-2658]add nolint:funlen to long functions to supress the lint warnings 

### DIFF
--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -559,6 +559,7 @@ func TestGetNonTerminatedTaskAlias(t *testing.T) {
 	task1 := NewTask(taskID1, app, context, pod1)
 	app.taskMap[taskID1] = task1
 	task1.sm.SetState(TaskStates().Pending)
+	//nolint:funlen
 	taskID2 := "task02"
 	task2 := NewTask(taskID2, app, context, pod2)
 	app.taskMap[taskID2] = task2

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -750,6 +750,7 @@ func TestTryReserve(t *testing.T) {
 	assert.NilError(t, err, "placeholders are not created")
 }
 
+//nolint:funlen
 func TestTryReservePostRestart(t *testing.T) {
 	context := initContextForTest()
 	dispatcher.RegisterEventHandler("TestAppHandler", dispatcher.EventTypeApp, context.ApplicationEventHandler())

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -525,6 +525,7 @@ func assertAppState(t *testing.T, app *Application, expectedState string, durati
 	}
 }
 
+//nolint:funlen
 func TestGetNonTerminatedTaskAlias(t *testing.T) {
 	context := initContextForTest()
 	app := NewApplication(appID, "root.a", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
@@ -559,7 +560,6 @@ func TestGetNonTerminatedTaskAlias(t *testing.T) {
 	task1 := NewTask(taskID1, app, context, pod1)
 	app.taskMap[taskID1] = task1
 	task1.sm.SetState(TaskStates().Pending)
-	//nolint:funlen
 	taskID2 := "task02"
 	task2 := NewTask(taskID2, app, context, pod2)
 	app.taskMap[taskID2] = task2

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -1482,6 +1482,7 @@ func TestPublishEventsCorrectly(t *testing.T) {
 	assert.NilError(t, err, "event should have been emitted")
 }
 
+//nolint:funlen
 func TestAddApplicationsWithTags(t *testing.T) {
 	context := initContextForTest()
 

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -855,6 +855,7 @@ func TestAddTask(t *testing.T) {
 	assert.Equal(t, len(context.applications["app00001"].GetNewTasks()), 2)
 }
 
+//nolint:funlen
 func TestRecoverTask(t *testing.T) {
 	context, apiProvider := initContextAndAPIProviderForTest()
 	dispatcher.Start()

--- a/pkg/cache/external/scheduler_cache_test.go
+++ b/pkg/cache/external/scheduler_cache_test.go
@@ -307,6 +307,7 @@ func TestGetNodesInfo(t *testing.T) {
 	expectHost(t, host2, nodesInfo)
 }
 
+//nolint:funlen
 func TestGetNodesInfoPodsWithAffinity(t *testing.T) {
 	cache := NewSchedulerCache(client.NewMockedAPIProvider(false).GetAPIs())
 	assert.Assert(t, cache.nodesInfoPodsWithAffinity == nil)

--- a/pkg/cache/task_state.go
+++ b/pkg/cache/task_state.go
@@ -314,6 +314,7 @@ func TaskStates() *TStates {
 	return storeTaskStates
 }
 
+//nolint:funlen
 func newTaskState() *fsm.FSM {
 	states := TaskStates()
 	return fsm.NewFSM(

--- a/pkg/cache/task_state.go
+++ b/pkg/cache/task_state.go
@@ -314,132 +314,130 @@ func TaskStates() *TStates {
 	return storeTaskStates
 }
 
-//nolint:funlen
 func newTaskState() *fsm.FSM {
 	states := TaskStates()
-	return fsm.NewFSM(
-		states.New, fsm.Events{
-			{
-				Name: InitTask.String(),
-				Src:  []string{states.New},
-				Dst:  states.Pending,
-			},
-			{
-				Name: SubmitTask.String(),
-				Src:  []string{states.Pending},
-				Dst:  states.Scheduling,
-			},
-			{
-				Name: TaskAllocated.String(),
-				Src:  []string{states.Scheduling},
-				Dst:  states.Allocated,
-			},
-			{
-				Name: TaskAllocated.String(),
-				Src:  []string{states.Completed},
-				Dst:  states.Completed,
-			},
-			{
-				Name: TaskBound.String(),
-				Src:  []string{states.Allocated},
-				Dst:  states.Bound,
-			},
-			{
-				Name: CompleteTask.String(),
-				Src:  states.Any,
-				Dst:  states.Completed,
-			},
-			{
-				Name: KillTask.String(),
-				Src:  []string{states.Pending, states.Scheduling, states.Allocated, states.Bound},
-				Dst:  states.Killing,
-			},
-			{
-				Name: TaskKilled.String(),
-				Src:  []string{states.Killing},
-				Dst:  states.Killed,
-			},
-			{
-				Name: TaskRejected.String(),
-				Src:  []string{states.New, states.Pending, states.Scheduling},
-				Dst:  states.Rejected,
-			},
-			{
-				Name: TaskFail.String(),
-				Src:  []string{states.New, states.Pending, states.Scheduling, states.Rejected, states.Allocated},
-				Dst:  states.Failed,
-			},
+	return fsm.NewFSM(states.New, eventDesc(states), callbacks(states))
+}
+
+func eventDesc(states *TStates) fsm.Events {
+	return fsm.Events{
+		{
+			Name: InitTask.String(),
+			Src:  []string{states.New},
+			Dst:  states.Pending,
 		},
-		fsm.Callbacks{
-			// The state machine is tightly tied to the Task object.
-			//
-			// The first argument must always be a Task and if there are more arguments,
-			// they must be a string. If this precondition is not met, a runtime panic
-			// could occur.
-			events.EnterState: func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				log.Log(log.ShimFSM).Info("Task state transition",
-					zap.String("app", task.applicationID),
-					zap.String("task", task.taskID),
-					zap.String("taskAlias", task.alias),
-					zap.String("source", event.Src),
-					zap.String("destination", event.Dst),
-					zap.String("event", event.Event))
-			},
-			states.Pending: func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				task.postTaskPending()
-			},
-			states.Allocated: func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				task.postTaskAllocated()
-			},
-			states.Rejected: func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				task.postTaskRejected()
-			},
-			states.Failed: func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				eventArgs := make([]string, 1)
-				reason := ""
-				if err := events.GetEventArgsAsStrings(eventArgs, event.Args[1].([]interface{})); err != nil {
-					log.Log(log.ShimFSM).Error("failed to parse event arg", zap.Error(err))
-					reason = err.Error()
-				} else {
-					reason = eventArgs[0]
-				}
-				task.postTaskFailed(reason)
-			},
-			states.Bound: func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				task.postTaskBound()
-			},
-			beforeHook(TaskFail): func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				task.beforeTaskFail()
-			},
-			beforeHook(TaskAllocated): func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				// All allocation events must include the allocationKey and nodeID passed from the core
-				eventArgs := make([]string, 2)
-				if err := events.GetEventArgsAsStrings(eventArgs, event.Args[1].([]interface{})); err != nil {
-					log.Log(log.ShimFSM).Error("failed to parse event arg", zap.Error(err))
-					return
-				}
-				allocationKey := eventArgs[0]
-				nodeID := eventArgs[1]
-				task.beforeTaskAllocated(event.Src, allocationKey, nodeID)
-			},
-			beforeHook(CompleteTask): func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				task.beforeTaskCompleted()
-			},
-			SubmitTask.String(): func(_ context.Context, event *fsm.Event) {
-				task := event.Args[0].(*Task) //nolint:errcheck
-				task.handleSubmitTaskEvent()
-			},
+		{
+			Name: SubmitTask.String(),
+			Src:  []string{states.Pending},
+			Dst:  states.Scheduling,
 		},
-	)
+		{
+			Name: TaskAllocated.String(),
+			Src:  []string{states.Scheduling},
+			Dst:  states.Allocated,
+		},
+		{
+			Name: TaskAllocated.String(),
+			Src:  []string{states.Completed},
+			Dst:  states.Completed,
+		},
+		{
+			Name: TaskBound.String(),
+			Src:  []string{states.Allocated},
+			Dst:  states.Bound,
+		},
+		{
+			Name: CompleteTask.String(),
+			Src:  states.Any,
+			Dst:  states.Completed,
+		},
+		{
+			Name: KillTask.String(),
+			Src:  []string{states.Pending, states.Scheduling, states.Allocated, states.Bound},
+			Dst:  states.Killing,
+		},
+		{
+			Name: TaskKilled.String(),
+			Src:  []string{states.Killing},
+			Dst:  states.Killed,
+		},
+		{
+			Name: TaskRejected.String(),
+			Src:  []string{states.New, states.Pending, states.Scheduling},
+			Dst:  states.Rejected,
+		},
+		{
+			Name: TaskFail.String(),
+			Src:  []string{states.New, states.Pending, states.Scheduling, states.Rejected, states.Allocated},
+			Dst:  states.Failed,
+		},
+	}
+}
+
+func callbacks(states *TStates) fsm.Callbacks {
+	return fsm.Callbacks{
+		events.EnterState: func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			log.Log(log.ShimFSM).Info("Task state transition",
+				zap.String("app", task.applicationID),
+				zap.String("task", task.taskID),
+				zap.String("taskAlias", task.alias),
+				zap.String("source", event.Src),
+				zap.String("destination", event.Dst),
+				zap.String("event", event.Event))
+		},
+		states.Pending: func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			task.postTaskPending()
+		},
+		states.Allocated: func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			task.postTaskAllocated()
+		},
+		states.Rejected: func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			task.postTaskRejected()
+		},
+		states.Failed: func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			eventArgs := make([]string, 1)
+			reason := ""
+			if err := events.GetEventArgsAsStrings(eventArgs, event.Args[1].([]interface{})); err != nil {
+				log.Log(log.ShimFSM).Error("failed to parse event arg", zap.Error(err))
+				reason = err.Error()
+			} else {
+				reason = eventArgs[0]
+			}
+			task.postTaskFailed(reason)
+		},
+		states.Bound: func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			task.postTaskBound()
+		},
+		beforeHook(TaskFail): func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			task.beforeTaskFail()
+		},
+		beforeHook(TaskAllocated): func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			eventArgs := make([]string, 2)
+			if err := events.GetEventArgsAsStrings(eventArgs, event.Args[1].([]interface{})); err != nil {
+				log.Log(log.ShimFSM).Error("failed to parse event arg", zap.Error(err))
+				return
+			}
+			allocationKey := eventArgs[0]
+			nodeID := eventArgs[1]
+			task.beforeTaskAllocated(event.Src, allocationKey, nodeID)
+		},
+		beforeHook(CompleteTask): func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			task.beforeTaskCompleted()
+		},
+		SubmitTask.String(): func(_ context.Context, event *fsm.Event) {
+			task := event.Args[0].(*Task) //nolint:errcheck
+			task.handleSubmitTaskEvent()
+		},
+	}
 }
 
 func beforeHook(event TaskEventType) string {

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -490,6 +490,7 @@ func TestSetTaskGroup(t *testing.T) {
 	assert.Equal(t, task.getTaskGroupName(), "test-group")
 }
 
+//nolint:funlen
 func TestHandleSubmitTaskEvent(t *testing.T) {
 	mockedContext, mockedSchedulerAPI := initContextAndAPIProviderForTest()
 	var allocRequest *si.AllocationRequest

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -147,6 +147,7 @@ func TestEquals(t *testing.T) {
 	assert.Equal(t, Equals(r1, r2), false)
 }
 
+//nolint:funlen
 func TestParsePodResource(t *testing.T) {
 	containers := make([]v1.Container, 0, 2)
 

--- a/pkg/plugin/predicates/predicate_manager_test.go
+++ b/pkg/plugin/predicates/predicate_manager_test.go
@@ -357,6 +357,7 @@ func TestPodFitsHostPorts(t *testing.T) {
 	}
 }
 
+//nolint:funlen
 func TestPodFitsSelector(t *testing.T) {
 	clientSet := clientSet()
 	informerFactory := informerFactory(clientSet)
@@ -1202,6 +1203,7 @@ func TestRunGeneralPredicates(t *testing.T) {
 	}
 }
 
+//nolint:funlen
 func TestInterPodAffinity(t *testing.T) {
 	clientSet := clientSet()
 	informerFactory := informerFactory(clientSet)


### PR DESCRIPTION
### What is this PR for?

To add nolint:funlen to long functions to supress the lint warnings, when we use `make lint` 
like this 
![image](https://github.com/apache/yunikorn-k8shim/assets/101171023/20f651f7-aae6-4569-a79a-09e4e36c0576)


### What type of PR is it?

- [x] - Improvement

### Todos
-  Improve other warn message

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2658

### How should this be tested?
in [Makefile](https://github.com/apache/yunikorn-k8shim/blob/master/Makefile#L294)  take off `--new-from-rev=$${headSHA}`
then run `make lint
`
### Screenshots (if appropriate)
NA
### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
