### PR TITLE
[YUNIKORN-2799] Solve dockerfile warning which emerged while building

### DIFF
--- a/docker/admission/Dockerfile
+++ b/docker/admission/Dockerfile
@@ -14,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM --platform=$TARGETPLATFORM scratch
+FROM scratch
 COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md yunikorn-admission-controller /
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-admission-controller" ]

--- a/docker/plugin/Dockerfile
+++ b/docker/plugin/Dockerfile
@@ -14,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM --platform=$TARGETPLATFORM scratch
+FROM scratch
 COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md yunikorn-scheduler-plugin scheduler-config.yaml /
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-scheduler-plugin", "--bind-address=0.0.0.0", "--config=/scheduler-config.yaml" ]

--- a/docker/scheduler/Dockerfile
+++ b/docker/scheduler/Dockerfile
@@ -14,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM --platform=$TARGETPLATFORM scratch
+FROM scratch
 COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md yunikorn-scheduler /
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-scheduler" ]

--- a/docker/webtest/Dockerfile
+++ b/docker/webtest/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Imagestage: use scratch base image
-FROM --platform=$TARGETPLATFORM scratch
+FROM scratch
 COPY --chown=0:0 document/index.html /html/
 COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md web-test-server /
 EXPOSE 9889


### PR DESCRIPTION
### What is this PR for?
 1 warning found:
 - RedundantTargetPlatform: Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior (line 17)
Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior
More info: https://docs.docker.com/go/dockerfile/rule/redundant-target-platform/
Dockerfile:17
```
  15 |     # See the License for the specific language governing permissions and
  16 |     # limitations under the License.
  17 | >>> FROM --platform=$TARGETPLATFORM scratch
  18 |     COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md yunikorn-scheduler /
  19 |     USER 4444:4444
```

from docker version 27.1.1

suggested change: remove `--platform=$TARGETPLATFORM` in dockerfile
ref: https://docs.docker.com/reference/build-checks/redundant-target-platform/#examples

change: 
1. shim: RedundantTargetPlatform
2. web: 
 - RedundantTargetPlatform: Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior (line 32)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 36)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 20)
 - InvalidDefaultArgInFrom: Default value for ARG node:${NODE_VERSION}-alpine results in empty or invalid base image name (line 20)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2799

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
