### PR TITLE
[YUNIKORN-2879] [shim] yunikorn unschedulable pods pending forever

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -20,6 +20,7 @@ package constants
 
 import (
 	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
+	"time"
 )
 
 // Common
@@ -56,6 +57,9 @@ const DefaultAppNamespace = "default"
 const DefaultUserLabel = DomainYuniKorn + "username"
 const DefaultUser = "nobody"
 
+const DefaultTaskRetryTimeInterval = 5 * time.Second
+const DefaultTaskRetryNum = 5
+
 // Spark
 const SparkLabelAppID = "spark-app-selector"
 
@@ -86,6 +90,9 @@ const SchedulingPolicyTimeoutParam = "placeholderTimeoutInSeconds"
 const SchedulingPolicyParamDelimiter = " "
 const SchedulingPolicyStyleParam = "gangSchedulingStyle"
 const SchedulingPolicyStyleParamDefault = "Soft"
+
+const AnnotationTaskRetryName = DomainYuniKorn + "task-retry-num"
+const AnnotationTaskRetryIntervalName = DomainYuniKorn + "task-retry-interval"
 
 var SchedulingPolicyStyleParamValues = map[string]string{"Hard": "Hard", "Soft": "Soft"}
 

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -462,6 +462,24 @@ func GetTaskGroupFromPodSpec(pod *v1.Pod) string {
 	return GetPodAnnotationValue(pod, constants.AnnotationTaskGroupName)
 }
 
+func GetTaskRetryNumFromPodSpec(pod *v1.Pod) int {
+	if value := GetPodAnnotationValue(pod, constants.AnnotationTaskRetryName); value != "" {
+		if v, err := strconv.Atoi(value); err == nil {
+			return v
+		}
+	}
+	return constants.DefaultTaskRetryNum
+}
+
+func GetTaskRetryTimeIntervalFromPodSpec(pod *v1.Pod) time.Duration {
+	if value := GetPodAnnotationValue(pod, constants.AnnotationTaskRetryIntervalName); value != "" {
+		if v, err := time.ParseDuration(value); err == nil {
+			return v
+		}
+	}
+	return constants.DefaultTaskRetryTimeInterval
+}
+
 func GetPlaceholderFlagFromPodSpec(pod *v1.Pod) bool {
 	if value := GetPodAnnotationValue(pod, constants.AnnotationPlaceholderFlag); value != "" {
 		if v, err := strconv.ParseBool(value); err == nil {


### PR DESCRIPTION
* task postfail or rejected reschedule

### What is this PR for?
when task fail, yunikorn unschedulable pods pending forever,introduce retry

### What type of PR is it?
* [ ] - Bug Fix
* [√ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
Issue associated with this PR：https://issues.apache.org/jira/browse/YUNIKORN-2879


### How should this be tested?
test cases
### Screenshots (if appropriate)
task fail to retry
![image](https://github.com/user-attachments/assets/a916a60e-952e-4523-83a0-4df06938fc3a)
after retry, bind successful
![image](https://github.com/user-attachments/assets/580f15ad-cf44-4591-b0fe-193b3b9dfb42)


### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
