### PR TITLE
[YUNIKORN-2851] Improve placeholder & placeholder_manger funtion's test coverage

### DIFF
--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -110,6 +110,7 @@ func TestNewPlaceholder(t *testing.T) {
 		testGroups, map[string]string{constants.AppTagNamespace: namespace, constants.AppTagImagePullSecrets: "secret1,secret2"},
 		mockedSchedulerAPI)
 	app.setTaskGroups(taskGroups)
+	app.setSchedulingParamsDefinition("gangSchedulingStyle=Soft")
 	marshalledTaskGroups, err := json.Marshal(taskGroups)
 	assert.NilError(t, err, "taskGroups marshalling failed")
 	app.setTaskGroupsDefinition(string(marshalledTaskGroups))
@@ -130,12 +131,13 @@ func TestNewPlaceholder(t *testing.T) {
 		"labelKey0":                           "labelKeyValue0",
 		"labelKey1":                           "labelKeyValue1",
 	})
-	assert.Equal(t, len(holder.pod.Annotations), 6, "unexpected number of annotations")
+	assert.Equal(t, len(holder.pod.Annotations), 7, "unexpected number of annotations")
 	assert.Equal(t, holder.pod.Annotations[constants.AnnotationTaskGroupName], app.taskGroups[0].Name)
 	assert.Equal(t, holder.pod.Annotations[constants.AnnotationPlaceholderFlag], constants.True)
 	assert.Equal(t, holder.pod.Annotations["annotationKey0"], "annotationValue0")
 	assert.Equal(t, holder.pod.Annotations["annotationKey1"], "annotationValue1")
 	assert.Equal(t, holder.pod.Annotations["annotationKey2"], "annotationValue2")
+	assert.Equal(t, holder.pod.Annotations[constants.AnnotationSchedulingPolicyParam], "gangSchedulingStyle=Soft")
 	var taskGroupsDef []TaskGroup
 	err = json.Unmarshal([]byte(holder.pod.Annotations[siCommon.DomainYuniKorn+"task-groups"]), &taskGroupsDef)
 	assert.NilError(t, err, "taskGroupsDef unmarshal failed")


### PR DESCRIPTION
### What is this PR for?
Improver the following funtion's test coverage:

- newPlaceholder (schedParamsDef not empty case)
- cleanUp (delete pod error case)
- cleanOrphanPlaceholders (delete pod error case)

### What type of PR is it?
* [x] - Test

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2851
