### PR TITLE
[YUNIKORN-2874] Fix reproducible builds when a release is generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ else
 endif
 
 # Release build requires using parent dir as base for buildroot
-RELEASE_BUILD := $(test -f "$(BASE_DIR)/.gitignore" ; echo $?)
+RELEASE_BUILD := $(test -f "$(BASE_DIR)/.gitignore" ; echo $$?)
 ifeq ($(RELEASE_BUILD),1)
 	DOCKER_BUILDROOT := $(shell cd "$(BASE_DIR)/.." ; pwd)
 	DOCKER_SRCROOT := /buildroot/k8shim

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ endif
 
 # Make sure we are in the same directory as the Makefile
 BASE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-PARENT_DIR := $(dir $(abspath $(BASE_DIR)/..))
 
 # Output directories
 OUTPUT=build


### PR DESCRIPTION
### What is this PR for?
Ensure that the parent directory (containing the core and SI) is mounted into the Docker build when generating reproducible builds in release mode.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2874

### How should this be tested?
Verified manually by applying this patch to a release tarball. When .gitignore is not detected, we mount the parent directory into the Docker build environment rather than just the shim dir.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
