### PR TITLE
[YUNIKORN-2504] Support canonical labels for queue/applicationId in scheduler

### DIFF
--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -91,8 +91,8 @@ func newPlaceholder(placeholderName string, app *Application, taskGroup TaskGrou
 			Name:      placeholderName,
 			Namespace: app.tags[constants.AppTagNamespace],
 			Labels: utils.MergeMaps(taskGroup.Labels, map[string]string{
-				constants.LabelApplicationID: app.GetApplicationID(),
-				constants.LabelQueueName:     app.GetQueue(),
+				constants.CanonicalLabelApplicationID: app.GetApplicationID(),
+				constants.CanonicalLabelQueueName:     app.GetQueue(),
 			}),
 			Annotations:     annotations,
 			OwnerReferences: ownerRefs,

--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -125,10 +125,10 @@ func TestNewPlaceholder(t *testing.T) {
 	assert.Equal(t, holder.pod.Name, "ph-name")
 	assert.Equal(t, holder.pod.Namespace, namespace)
 	assert.DeepEqual(t, holder.pod.Labels, map[string]string{
-		constants.LabelApplicationID: appID,
-		constants.LabelQueueName:     queue,
-		"labelKey0":                  "labelKeyValue0",
-		"labelKey1":                  "labelKeyValue1",
+		constants.CanonicalLabelApplicationID: appID,
+		constants.CanonicalLabelQueueName:     queue,
+		"labelKey0":                           "labelKeyValue0",
+		"labelKey1":                           "labelKeyValue1",
 	})
 	assert.Equal(t, len(holder.pod.Annotations), 6, "unexpected number of annotations")
 	assert.Equal(t, holder.pod.Annotations[constants.AnnotationTaskGroupName], app.taskGroups[0].Name)

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/looplab/fsm"
@@ -185,6 +186,22 @@ func (task *Task) UpdateTaskPodStatus(pod *v1.Pod) (*v1.Pod, error) {
 
 func (task *Task) UpdateTaskPod(pod *v1.Pod, podMutator func(pod *v1.Pod)) (*v1.Pod, error) {
 	return task.context.apiProvider.GetAPIs().KubeClient.UpdatePod(pod, podMutator)
+}
+
+func (task *Task) failTaskPodWithReasonAndMsg(reason string, msg string) {
+	podCopy := task.pod.DeepCopy()
+	podCopy.Status = v1.PodStatus{
+		Phase:   v1.PodFailed,
+		Reason:  reason,
+		Message: msg,
+	}
+	log.Log(log.ShimCacheTask).Info("setting pod to failed", zap.String("podName", podCopy.Name))
+	pod, err := task.UpdateTaskPodStatus(podCopy)
+	if err != nil {
+		log.Log(log.ShimCacheTask).Error("failed to update task pod status", zap.Error(err))
+	} else {
+		log.Log(log.ShimCacheTask).Info("new pod status", zap.String("status", string(pod.Status.Phase)))
+	}
 }
 
 func (task *Task) isTerminated() bool {
@@ -457,16 +474,21 @@ func (task *Task) postTaskBound() {
 	}
 }
 
-func (task *Task) postTaskRejected() {
-	// currently, once task is rejected by scheduler, we directly move task to failed state.
-	// so this function simply triggers the state transition when it is rejected.
-	// but further, we can introduce retry mechanism if necessary.
+func (task *Task) postTaskRejected(reason string) {
+	// if task is rejected because of conflicting metadata, we should fail the pod with reason
+	if strings.Contains(reason, constants.TaskPodInconsistMetadataFailure) {
+		// Before version 1.7.0, this path would never be reached.
+		// After version 1.7.0, task pod should fail if pod has conflicting metadata.
+		task.failTaskPodWithReasonAndMsg(constants.TaskRejectedFailure, reason)
+	}
+
+	// move task to failed state.
 	dispatcher.Dispatch(NewFailTaskEvent(task.applicationID, task.taskID,
-		fmt.Sprintf("task %s failed because it is rejected by scheduler", task.alias)))
+		fmt.Sprintf("task %s failed because it is rejected", task.alias)))
 
 	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
 		v1.EventTypeWarning, "TaskRejected", "TaskRejected",
-		"Task %s is rejected by the scheduler", task.alias)
+		"Task %s is rejected", task.alias)
 }
 
 // beforeTaskFail releases the allocation or ask from scheduler core
@@ -543,7 +565,62 @@ func (task *Task) releaseAllocation() {
 // some sanity checks before sending task for scheduling,
 // this reduces the scheduling overhead by blocking such
 // request away from the core scheduler.
-func (task *Task) sanityCheckBeforeScheduling() error {
+func (task *Task) sanityCheckBeforeScheduling() (error, bool) {
+	rejectTask := false
+
+	if err := task.checkPodPVCs(); err != nil {
+		return err, rejectTask
+	}
+
+	// only check pod labels and annotations consistency if pod is not already bound
+	// reject the task if pod metadata is conflicting
+	if !utils.PodAlreadyBound(task.pod) {
+		if err := task.checkTaskPodWithoutConflictMetadata(); err != nil {
+			// Before version 1.7.0, return nil error and log a warning if pod metadata is conflicting
+			// After version 1.7.0, err should be returned if pod metadata is conflicting
+			// After version 1.7.0, rejectTask should be true if pod metadata is conflicting
+			log.Log(log.ShimCacheTask).Warn("Task pod has conflicting metadata, the unbound task pod will be rejected after version 1.7.0",
+				zap.String("appID", task.applicationID),
+				zap.String("podName", task.pod.Name),
+				zap.String("error", err.Error()))
+			return nil, rejectTask
+		}
+	}
+
+	return nil, rejectTask
+}
+
+func (task *Task) checkTaskPodWithoutConflictMetadata() error {
+	// check application ID
+	appIdLabelKeys := []string{
+		constants.CanonicalLabelApplicationID,
+		constants.SparkLabelAppID,
+		constants.LabelApplicationID,
+	}
+	appIdAnnotationKeys := []string{
+		constants.AnnotationApplicationID,
+	}
+	if !utils.ValidatePodLabelAnnotationConsistency(task.pod, appIdLabelKeys, appIdAnnotationKeys) {
+		return fmt.Errorf("application ID is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+	}
+
+	// check queue name
+	queueLabelKeys := []string{
+		constants.CanonicalLabelQueueName,
+		constants.LabelQueueName,
+	}
+
+	queueAnnotationKeys := []string{
+		constants.AnnotationQueueName,
+	}
+
+	if !utils.ValidatePodLabelAnnotationConsistency(task.pod, queueLabelKeys, queueAnnotationKeys) {
+		return fmt.Errorf("queue is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+	}
+	return nil
+}
+
+func (task *Task) checkPodPVCs() error {
 	// Check PVCs used by the pod
 	namespace := task.pod.Namespace
 	manifest := &(task.pod.Spec)

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -624,8 +624,8 @@ func (task *Task) checkTaskPodWithoutConflictMetadata() error {
 }
 
 func (task *Task) checkPodPVCs() error {
-	task.lock.RLock()
 	// Check PVCs used by the pod
+	task.lock.RLock()
 	namespace := task.pod.Namespace
 	manifest := &(task.pod.Spec)
 	task.lock.RUnlock()

--- a/pkg/cache/task_state.go
+++ b/pkg/cache/task_state.go
@@ -396,7 +396,15 @@ func callbacks(states *TStates) fsm.Callbacks {
 		},
 		states.Rejected: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
-			task.postTaskRejected()
+			eventArgs := make([]string, 1)
+			reason := ""
+			if err := events.GetEventArgsAsStrings(eventArgs, event.Args[1].([]interface{})); err != nil {
+				log.Log(log.ShimFSM).Error("failed to parse event arg", zap.Error(err))
+				reason = err.Error()
+			} else {
+				reason = eventArgs[0]
+			}
+			task.postTaskRejected(reason)
 		},
 		states.Failed: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -784,7 +784,7 @@ func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
 			appIdInconsitentErr,
 		},
 		{
-			"have conflict queueNmae in canonical label",
+			"have conflict queueName in canonical label",
 			map[string]string{
 				constants.CanonicalLabelQueueName: queue2Name,
 				constants.LabelQueueName:          queueName,
@@ -794,7 +794,7 @@ func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
 			queueInconsitentErr,
 		},
 		{
-			"have conflict queueNmae in legacy label",
+			"have conflict queueName in legacy label",
 			map[string]string{
 				constants.CanonicalLabelQueueName: queueName,
 				constants.LabelQueueName:          queue2Name,
@@ -804,7 +804,7 @@ func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
 			queueInconsitentErr,
 		},
 		{
-			"have conflict queueNmae in annotation",
+			"have conflict queueName in annotation",
 			map[string]string{
 				constants.CanonicalLabelQueueName: queueName,
 				constants.LabelQueueName:          queueName,

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -19,6 +19,7 @@
 package cache
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -702,6 +703,135 @@ func TestSimultaneousTaskCompleteAndAllocate(t *testing.T) {
 	err = task1.handle(ev1)
 	assert.NilError(t, err, "failed to handle AllocateTask event")
 	assert.Equal(t, task1.GetTaskState(), TaskStates().Completed)
+}
+
+// nolint: funlen
+func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
+	const (
+		appID      = "app01"
+		app2ID     = "app02"
+		queueName  = "root.sandbox1"
+		queue2Name = "root.sandbox2"
+	)
+	var appIdInconsitentErr = fmt.Errorf("application ID is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+	var queueInconsitentErr = fmt.Errorf("queue is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+
+	testCases := []struct {
+		name           string
+		podLabels      map[string]string
+		podAnnotations map[string]string
+		expected       error
+	}{
+		{
+			"empty label and empty annotation in pod", nil, nil, nil,
+		},
+		{
+			"appId and queueName have no conflict",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: appID,
+				constants.SparkLabelAppID:             appID,
+				constants.LabelApp:                    appID,
+				constants.CanonicalLabelQueueName:     queueName,
+				constants.LabelQueueName:              queueName,
+			}, map[string]string{
+				constants.AnnotationApplicationID: appID,
+				constants.AnnotationQueueName:     queueName,
+			},
+			nil,
+		},
+		{
+			"have conflict appId in canonical label",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: app2ID,
+				constants.SparkLabelAppID:             appID,
+				constants.LabelApplicationID:          appID,
+			}, map[string]string{
+				constants.AnnotationApplicationID: appID,
+			},
+			appIdInconsitentErr,
+		},
+		{
+			"have conflict appId in spark label",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: appID,
+				constants.SparkLabelAppID:             app2ID,
+				constants.LabelApplicationID:          appID,
+			}, map[string]string{
+				constants.AnnotationApplicationID: appID,
+			},
+			appIdInconsitentErr,
+		},
+		{
+			"have conflict appId in legacy label",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: appID,
+				constants.SparkLabelAppID:             appID,
+				constants.LabelApplicationID:          app2ID,
+			}, map[string]string{
+				constants.AnnotationApplicationID: appID,
+			},
+			appIdInconsitentErr,
+		},
+		{
+			"have conflict appId in annotation",
+			map[string]string{
+				constants.CanonicalLabelApplicationID: appID,
+				constants.SparkLabelAppID:             appID,
+				constants.LabelApplicationID:          appID,
+			}, map[string]string{
+				constants.AnnotationApplicationID: app2ID,
+			},
+			appIdInconsitentErr,
+		},
+		{
+			"have conflict queueNmae in canonical label",
+			map[string]string{
+				constants.CanonicalLabelQueueName: queue2Name,
+				constants.LabelQueueName:          queueName,
+			}, map[string]string{
+				constants.AnnotationQueueName: queueName,
+			},
+			queueInconsitentErr,
+		},
+		{
+			"have conflict queueNmae in legacy label",
+			map[string]string{
+				constants.CanonicalLabelQueueName: queueName,
+				constants.LabelQueueName:          queue2Name,
+			}, map[string]string{
+				constants.AnnotationQueueName: queueName,
+			},
+			queueInconsitentErr,
+		},
+		{
+			"have conflict queueNmae in annotation",
+			map[string]string{
+				constants.CanonicalLabelQueueName: queueName,
+				constants.LabelQueueName:          queueName,
+			}, map[string]string{
+				constants.AnnotationQueueName: queue2Name,
+			},
+			queueInconsitentErr,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := NewApplication(appID, "root.default", "user", testGroups, map[string]string{}, nil)
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      tc.podLabels,
+					Annotations: tc.podAnnotations,
+				},
+			}
+			task := NewTask("task01", app, nil, pod)
+			err := task.checkTaskPodWithoutConflictMetadata()
+			if err != nil {
+				assert.Equal(t, tc.expected.Error(), err.Error())
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
 }
 
 func TestUpdatePodCondition(t *testing.T) {

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -713,8 +713,8 @@ func TestCheckTaskPodWithoutConflictMetadata(t *testing.T) {
 		queueName  = "root.sandbox1"
 		queue2Name = "root.sandbox2"
 	)
-	var appIdInconsitentErr = fmt.Errorf("application ID is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
-	var queueInconsitentErr = fmt.Errorf("queue is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistMetadataFailure)
+	var appIdInconsitentErr = fmt.Errorf("application ID is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistentMetadataFailure)
+	var queueInconsitentErr = fmt.Errorf("queue is not consistently set in pod's labels and annotations. [%s]", constants.TaskPodInconsistentMetadataFailure)
 
 	testCases := []struct {
 		name           string

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -86,6 +86,8 @@ var SchedulingPolicyStyleParamValues = map[string]string{"Hard": "Hard", "Soft":
 
 const ApplicationInsufficientResourcesFailure = "ResourceReservationTimeout"
 const ApplicationRejectedFailure = "ApplicationRejected"
+const TaskRejectedFailure = "TaskRejected"
+const TaskPodInconsistMetadataFailure = "PodInconsistentMetadata"
 
 // namespace.max.* (Retaining for backwards compatibility. Need to be removed in next major release)
 const CPUQuota = DomainYuniKorn + "namespace.max.cpu"

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -87,7 +87,7 @@ var SchedulingPolicyStyleParamValues = map[string]string{"Hard": "Hard", "Soft":
 const ApplicationInsufficientResourcesFailure = "ResourceReservationTimeout"
 const ApplicationRejectedFailure = "ApplicationRejected"
 const TaskRejectedFailure = "TaskRejected"
-const TaskPodInconsistMetadataFailure = "PodInconsistentMetadata"
+const TaskPodInconsistentMetadataFailure = "PodInconsistentMetadata"
 
 // namespace.max.* (Retaining for backwards compatibility. Need to be removed in next major release)
 const CPUQuota = DomainYuniKorn + "namespace.max.cpu"


### PR DESCRIPTION
### What is this PR for?

Support canonical Queue/ApplicationId labels in Pod, allows it coexist with the existing metadata.
- yunikorn.apache.org/app-id (New, **Canonical Label**)
- yunikorn.apache.org/queue (New, **Canonical Label)**

YuniKorn will reject those pods with conflicting metadata after version 1.7.0.
- Check metadata consistency before move task state from 'New' to 'Pending'. Run the pod metadata check in task.sanityCheckBeforeScheduling()
- Before 1.7.0, If sanity check failed due to inconsistent metadata, then log a warning message
- After 1.7.0, If sanity check failed due to inconsistent metadata, move the task from 'New' to 'Rejected' state. And fail the pod with reasons.

ApplicationID is fetched from pod in below order:
1. Label: constants.CanonicalLabelApplicationID (**New**)
2. Annotation: constants.AnnotationApplicationID
3. Label: constants.LabelApplicationID
4. Label: constants.SparkLabelAppID

Queue name is fetched from pod in below ortder
1. Label: constants.CanonicalLabelQueueName (**New**)
2. Annotation: constants.AnnotationQueueName
3. Label: constants.LabelQueueName (**Previous:  constants.LabelQueueName  > constants.AnnotationQueueName**)

### What type of PR is it?
* [X] - Feature

### Todos
- Admission Controller should fail the pod request too if the metadata is inconsistent. Will create another Jira once this PR got merged.
- Update Doc https://yunikorn.apache.org/docs/next/user_guide/labels_and_annotations_in_yunikorn

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2504


### How should this be tested?

Run below simple sleep pods: (Which have canonical metadata for queue/app-id, but have a confilcting annotations.)
```

apiVersion: v1
kind: Pod
metadata:
  labels:
    app: sleep
    yunikorn.apache.org/app-id: "application-sleep-0001"
    yunikorn.apache.org/queue: "root.sandbox"
  annotations:
    yunikorn.apache.org/queue: "root.sandbox-another"
  name: pod-with-inconsistent-queue
spec:
  schedulerName: yunikorn
  restartPolicy: Never
  containers:
    - name: sleep-6000s
      image: "alpine:latest"
      command: ["sleep", "6000"]
      resources:
        requests:
          cpu: "100m"
          memory: "500M"
          


---
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: sleep
    yunikorn.apache.org/app-id: "application-sleep-0002"
  annotations:
    yunikorn.apache.org/app-id: "application-sleep-0002-another"
  name: pod-with-inconsistent-app-id
spec:
  schedulerName: yunikorn
  restartPolicy: Never
  containers:
    - name: sleep-6000s
      image: "alpine:latest"
      command: ["sleep", "6000"]
      resources:
        requests:
          cpu: "100m"
          memory: "500M"
       
```

Check the scheduler pod logs: 
``` 
kubectl logs -l component=yunikorn-scheduler -n yunikorn --tail=200000 > yunikorn-scheduler-logs.txt
```

You will see the warning logs like this:
```

2024-07-05T18:26:17.591Z	WARN	shim.cache.task	cache/task.go:582	Task pod has conflicting metadata, the unbound task pod will be rejected after version 1.7.0	{"appID": "application-sleep-00002", "podName": "pod-with-inconsistent-queue", "error": "queue is not consistently set in pod's labels and annotations. [PodInconsistentMetadata]"}

2024-07-05T18:26:17.592Z	WARN	shim.cache.task	cache/task.go:582	Task pod has conflicting metadata, the unbound task pod will be rejected after version 1.7.0	{"appID": "application-sleep-00001-annotation", "podName": "pod-with-inconsistent-app-id", "error": "application ID is not consistently set in pod's labels and annotations. [PodInconsistentMetadata]"}

```



### Screenshots (if appropriate)
Before 1.7.0, only log warning message:
<img width="1106" alt="image" src="https://github.com/apache/yunikorn-k8shim/assets/26764036/4750c3d8-1ea5-46b6-a9be-7966a58e447c">

After 1.7.0, below is the screenshot without admission controller: (Another PR will be submit after version 1.6.0 released.) 
(This is the original screenshot in the closed [draft PR](https://github.com/apache/yunikorn-k8shim/pull/860))
<img width="960" alt="image" src="https://github.com/apache/yunikorn-k8shim/assets/26764036/22ad137f-245f-4ec8-8332-947eb4c521f4">

<img width="974" alt="image" src="https://github.com/apache/yunikorn-k8shim/assets/26764036/d28d80f2-89c0-4976-bc3e-d8bb45c169e1">

<img width="973" alt="image" src="https://github.com/apache/yunikorn-k8shim/assets/26764036/00ebf818-4115-4605-8fe8-7a3cf1a47a1f">


### Questions:
NA
