### PR TITLE
[YUNIKORN-1126] Added E2E Tests for Best Effort Pod

### DIFF
--- a/test/e2e/basic_scheduling/basic_scheduling_test.go
+++ b/test/e2e/basic_scheduling/basic_scheduling_test.go
@@ -142,6 +142,17 @@ var _ = ginkgo.Describe("", func() {
 
 		ginkgo.By("Verify that the pod's scheduler name is yunikorn")
 		gomega.Ω("yunikorn").To(gomega.Equal(bestEffortPod.Spec.SchedulerName))
+		allocation := appsInfo.Allocations[0]
+		gomega.Ω(allocation).NotTo(gomega.BeNil())
+		gomega.Ω(allocation.AllocationKey).NotTo(gomega.BeNil())
+		gomega.Ω(allocation.NodeID).NotTo(gomega.BeNil())
+		gomega.Ω(allocation.ApplicationID).To(gomega.Equal(bestEffortPod.ObjectMeta.Labels["applicationId"]))
+		core := bestEffortPod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
+		mem := bestEffortPod.Spec.Containers[0].Resources.Requests.Memory().Value()
+		resMap := allocation.ResourcePerAlloc
+		Ω(len(resMap)).NotTo(gomega.BeZero())
+		Ω(resMap["memory"]).To(gomega.Equal(mem))
+		Ω(resMap["vcore"]).To(gomega.Equal(core))
 	})
 
 	ginkgo.It("Verify_NonBestEffort_QOS_Pod_Scheduling", func() {
@@ -167,6 +178,17 @@ var _ = ginkgo.Describe("", func() {
 
 		ginkgo.By("Verify that the pod's scheduler name is yunikorn")
 		gomega.Ω("yunikorn").To(gomega.Equal(burstablePod.Spec.SchedulerName))
+		allocation := appsInfo.Allocations[0]
+		gomega.Ω(allocation).NotTo(gomega.BeNil())
+		gomega.Ω(allocation.AllocationKey).NotTo(gomega.BeNil())
+		gomega.Ω(allocation.NodeID).NotTo(gomega.BeNil())
+		gomega.Ω(allocation.ApplicationID).To(gomega.Equal(burstablePod.ObjectMeta.Labels["applicationId"]))
+		core := burstablePod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
+		mem := burstablePod.Spec.Containers[0].Resources.Requests.Memory().Value()
+		resMap := allocation.ResourcePerAlloc
+		Ω(len(resMap)).NotTo(gomega.BeZero())
+		Ω(resMap["memory"]).To(gomega.Equal(mem))
+		Ω(resMap["vcore"]).To(gomega.Equal(core))
 	})
 
 	ginkgo.AfterEach(func() {


### PR DESCRIPTION
This PR is for adding end-to-end tests to verify the scheduling of pods with different Quality of Service (QOS) classes in the YuniKorn Kubernetes scheduler.  The tests are specifically checking the scheduling of pods with "BestEffort" and "NonBestEffort" (likely "Burstable" or "Guaranteed") QOS classes. 
The tests ensure that the pods are correctly scheduled and running and that their QOS classes are as expected.  The PR also includes changes to the SleepPodConfig struct and the InitSleepPod function to support setting the QOS class of the pods.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1126

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
