### PR TITLE
[YUNIKORN-2810] Throw a warning if a pod has inconsistent metadata in the shim

### DIFF
--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -536,16 +536,22 @@ func (task *Task) sanityCheckBeforeScheduling() error {
 	// After version 1.7.0, we should reject the task whose pod is unbound and has conflicting metadata.
 	if !utils.PodAlreadyBound(task.pod) {
 		if err := utils.CheckAppIdInPod(task.pod); err != nil {
-			log.Log(log.ShimCacheTask).Warn("The task has conflicting metadata will be rejected after version 1.7.0.",
+			log.Log(log.ShimCacheTask).Warn("Pod has inconsistent application metadata and may be rejected in a future YuniKorn release.",
 				zap.String("appID", task.applicationID),
 				zap.String("podName", task.pod.Name),
 				zap.String("error", err.Error()))
+
+			events.GetRecorder().Eventf(task.pod.DeepCopy(),
+				nil, v1.EventTypeWarning, "Scheduling", "Scheduling", fmt.Sprintf("Pod has inconsistent application metadata and may be rejected in a future YuniKorn release: %s", err.Error()))
 		}
 		if err := utils.CheckQueueNameInPod(task.pod); err != nil {
-			log.Log(log.ShimCacheTask).Warn("The task has conflicting metadata will be rejected after version 1.7.0.",
+			log.Log(log.ShimCacheTask).Warn("Pod has inconsistent queue metadata and may be rejected in a future YuniKorn release.",
 				zap.String("appID", task.applicationID),
 				zap.String("podName", task.pod.Name),
 				zap.String("error", err.Error()))
+
+			events.GetRecorder().Eventf(task.pod.DeepCopy(),
+				nil, v1.EventTypeWarning, "Scheduling", "Scheduling", fmt.Sprintf("Pod has inconsistent queue metadata and may be rejected in a future YuniKorn release: %s", err.Error()))
 		}
 	}
 	return task.checkPodPVCs()

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -26,6 +26,10 @@ import (
 const True = "true"
 const False = "false"
 
+// Kubernetes
+const Label = "label"
+const Annotation = "annotation"
+
 // Cluster
 const DefaultNodeAttributeHostNameKey = "si.io/hostname"
 const DefaultNodeAttributeRackNameKey = "si.io/rackname"

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -124,3 +124,9 @@ const AutoGenAppSuffix = "autogen"
 
 // Compression Algorithms for schedulerConfig
 const GzipSuffix = "gz"
+
+// The key list which are used to identify the application ID or queue name in pod.
+var AppIdLabelKeys = []string{CanonicalLabelApplicationID, SparkLabelAppID, LabelApplicationID}
+var AppIdAnnotationKeys = []string{AnnotationApplicationID}
+var QueueLabelKeys = []string{CanonicalLabelQueueName, LabelQueueName}
+var QueueAnnotationKeys = []string{AnnotationQueueName}

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -214,29 +214,14 @@ func GetApplicationIDFromPod(pod *v1.Pod) string {
 }
 
 func CheckAppIdInPod(pod *v1.Pod) error {
-	appIdLabelKeys := []string{
-		constants.CanonicalLabelApplicationID,
-		constants.SparkLabelAppID,
-		constants.LabelApplicationID,
-	}
-	appIdAnnotationKeys := []string{
-		constants.AnnotationApplicationID,
-	}
-	if err := ValidatePodLabelAnnotation(pod, appIdLabelKeys, appIdAnnotationKeys); err != nil {
+	if err := ValidatePodLabelAnnotation(pod, constants.AppIdLabelKeys, constants.AppIdAnnotationKeys); err != nil {
 		return fmt.Errorf("pod has inconsistent application ID in labels and annotations. %w", err)
 	}
 	return nil
 }
 
 func CheckQueueNameInPod(pod *v1.Pod) error {
-	queueLabelKeys := []string{
-		constants.CanonicalLabelQueueName,
-		constants.LabelQueueName,
-	}
-	queueAnnotationKeys := []string{
-		constants.AnnotationQueueName,
-	}
-	if err := ValidatePodLabelAnnotation(pod, queueLabelKeys, queueAnnotationKeys); err != nil {
+	if err := ValidatePodLabelAnnotation(pod, constants.QueueLabelKeys, constants.QueueAnnotationKeys); err != nil {
 		return fmt.Errorf("pod has inconsistent queue name in labels and annotations. %w", err)
 	}
 	return nil

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -214,44 +214,46 @@ func GetApplicationIDFromPod(pod *v1.Pod) string {
 }
 
 func CheckAppIdInPod(pod *v1.Pod) error {
-	if err := ValidatePodLabelAnnotation(pod, constants.AppIdLabelKeys, constants.AppIdAnnotationKeys); err != nil {
-		return fmt.Errorf("pod has inconsistent application ID in labels and annotations. %w", err)
-	}
-	return nil
+	return ValidatePodLabelAnnotation(pod, constants.AppIdLabelKeys, constants.AppIdAnnotationKeys)
 }
 
 func CheckQueueNameInPod(pod *v1.Pod) error {
-	if err := ValidatePodLabelAnnotation(pod, constants.QueueLabelKeys, constants.QueueAnnotationKeys); err != nil {
-		return fmt.Errorf("pod has inconsistent queue name in labels and annotations. %w", err)
-	}
-	return nil
+	return ValidatePodLabelAnnotation(pod, constants.QueueLabelKeys, constants.QueueAnnotationKeys)
 }
 
 // return true if all non-empty values are same across all provided label/annotation
 func ValidatePodLabelAnnotation(pod *v1.Pod, labelKeys []string, annotationKeys []string) error {
+	var referenceKey string
 	var referenceValue string
+	var referenceType string
 
+	checkingType := constants.Label
 	for _, key := range labelKeys {
 		value := GetPodLabelValue(pod, key)
 		if value == "" {
 			continue
 		}
 		if referenceValue == "" {
+			referenceKey = key
 			referenceValue = value
+			referenceType = checkingType
 		} else if referenceValue != value {
-			return fmt.Errorf("inconsistent values: %s, %s", referenceValue, value)
+			return fmt.Errorf("%s %s: \"%s\" doesn't match %s %s: \"%s\"", checkingType, key, value, referenceType, referenceKey, referenceValue)
 		}
 	}
 
+	checkingType = constants.Annotation
 	for _, key := range annotationKeys {
 		value := GetPodAnnotationValue(pod, key)
 		if value == "" {
 			continue
 		}
 		if referenceValue == "" {
+			referenceKey = key
 			referenceValue = value
+			referenceType = checkingType
 		} else if referenceValue != value {
-			return fmt.Errorf("inconsistent values: %s, %s", referenceValue, value)
+			return fmt.Errorf("%s %s: \"%s\" doesn't match %s %s: \"%s\"", checkingType, key, value, referenceType, referenceKey, referenceValue)
 		}
 	}
 

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -726,7 +726,7 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 
 func TestCheckAppIdInPod(t *testing.T) {
 	mismatchError := errors.New("pod has inconsistent application ID")
-	tests := []struct {
+	testCases := []struct {
 		name     string
 		pod      *v1.Pod
 		expected error
@@ -774,11 +774,11 @@ func TestCheckAppIdInPod(t *testing.T) {
 			expected: mismatchError,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := CheckAppIdInPod(tt.pod)
-			if tt.expected != nil {
-				assert.ErrorContains(t, err, tt.expected.Error())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckAppIdInPod(tc.pod)
+			if tc.expected != nil {
+				assert.ErrorContains(t, err, tc.expected.Error())
 			} else {
 				assert.NilError(t, err)
 			}
@@ -788,7 +788,7 @@ func TestCheckAppIdInPod(t *testing.T) {
 
 func TestCheckQueueNameInPod(t *testing.T) {
 	mismatchError := errors.New("pod has inconsistent queue name")
-	tests := []struct {
+	testCases := []struct {
 		name     string
 		pod      *v1.Pod
 		expected error
@@ -835,11 +835,11 @@ func TestCheckQueueNameInPod(t *testing.T) {
 			expected: mismatchError,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := CheckQueueNameInPod(tt.pod)
-			if tt.expected != nil {
-				assert.ErrorContains(t, err, tt.expected.Error())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckQueueNameInPod(tc.pod)
+			if tc.expected != nil {
+				assert.ErrorContains(t, err, tc.expected.Error())
 			} else {
 				assert.NilError(t, err)
 			}

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -777,7 +777,7 @@ func TestCheckAppIdInPod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := CheckAppIdInPod(tt.pod)
-			if err != nil {
+			if tt.expected != nil {
 				assert.ErrorContains(t, err, tt.expected.Error())
 			} else {
 				assert.NilError(t, err)
@@ -837,8 +837,8 @@ func TestCheckQueueNameInPod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := CheckAppIdInPod(tt.pod)
-			if err != nil {
+			err := CheckQueueNameInPod(tt.pod)
+			if tt.expected != nil {
 				assert.ErrorContains(t, err, tt.expected.Error())
 			} else {
 				assert.NilError(t, err)
@@ -921,7 +921,7 @@ func TestValidatePodLabelAnnotation(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidatePodLabelAnnotation(tc.pod, labelKeys, annotationKeys)
-			if err != nil {
+			if tc.expected != nil {
 				assert.ErrorContains(t, err, tc.expected.Error())
 			} else {
 				assert.NilError(t, err)

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -725,7 +725,6 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 }
 
 func TestCheckAppIdInPod(t *testing.T) {
-	mismatchError := errors.New("pod has inconsistent application ID")
 	testCases := []struct {
 		name     string
 		pod      *v1.Pod
@@ -757,7 +756,7 @@ func TestCheckAppIdInPod(t *testing.T) {
 					},
 				},
 			},
-			expected: mismatchError,
+			expected: errors.New("label spark-app-selector: \"app-456\" doesn't match label yunikorn.apache.org/app-id: \"app-123\""),
 		},
 		{
 			name: "inconsistent app ID between label and annotation",
@@ -771,7 +770,7 @@ func TestCheckAppIdInPod(t *testing.T) {
 					},
 				},
 			},
-			expected: mismatchError,
+			expected: errors.New("annotation yunikorn.apache.org/app-id: \"app-456\" doesn't match label yunikorn.apache.org/app-id: \"app-123\""),
 		},
 	}
 	for _, tc := range testCases {
@@ -787,7 +786,6 @@ func TestCheckAppIdInPod(t *testing.T) {
 }
 
 func TestCheckQueueNameInPod(t *testing.T) {
-	mismatchError := errors.New("pod has inconsistent queue name")
 	testCases := []struct {
 		name     string
 		pod      *v1.Pod
@@ -818,7 +816,7 @@ func TestCheckQueueNameInPod(t *testing.T) {
 					},
 				},
 			},
-			expected: mismatchError,
+			expected: errors.New("label queue: \"root.b\" doesn't match label yunikorn.apache.org/queue: \"root.a\""),
 		},
 		{
 			name: "inconsistent app ID between label and annotation",
@@ -832,7 +830,7 @@ func TestCheckQueueNameInPod(t *testing.T) {
 					},
 				},
 			},
-			expected: mismatchError,
+			expected: errors.New("annotation yunikorn.apache.org/queue: \"root.b\" doesn't match label yunikorn.apache.org/queue: \"root.a\""),
 		},
 	}
 	for _, tc := range testCases {
@@ -850,7 +848,6 @@ func TestCheckQueueNameInPod(t *testing.T) {
 func TestValidatePodLabelAnnotation(t *testing.T) {
 	labelKeys := []string{"labelKey1", "labelKey2"}
 	annotationKeys := []string{"annotationKey1", "annotationKey2"}
-	mismatchError := errors.New("inconsistent values: ")
 
 	testCases := []struct {
 		name     string
@@ -888,7 +885,7 @@ func TestValidatePodLabelAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expected: mismatchError,
+			expected: errors.New("label labelKey2: \"value2\" doesn't match label labelKey1: \"value1\""),
 		},
 		{
 			name: "pod with inconsistent value between label and annotation",
@@ -902,7 +899,7 @@ func TestValidatePodLabelAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expected: mismatchError,
+			expected: errors.New("annotation annotationKey1: \"value2\" doesn't match label labelKey1: \"value1\""),
 		},
 		{
 			name: "pod with inconsistent value in annotations",
@@ -914,7 +911,7 @@ func TestValidatePodLabelAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expected: mismatchError,
+			expected: errors.New("annotation annotationKey2: \"value2\" doesn't match annotation annotationKey1: \"value1\""),
 		},
 	}
 


### PR DESCRIPTION
### What is this PR for?
- Throw below warning in scheduler pod if pod has inconsistent metadata
```
2024-08-23T10:44:15.940Z	WARN	shim.cache.task	cache/task.go:545	The task has conflicting metadata will be rejected after version 1.7.0.	{"appID": "application-sleep-00002", "podName": "pod-with-inconsistent-queue", "error": "pod has inconsistent queue name in labels and annotations. inconsistent values: root.sandbox, root.sandbox-annotation"}

2024-08-23T10:44:15.940Z	WARN	shim.cache.task	cache/task.go:539	The task has conflicting metadata will be rejected after version 1.7.0.	{"appID": "application-sleep-00001-annotation", "podName": "pod-with-inconsistent-app-id", "error": "pod has inconsistent application ID in labels and annotations. inconsistent values: application-sleep-00001, application-sleep-00001-annotation"}

```

- Extract the logic in sanityCheckBeforeScheduling to new method checkPodPVCs()

### What type of PR is it?
* [x] - Feature

### Todos
* Throw warning in AdmissionController if a pod has inconsistent metadata
* Update Doc https://yunikorn.apache.org/docs/next/user_guide/labels_and_annotations_in_yunikorn

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2810

### How should this be tested?
- make test
- Or build k8shim and create pods with below yaml:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: yunikorn-configs
  namespace: yunikorn
data:
  queues.yaml: |
    partitions:
      - name: default
        queues:
          - name: root
            submitacl: '*'
            queues:
              - name: sandbox
        placementrules:
          - name: provided
            create: true

---



apiVersion: v1
kind: Pod
metadata:
  labels:
    app: sleep
    yunikorn.apache.org/app-id: "application-sleep-00002"
    queue: "root.sandbox"
  annotations:
    yunikorn.apache.org/queue: "root.sandbox-annotation"
  name: pod-with-inconsistent-queue
spec:
  schedulerName: yunikorn
  restartPolicy: Never
  containers:
    - name: sleep-6000s
      image: "alpine:latest"
      command: ["sleep", "6000"]
      resources:
        requests:
          cpu: "100m"
          memory: "500M"

---

apiVersion: v1
kind: Pod
metadata:
  labels:
    app: sleep
    applicationId: "application-sleep-00001"
  annotations:
    yunikorn.apache.org/app-id: "application-sleep-00001-annotation"
  name: pod-with-inconsistent-app-id
spec:
  schedulerName: yunikorn
  restartPolicy: Never
  containers:
    - name: sleep-6000s
      image: "alpine:latest"
      command: ["sleep", "6000"]
      resources:
        requests:
          cpu: "100m"
          memory: "500M"

```

Run below command to check sheduler log. 
```kubectl logs -l component=yunikorn-scheduler -n yunikorn > yunikorn-scheduler-logs.txt```

### Screenshots (if appropriate)



### Questions:
NA
