### PR TITLE
[YUNIKORN-2835] Refactor switch statement in UpdateApplication

### DIFF
--- a/pkg/cache/scheduler_callback.go
+++ b/pkg/cache/scheduler_callback.go
@@ -146,11 +146,9 @@ func (callback *AsyncRMCallback) UpdateApplication(response *si.ApplicationRespo
 				ev := NewResumingApplicationEvent(updated.ApplicationID)
 				dispatcher.Dispatch(ev)
 			}
-		default:
-			if updated.State == ApplicationStates().Failing || updated.State == ApplicationStates().Failed {
-				ev := NewFailApplicationEvent(updated.ApplicationID, updated.Message)
-				dispatcher.Dispatch(ev)
-			}
+		case ApplicationStates().Failing, ApplicationStates().Failed:
+			ev := NewFailApplicationEvent(updated.ApplicationID, updated.Message)
+			dispatcher.Dispatch(ev)
 		}
 	}
 	return nil


### PR DESCRIPTION
### What is this PR for?
The application state handling code in the UpdateApplication method of AsyncRMCallback struct (in scheduler_callback.go) could be improved.

The current implementation uses a switch statement with a default case that actually handles two specific states, which may not align with the typical expectations for a default case.


### What type of PR is it?
* [x] - Refactoring

### What is the Jira issue?
[YUNIKORN-2835](https://issues.apache.org/jira/browse/YUNIKORN-2835)

### How should this be tested?
This has already passed the CI tests(unit test) on my forked repo: [Link](https://github.com/blueBlue0102/yunikorn-k8shim/actions/runs/10551200123)

