### PR TITLE
[YUNIKORN-2699] Preemption e2e tests fail in latest master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ module github.com/apache/yunikorn-k8shim
 go 1.21
 
 require (
-	github.com/apache/yunikorn-core v0.0.0-20240625135621-67a7167f945b
+	github.com/apache/yunikorn-core v0.0.0-20240705110923-108ed0d25768
 	github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cq
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
-github.com/apache/yunikorn-core v0.0.0-20240625135621-67a7167f945b h1:uaMerB8Uin550/sgS3qNiynw5ZbQFMzjjWjysFZ0VV4=
-github.com/apache/yunikorn-core v0.0.0-20240625135621-67a7167f945b/go.mod h1:pSi7AFBRiGCGQ7RwQffpD4m6dvA5lc1HuCrg7LpJJqs=
+github.com/apache/yunikorn-core v0.0.0-20240705110923-108ed0d25768 h1:RYjrRqr8rumlEAbYRh5Z88FsJe+8LQ4c1mzjNJoSk70=
+github.com/apache/yunikorn-core v0.0.0-20240705110923-108ed0d25768/go.mod h1:pSi7AFBRiGCGQ7RwQffpD4m6dvA5lc1HuCrg7LpJJqs=
 github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1 h1:v4J9L3MlW8BQfYnbq6FV2l3uyay3SqMS2Ffpo+SFat4=
 github.com/apache/yunikorn-scheduler-interface v0.0.0-20240425182941-07f5695119a1/go.mod h1:WuHJpVk34t8N5+1ErYGj/5Qq33/cRzL4YtuoAsbMtWc=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/test/e2e/preemption/preemption_test.go
+++ b/test/e2e/preemption/preemption_test.go
@@ -137,7 +137,6 @@ var _ = ginkgo.Describe("Preemption", func() {
 	})
 
 	ginkgo.It("Verify_basic_preemption", func() {
-		ginkgo.Skip("Disabled until YUNIKORN-2699 is resolved")
 		ginkgo.By("A queue uses resource more than the guaranteed value even after removing one of the pods. The cluster doesn't have enough resource to deploy a pod in another queue which uses resource less than the guaranteed value.")
 		// update config
 		ginkgo.By(fmt.Sprintf("Update root.sandbox1 and root.sandbox2 with guaranteed memory %dM", sleepPodMemLimit))
@@ -332,7 +331,6 @@ var _ = ginkgo.Describe("Preemption", func() {
 	})
 
 	ginkgo.It("Verify_preemption_on_priority_queue", func() {
-		ginkgo.Skip("Disabled until YUNIKORN-2699 is resolved")
 		ginkgo.By("A task can only preempt a task with lower or equal priority")
 		// update config
 		ginkgo.By(fmt.Sprintf("Update root.sandbox1, root.low-priority, root.high-priority with guaranteed memory %dM", sleepPodMemLimit))
@@ -427,7 +425,6 @@ var _ = ginkgo.Describe("Preemption", func() {
 	})
 
 	ginkgo.It("Verify_allow_preemption_tag", func() {
-		ginkgo.Skip("Disabled until YUNIKORN-2699 is resolved")
 		ginkgo.By("The value of 'false' for the allow preemption annotation on the PriorityClass moves the Pod to the back of the preemption list")
 		// update config
 		ginkgo.By(fmt.Sprintf("Update root.sandbox3, root.sandbox4 and root.sandbox5 with guaranteed memory %dM", sleepPodMemLimit2))

--- a/test/e2e/preemption/preemption_test.go
+++ b/test/e2e/preemption/preemption_test.go
@@ -178,7 +178,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			// Wait for pod to move to running state
 			podErr = kClient.WaitForPodBySelectorRunning(dev,
 				fmt.Sprintf("app=%s", sleepRespPod.ObjectMeta.Labels["app"]),
-				60)
+				120)
 			gomega.Ω(podErr).NotTo(gomega.HaveOccurred())
 		}
 
@@ -519,7 +519,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 		// sleepjob5 pod can be scheduled before pods in root.sandbox3 are succeeded
 		ginkgo.By("The sleep pod " + sleepPod5Config.Name + " can be scheduled")
-		err = kClient.WaitForPodScheduled(ns.Name, sleepRespPod5.Name, 30*time.Second)
+		err = kClient.WaitForPodScheduled(ns.Name, sleepRespPod5.Name, 90*time.Second)
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
 
 		// assert one of the pods in root.sandbox3 is preempted


### PR DESCRIPTION
### What is this PR for?

Incorrect victims list has been sent from core to shim for preemption. Fixed the issue by sending the correct list at core side.
Once victims has been chosen finally, there is one more round of filtering step to do further filter in TryPreemption(). After this filtering step, final list has been prepared. Instead of sending the final list to shim, earlier list has been sent. Hence, some victims has been preempted unnecessarily.

### What type of PR is it?
* [ ] - Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2699

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
