### PR TITLE
[YUNIKORN-2892] Log correct log for terminate type when releasing tas…

### DIFF
--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -496,7 +496,7 @@ func (task *Task) beforeTaskCompleted() {
 func (task *Task) releaseAllocation() {
 	// We need to get the termination type from the task, when it is "" we default to the normal termination.
 	// We should log it correctly instead of "" in the logs.
-	terminationType := string(common.GetTerminationTypeFromString(task.terminationType))
+	terminationType := common.GetTerminationTypeFromString(task.terminationType)
 
 	// scheduler api might be nil in some tests
 	if task.context.apiProvider.GetAPIs().SchedulerAPI != nil {
@@ -506,7 +506,7 @@ func (task *Task) releaseAllocation() {
 			zap.String("taskAlias", task.alias),
 			zap.String("allocationKey", task.allocationKey),
 			zap.String("task", task.GetTaskState()),
-			zap.String("terminationType", terminationType))
+			zap.String("terminationType", string(terminationType)))
 
 		// send an AllocationReleaseRequest
 		var releaseRequest *si.AllocationRequest

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -494,8 +494,6 @@ func (task *Task) beforeTaskCompleted() {
 
 // releaseAllocation sends the release request for the Allocation to the core.
 func (task *Task) releaseAllocation() {
-	// We need to get the termination type from the task, when it is "" we default to the normal termination.
-	// We should log it correctly instead of "" in the logs.
 	terminationType := common.GetTerminationTypeFromString(task.terminationType)
 
 	// scheduler api might be nil in some tests

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -494,6 +494,10 @@ func (task *Task) beforeTaskCompleted() {
 
 // releaseAllocation sends the release request for the Allocation to the core.
 func (task *Task) releaseAllocation() {
+	// We need to get the termination type from the task, when it is "" we default to the normal termination.
+	// We should log it correctly instead of "" in the logs.
+	terminationType := string(common.GetTerminationTypeFromString(task.terminationType))
+
 	// scheduler api might be nil in some tests
 	if task.context.apiProvider.GetAPIs().SchedulerAPI != nil {
 		log.Log(log.ShimCacheTask).Debug("prepare to send release request",
@@ -502,7 +506,7 @@ func (task *Task) releaseAllocation() {
 			zap.String("taskAlias", task.alias),
 			zap.String("allocationKey", task.allocationKey),
 			zap.String("task", task.GetTaskState()),
-			zap.String("terminationType", task.terminationType))
+			zap.String("terminationType", terminationType))
 
 		// send an AllocationReleaseRequest
 		var releaseRequest *si.AllocationRequest
@@ -526,7 +530,7 @@ func (task *Task) releaseAllocation() {
 			task.applicationID,
 			task.taskID,
 			task.application.partition,
-			task.terminationType,
+			terminationType,
 		)
 
 		if releaseRequest.Releases != nil {

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -121,13 +121,13 @@ func GetTerminationTypeFromString(terminationTypeStr string) si.TerminationType 
 	return si.TerminationType_STOPPED_BY_RM
 }
 
-func CreateReleaseRequestForTask(appID, taskID, partition, terminationType string) *si.AllocationRequest {
+func CreateReleaseRequestForTask(appID, taskID, partition string, terminationType si.TerminationType) *si.AllocationRequest {
 	allocToRelease := make([]*si.AllocationRelease, 1)
 	allocToRelease[0] = &si.AllocationRelease{
 		ApplicationID:   appID,
 		AllocationKey:   taskID,
 		PartitionName:   partition,
-		TerminationType: GetTerminationTypeFromString(terminationType),
+		TerminationType: terminationType,
 		Message:         "task completed",
 	}
 

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -390,3 +390,28 @@ func TestCreateAllocationForTask(t *testing.T) {
 	assert.Equal(t, tags[common.DomainK8s+common.GroupMeta+"podName"], podName1)
 	assert.Equal(t, alloc1.Priority, int32(100))
 }
+
+// TestGetTerminationTypeFromString tests the GetTerminationTypeFromString function.
+func TestGetTerminationTypeFromString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected si.TerminationType
+	}{
+		{"UNKNOWN_TERMINATION_TYPE", si.TerminationType_UNKNOWN_TERMINATION_TYPE},
+		{"STOPPED_BY_RM", si.TerminationType_STOPPED_BY_RM},
+		{"TIMEOUT", si.TerminationType_TIMEOUT},
+		{"PREEMPTED_BY_SCHEDULER", si.TerminationType_PREEMPTED_BY_SCHEDULER},
+		{"PLACEHOLDER_REPLACED", si.TerminationType_PLACEHOLDER_REPLACED},
+		{"INVALID_TYPE", si.TerminationType_STOPPED_BY_RM},
+		{"", si.TerminationType_STOPPED_BY_RM},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result := GetTerminationTypeFromString(test.input)
+			if result != test.expected {
+				t.Errorf("For input '%s', expected %v, got %v", test.input, test.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -32,7 +32,7 @@ const nodeID = "node-01"
 
 func TestCreateReleaseRequestForTask(t *testing.T) {
 	// with allocationKey
-	request := CreateReleaseRequestForTask("app01", "task01", "default", "STOPPED_BY_RM")
+	request := CreateReleaseRequestForTask("app01", "task01", "default", si.TerminationType_STOPPED_BY_RM)
 	assert.Assert(t, request.Releases != nil)
 	assert.Assert(t, request.Releases.AllocationsToRelease != nil)
 	assert.Equal(t, len(request.Releases.AllocationsToRelease), 1)
@@ -41,7 +41,7 @@ func TestCreateReleaseRequestForTask(t *testing.T) {
 	assert.Equal(t, request.Releases.AllocationsToRelease[0].PartitionName, "default")
 	assert.Equal(t, request.Releases.AllocationsToRelease[0].TerminationType, si.TerminationType_STOPPED_BY_RM)
 
-	request = CreateReleaseRequestForTask("app01", "task01", "default", "UNKNOWN_TERMINATION_TYPE")
+	request = CreateReleaseRequestForTask("app01", "task01", "default", si.TerminationType_UNKNOWN_TERMINATION_TYPE)
 	assert.Assert(t, request.Releases != nil)
 	assert.Assert(t, request.Releases.AllocationsToRelease != nil)
 	assert.Equal(t, len(request.Releases.AllocationsToRelease), 1)


### PR DESCRIPTION
…k from shim side

### What is this PR for?
Now we will log empty terminate type when releasing task from shim side, we should improve this to consistent with the real terminate type.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-289
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
