### PR TITLE
[YUNIKORN-2842] Improve metadata & gang_utils funtion's test coverage

### DIFF
--- a/pkg/cache/gang_utils_test.go
+++ b/pkg/cache/gang_utils_test.go
@@ -150,6 +150,7 @@ func Test_GetPlaceholderResourceRequest(t *testing.T) {
 		{"base", map[string]resource.Quantity{"pods": resource.MustParse("1")}, v1.ResourceList{"pods": resource.MustParse("1")}},
 		{"hugepages", map[string]resource.Quantity{"hugepages-huge": resource.MustParse("2")}, v1.ResourceList{"hugepages-huge": resource.MustParse("2")}},
 		{"mixed", map[string]resource.Quantity{"pods": resource.MustParse("4"), "nvidia.com/gpu": resource.MustParse("5")}, v1.ResourceList{"pods": resource.MustParse("4"), "nvidia.com/gpu": resource.MustParse("5")}},
+		{"empty key", map[string]resource.Quantity{"": resource.MustParse("1")}, v1.ResourceList{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cache/metadata_test.go
+++ b/pkg/cache/metadata_test.go
@@ -19,7 +19,6 @@
 package cache
 
 import (
-	"reflect"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -104,7 +103,7 @@ func TestGetTaskMetadata(t *testing.T) {
 	// case: empty pod
 	task, ok = getTaskMetadata(&v1.Pod{})
 	assert.Equal(t, ok, false)
-	assert.Assert(t, reflect.DeepEqual(task, TaskMetadata{}))
+	assert.DeepEqual(t, task, TaskMetadata{})
 }
 
 func TestGetAppMetadata(t *testing.T) { //nolint:funlen

--- a/pkg/cache/metadata_test.go
+++ b/pkg/cache/metadata_test.go
@@ -19,6 +19,7 @@
 package cache
 
 import (
+	"reflect"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -99,9 +100,16 @@ func TestGetTaskMetadata(t *testing.T) {
 	assert.Equal(t, task.ApplicationID, "yunikorn-default-autogen")
 	assert.Equal(t, task.TaskID, "UID-POD-00001")
 	assert.Equal(t, task.TaskGroupName, "")
+
+	// case: empty pod
+	task, ok = getTaskMetadata(&v1.Pod{})
+	assert.Equal(t, ok, false)
+	assert.Assert(t, reflect.DeepEqual(task, TaskMetadata{}))
 }
 
 func TestGetAppMetadata(t *testing.T) { //nolint:funlen
+	conf.GetSchedulerConf().SetTestMode(true)
+
 	defer utils.SetPluginMode(false)
 	defer func() { conf.GetSchedulerConf().GenerateUniqueAppIds = false }()
 	utils.SetPluginMode(false)
@@ -301,6 +309,33 @@ func TestGetAppMetadata(t *testing.T) { //nolint:funlen
 	utils.SetPluginMode(true)
 	app, ok = getAppMetadata(&pod)
 	assert.Equal(t, ok, false)
+
+	// case: invalid annotation task groups
+	pod = v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name:      "pod00001",
+			Namespace: "default",
+			UID:       "UID-POD-00001",
+			Labels: map[string]string{
+				"applicationId": "app00001",
+				"queue":         "root.a",
+			},
+			Annotations: map[string]string{
+				constants.AnnotationTaskGroups: "{ name:\"\" }",
+			},
+		},
+		Spec:   v1.PodSpec{SchedulerName: constants.SchedulerName},
+		Status: v1.PodStatus{Phase: v1.PodPending},
+	}
+	app, ok = getAppMetadata(&pod)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, app.SchedulingPolicyParameters.GetGangSchedulingStyle(), "Soft")
+	assert.Equal(t, app.Tags[common.AppTagCreateForce], "false")
+	assert.Equal(t, len(app.TaskGroups), 0)
 }
 
 func TestGetOwnerReferences(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
Improve the following test coverage:

- GetPlaceholderResourceRequests (empty resource key case)
- getTaskMetadata (appID empty string case)
- getAppMetadata (get GetTaskGroupsFromAnnotation error case)

### What type of PR is it?
* [x] - Test

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2842

