### PR TITLE
[YUNIKORN-2844] Inject event recorder externally

### DIFF
--- a/pkg/common/events/recorder_test.go
+++ b/pkg/common/events/recorder_test.go
@@ -23,15 +23,10 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-
-	"github.com/apache/yunikorn-k8shim/pkg/conf"
 )
 
 func TestInit(t *testing.T) {
 	// simply test the get won't fail
-	// which means the get function honors the testMode and
-	// skips initiating a real event recorder
-	conf.GetSchedulerConf().SetTestMode(true)
 	recorder := GetRecorder()
-	assert.Equal(t, reflect.TypeOf(recorder).String(), "*events.FakeRecorder")
+	assert.Equal(t, reflect.TypeOf(recorder).String(), "*events.MockedRecorder")
 }


### PR DESCRIPTION
### What is this PR for?
Don't create the event recorder inside `GetRecorder()` because it has to call `IsTestMode()`. Afthis this PR, we can remove that method.
Instead, use a mock recorder by default, then inject the real one when YuniKorn starts.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2844

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
