### PR TITLE
[YUNIKORN-2713] Use queue specific REST API directly

### DIFF
--- a/test/e2e/framework/configmanager/constants.go
+++ b/test/e2e/framework/configmanager/constants.go
@@ -36,6 +36,7 @@ const (
 	// REST endpoints of YuniKorn
 	PartitionsPath    = "ws/v1/partitions"
 	QueuesPath        = "ws/v1/partition/%s/queues"
+	QueuePath         = "ws/v1/partition/%s/queue/%s"
 	AppsPath          = "ws/v1/partition/%s/queue/%s/applications"
 	AppPath           = "ws/v1/partition/%s/queue/%s/application/%s"
 	PartitionAppPath  = "ws/v1/partition/%s/application/%s"

--- a/test/e2e/framework/helpers/yunikorn/rest_api_utils.go
+++ b/test/e2e/framework/helpers/yunikorn/rest_api_utils.go
@@ -432,10 +432,13 @@ func (c *RClient) GetQueue(partition string, queueName string, withChildren bool
 
 	var queue *dao.PartitionQueueDAOInfo
 	_, err = c.do(req, &queue)
+	if err != nil {
+		return nil, err
+	}
 	if queue == nil {
 		return nil, fmt.Errorf("QueueInfo not found: %s", queueName)
 	}
-	return queue, err
+	return queue, nil
 }
 
 // ConditionFunc returns true if queue timestamp property equals ts

--- a/test/e2e/gang_scheduling/gang_scheduling_test.go
+++ b/test/e2e/gang_scheduling/gang_scheduling_test.go
@@ -445,7 +445,7 @@ var _ = Describe("", func() {
 		}
 
 		// Verify queue resources = 0
-		qInfo, qErr := restClient.GetQueue(configmanager.DefaultPartition, nsQueue)
+		qInfo, qErr := restClient.GetQueue(configmanager.DefaultPartition, nsQueue, false)
 		Ω(qErr).NotTo(HaveOccurred())
 		var usedResource yunikorn.ResourceUsage
 		var usedPercentageResource yunikorn.ResourceUsage

--- a/test/e2e/queue_quota_mgmt/queue_quota_mgmt_test.go
+++ b/test/e2e/queue_quota_mgmt/queue_quota_mgmt_test.go
@@ -136,7 +136,7 @@ var _ = Describe("", func() {
 			Ω(kClient.WaitForPodRunning(sleepRespPod.Namespace, sleepRespPod.Name, time.Duration(60)*time.Second)).NotTo(HaveOccurred())
 
 			// Verify that the resources requested by above sleep pod is accounted for in the queues response
-			queueInfo, err = restClient.GetQueue("default", "root."+ns)
+			queueInfo, err = restClient.GetQueue("default", "root."+ns, false)
 			Ω(err).NotTo(HaveOccurred())
 			Ω(queueInfo).NotTo(BeNil())
 			Ω(queueInfo.QueueName).Should(Equal("root." + ns))


### PR DESCRIPTION
### What is this PR for?

There are some places in e2e tests using old way to fetching all queues for the given partition, then fetch queue specific info in next call. Instead, Queue info can be fetched directly in a single call. 

### What type of PR is it?

* [x] - Refactoring

### What is the Jira issue?

[YUNIKORN-2713](https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-2713)

