### PR TITLE
[YUNIKORN-2182] Set ReadHeaderTimeout in http server

### DIFF
--- a/pkg/cmd/admissioncontroller/main.go
+++ b/pkg/cmd/admissioncontroller/main.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -160,7 +161,8 @@ func (wh *WebHook) Startup(certs *tls.Certificate) {
 			CipherSuites: wh.getCipherSuites(),       // limit cipher suite to secure ones
 			Certificates: []tls.Certificate{*certs},
 		},
-		Handler: mux,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {


### PR DESCRIPTION
### What is this PR for?
Set ReadHeaderTimeout in the HTTP server. 
Currently, no timeout configuration is set, which may expose the server to the risk of a Slowloris attack.
This attack depletes server resources by maintaining numerous long-idle connections.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring
### What is the Jira issue?
[YUNIKORN-2182](https://issues.apache.org/jira/browse/YUNIKORN-2182)
### How should this be tested?
make test
### Screenshots (if appropriate)
