### PR TITLE
[YUNIKORN-2807] Don't log 'task missing' as ERROR

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -1260,7 +1260,7 @@ func (ctx *Context) TaskEventHandler() func(obj interface{}) {
 			taskID := event.GetTaskID()
 			task := ctx.getTask(appID, taskID)
 			if task == nil {
-				log.Log(log.ShimContext).Error("failed to handle task event, task does not exist",
+				log.Log(log.ShimContext).Debug("failed to handle task event, task does not exist",
 					zap.String("applicationID", appID),
 					zap.String("taskID", taskID))
 				return


### PR DESCRIPTION
### What is this PR for?
When a task no longer exists but we have an event to process, we log very loudly. This is not uncommon, and happens frequently when pods are deleted. Log at DEBUG instead.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2807

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
