### PR TITLE
[YUNIKORN-2446] Add OCI annotations to public docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,8 +511,6 @@ sched_image: $(OUTPUT)/third-party-licenses.md scheduler docker/scheduler
 	--label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
 	${QUIET}
 
-    
-
 # Build a plugin image based on the production ready version
 .PHONY: plugin_image
 plugin_image: $(OUTPUT)/third-party-licenses.md plugin docker/plugin conf/scheduler-config.yaml

--- a/Makefile
+++ b/Makefile
@@ -501,7 +501,17 @@ sched_image: $(OUTPUT)/third-party-licenses.md scheduler docker/scheduler
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
+	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
+    --label org.opencontainers.image.description="Apache Yunikorn" \
+    --label org.opencontainers.image.created="$(DATE)" \
+    --label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
+    --label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
+    --label org.opencontainers.image.revision="$(SHIM_SHA)" \
+    --label org.opencontainers.image.license="Apache-2.0" \
+    --label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
 	${QUIET}
+
+    
 
 # Build a plugin image based on the production ready version
 .PHONY: plugin_image
@@ -522,6 +532,14 @@ plugin_image: $(OUTPUT)/third-party-licenses.md plugin docker/plugin conf/schedu
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
+	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
+    --label org.opencontainers.image.description="Apache Yunikorn" \
+    --label org.opencontainers.image.created="$(DATE)" \
+    --label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
+    --label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
+    --label org.opencontainers.image.revision="$(SHIM_SHA)" \
+    --label org.opencontainers.image.license="Apache-2.0" \
+    --label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
 	${QUIET}
 
 # Build admission controller binary in a production ready version
@@ -570,6 +588,14 @@ adm_image: $(OUTPUT)/third-party-licenses.md admission docker/admission
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
+	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
+    --label org.opencontainers.image.description="Apache Yunikorn" \
+    --label org.opencontainers.image.created="$(DATE)" \
+    --label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
+    --label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
+    --label org.opencontainers.image.revision="$(SHIM_SHA)" \
+    --label org.opencontainers.image.license="Apache-2.0" \
+    --label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
 	${QUIET}
 
 # Build all images based on the production ready version

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,11 @@ TEST_SERVER_BINARY=web-test-server
 TOOLS_DIR=tools
 REPO=github.com/apache/yunikorn-k8shim/pkg
 
+IMAGE_SOURCE?=https://github.com/apache/yunikorn-k8shim
+IMAGE_URL?=https://hub.docker.com/r/apache/yunikorn
+LICENSE=Apache-2.0
+DOCS_URL=https://yunikorn.apache.org
+
 # PATH
 export PATH := $(BASE_DIR)/$(TOOLS_DIR):$(GO_EXE_PATH):$(PATH)
 
@@ -501,14 +506,15 @@ sched_image: $(OUTPUT)/third-party-licenses.md scheduler docker/scheduler
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
-	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
-	--label org.opencontainers.image.description="Apache Yunikorn Scheduler" \
-	--label org.opencontainers.image.created="$(DATE)" \
-	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
-	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
-	--label org.opencontainers.image.revision="$(SHIM_SHA)" \
-	--label org.opencontainers.image.license="Apache-2.0" \
-	--label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
+	--label "org.opencontainers.image.title=${SCHEDULER_BINARY}" \
+	--label "org.opencontainers.image.description=Apache YuniKorn Scheduler" \
+	--label "org.opencontainers.image.version=${VERSION}" \
+	--label "org.opencontainers.image.created=$(DATE)" \
+	--label "org.opencontainers.image.source=${IMAGE_SOURCE}" \
+	--label "org.opencontainers.image.url=${IMAGE_URL}" \
+	--label "org.opencontainers.image.revision=$(SHIM_SHA)" \
+	--label "org.opencontainers.image.license=${LICENSE}" \
+	--label "org.opencontainers.image.documentation=${DOCS_URL}" \
 	${QUIET}
 
 # Build a plugin image based on the production ready version
@@ -530,14 +536,15 @@ plugin_image: $(OUTPUT)/third-party-licenses.md plugin docker/plugin conf/schedu
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
-	--label org.opencontainers.image.title="yunikorn-scheduler-plugin-k8s" \
-	--label org.opencontainers.image.description="Apache Yunikorn Plugin" \
-	--label org.opencontainers.image.created="$(DATE)" \
-	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
-	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
-	--label org.opencontainers.image.revision="$(SHIM_SHA)" \
-	--label org.opencontainers.image.license="Apache-2.0" \
-	--label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
+	--label "org.opencontainers.image.title=${PLUGIN_BINARY}" \
+	--label "org.opencontainers.image.description=Apache YuniKorn Scheduler (Plugin)" \
+	--label "org.opencontainers.image.version=${VERSION}" \
+	--label "org.opencontainers.image.created=$(DATE)" \
+	--label "org.opencontainers.image.source=${IMAGE_SOURCE}" \
+	--label "org.opencontainers.image.url=${IMAGE_URL}" \
+	--label "org.opencontainers.image.revision=$(SHIM_SHA)" \
+	--label "org.opencontainers.image.license=${LICENSE}" \
+	--label "org.opencontainers.image.documentation=${DOCS_URL}" \
 	${QUIET}
 
 # Build admission controller binary in a production ready version
@@ -586,14 +593,15 @@ adm_image: $(OUTPUT)/third-party-licenses.md admission docker/admission
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
-	--label org.opencontainers.image.title="yunikorn-admission-controller-k8s" \
-	--label org.opencontainers.image.description="Apache Yunikorn Admission Controller" \
-	--label org.opencontainers.image.created="$(DATE)" \
-	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
-	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
-	--label org.opencontainers.image.revision="$(SHIM_SHA)" \
-	--label org.opencontainers.image.license="Apache-2.0" \
-	--label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
+	--label "org.opencontainers.image.title=${ADMISSION_CONTROLLER_BINARY}" \
+	--label "org.opencontainers.image.description=Apache YuniKorn Admission Controller" \
+	--label "org.opencontainers.image.version=${VERSION}" \
+	--label "org.opencontainers.image.created=$(DATE)" \
+	--label "org.opencontainers.image.source=${IMAGE_SOURCE}" \
+	--label "org.opencontainers.image.url=${IMAGE_URL}" \
+	--label "org.opencontainers.image.revision=$(SHIM_SHA)" \
+	--label "org.opencontainers.image.license=${LICENSE}" \
+	--label "org.opencontainers.image.documentation=${DOCS_URL}" \
 	${QUIET}
 
 # Build all images based on the production ready version

--- a/Makefile
+++ b/Makefile
@@ -502,13 +502,13 @@ sched_image: $(OUTPUT)/third-party-licenses.md scheduler docker/scheduler
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
 	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
-    --label org.opencontainers.image.description="Apache Yunikorn" \
-    --label org.opencontainers.image.created="$(DATE)" \
-    --label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
-    --label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
-    --label org.opencontainers.image.revision="$(SHIM_SHA)" \
-    --label org.opencontainers.image.license="Apache-2.0" \
-    --label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
+    	--label org.opencontainers.image.description="Apache Yunikorn" \
+    	--label org.opencontainers.image.created="$(DATE)" \
+    	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
+    	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
+    	--label org.opencontainers.image.revision="$(SHIM_SHA)" \
+    	--label org.opencontainers.image.license="Apache-2.0" \
+    	--label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
 	${QUIET}
 
     
@@ -533,13 +533,13 @@ plugin_image: $(OUTPUT)/third-party-licenses.md plugin docker/plugin conf/schedu
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
 	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
-    --label org.opencontainers.image.description="Apache Yunikorn" \
-    --label org.opencontainers.image.created="$(DATE)" \
-    --label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
-    --label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
-    --label org.opencontainers.image.revision="$(SHIM_SHA)" \
-    --label org.opencontainers.image.license="Apache-2.0" \
-    --label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
+	--label org.opencontainers.image.description="Apache Yunikorn" \
+	--label org.opencontainers.image.created="$(DATE)" \
+	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
+	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
+	--label org.opencontainers.image.revision="$(SHIM_SHA)" \
+	--label org.opencontainers.image.license="Apache-2.0" \
+	--label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
 	${QUIET}
 
 # Build admission controller binary in a production ready version
@@ -589,13 +589,13 @@ adm_image: $(OUTPUT)/third-party-licenses.md admission docker/admission
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
 	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
-    --label org.opencontainers.image.description="Apache Yunikorn" \
-    --label org.opencontainers.image.created="$(DATE)" \
-    --label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
-    --label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
-    --label org.opencontainers.image.revision="$(SHIM_SHA)" \
-    --label org.opencontainers.image.license="Apache-2.0" \
-    --label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
+	--label org.opencontainers.image.description="Apache Yunikorn" \
+	--label org.opencontainers.image.created="$(DATE)" \
+	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
+	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
+	--label org.opencontainers.image.revision="$(SHIM_SHA)" \
+	--label org.opencontainers.image.license="Apache-2.0" \
+	--label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
 	${QUIET}
 
 # Build all images based on the production ready version

--- a/Makefile
+++ b/Makefile
@@ -502,13 +502,13 @@ sched_image: $(OUTPUT)/third-party-licenses.md scheduler docker/scheduler
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
 	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
-    	--label org.opencontainers.image.description="Apache Yunikorn" \
-    	--label org.opencontainers.image.created="$(DATE)" \
-    	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
-    	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
-    	--label org.opencontainers.image.revision="$(SHIM_SHA)" \
-    	--label org.opencontainers.image.license="Apache-2.0" \
-    	--label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
+	--label org.opencontainers.image.description="Apache Yunikorn Scheduler" \
+	--label org.opencontainers.image.created="$(DATE)" \
+	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
+	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
+	--label org.opencontainers.image.revision="$(SHIM_SHA)" \
+	--label org.opencontainers.image.license="Apache-2.0" \
+	--label org.opencontainers.image.documentation="https://yunikorn.apache.org" \
 	${QUIET}
 
     
@@ -532,8 +532,8 @@ plugin_image: $(OUTPUT)/third-party-licenses.md plugin docker/plugin conf/schedu
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
-	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
-	--label org.opencontainers.image.description="Apache Yunikorn" \
+	--label org.opencontainers.image.title="yunikorn-scheduler-plugin-k8s" \
+	--label org.opencontainers.image.description="Apache Yunikorn Plugin" \
 	--label org.opencontainers.image.created="$(DATE)" \
 	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
 	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \
@@ -588,8 +588,8 @@ adm_image: $(OUTPUT)/third-party-licenses.md admission docker/admission
 	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}" \
-	--label org.opencontainers.image.title="yunikorn-scheduler-k8s" \
-	--label org.opencontainers.image.description="Apache Yunikorn" \
+	--label org.opencontainers.image.title="yunikorn-admission-controller-k8s" \
+	--label org.opencontainers.image.description="Apache Yunikorn Admission Controller" \
 	--label org.opencontainers.image.created="$(DATE)" \
 	--label org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim" \
 	--label org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn" \


### PR DESCRIPTION
### What is this PR for?
source: https://github.com/apache/yunikorn-web/pull/174#issuecomment-1959233281

OCI annotations: https://github.com/opencontainers/image-spec/blob/main/annotations.md

I believe most Yunikorn users are using the docker images into which we push, and so we should consider following a public protocol to set attributions for our public images.

```
org.opencontainers.image.title="yunikorn-scheduler-k8s"
org.opencontainers.image.description="Apache Yunikorn"
org.opencontainers.image.created="${build_date}"
org.opencontainers.image.source="https://github.com/apache/yunikorn-k8shim"
org.opencontainers.image.url="https://hub.docker.com/r/apache/yunikorn"
org.opencontainers.image.revision="${build_revision}"
org.opencontainers.image.license="Apache-2.0"
org.opencontainers.image.documentation="https://yunikorn.apache.org"
```

Reference:
[1] [Annotations and Labels in Container Images](https://adrianmouat.com/posts/annotations-and-labels-in-container-images/)
[2] [OCI annotation spec](https://github.com/opencontainers/image-spec/blob/8797c3fedb77200c102c816ddcd295bb1e19d3e3/annotations.md)

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2446

### How should this be tested?

#### Make all 3 images
```
make image
```

#### Inspect if oci annotations is added into `config.labels`
```
docker image inspect --format='{{json .Config.Labels}}' apache/yunikorn:scheduler-amd64-latest | jq
```
```
docker image inspect --format='{{json .Config.Labels}}' apache/yunikorn:scheduler-plugin-amd64-latest | jq
```
```
docker image inspect --format='{{json .Config.Labels}}' apache/yunikorn:admission-amd64-latest | jq
```
### Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/d9f586ca-c8e1-4988-94aa-d891e5a7d0e3)


### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
