### PR TITLE
[YUNIKORN-2319] cache.Task: reference to old pod object is kept after update

### DIFF
--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -494,6 +494,11 @@ func TestUpdatePod(t *testing.T) {
 	context.UpdatePod(pod1, pod3)
 	pod = context.schedulerCache.GetPod("UID-00001")
 	assert.Check(t, pod == nil, "pod still found after termination")
+	app := context.getApplication("yunikorn-test-00001")
+	// ensure that an updated pod is updated inside the Task
+	task, err := app.GetTask("UID-00001")
+	assert.NilError(t, err)
+	assert.Assert(t, task.GetTaskPod() == pod3, "task pod has not been updated")
 
 	// ensure a non-terminated pod is updated
 	context.UpdatePod(pod1, pod2)


### PR DESCRIPTION
### What is this PR for?
Whenever a pod is updated, then replace it inside the `Task` as well so that the previous version can be garbage collected.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2319

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
