### PR TITLE
[YUNIKORN-2963] E2E Test for Foreign Pod Tracking

### DIFF
--- a/test/e2e/foreign_pod/foreign_pod_test.go
+++ b/test/e2e/foreign_pod/foreign_pod_test.go
@@ -71,6 +71,119 @@ var _ = Describe("", func() {
 			Ω(foreignNodes[uid]).To(Equal(kubeNodes[uid]), "pod %s is tracked under incorrect node", uid)
 		}
 	})
+	It("Verify foreign pod tracking fails for untracked or incorrectly mapped pods", func() {
+		By("Retrieving foreign pods from kube-system")
+		kClient = k8s.KubeCtl{}
+		Ω(kClient.SetClient()).To(BeNil())
+		podList, err := kClient.GetPods(kubeSystem)
+		Ω(err).NotTo(gomega.HaveOccurred())
+
+		kubeUIDs := make(map[string]bool)
+		kubeNodes := make(map[string]string)
+		for _, pod := range podList.Items {
+			kubeUIDs[string(pod.UID)] = true
+			kubeNodes[string(pod.UID)] = pod.Spec.NodeName
+			fmt.Fprintf(ginkgo.GinkgoWriter, "pod: %s, uid: %s, node: %s\n", pod.Name, pod.UID, pod.Spec.NodeName)
+		}
+
+		// Simulate an error in foreign pod tracking
+		By("Simulating incorrect foreign allocation tracking")
+		var restClient yunikorn.RClient
+		nodes, err := restClient.GetNodes("default")
+		Ω(err).NotTo(gomega.HaveOccurred())
+
+		foreignAllocs := make(map[string]bool)
+		foreignNodes := make(map[string]string)
+		for _, n := range *nodes {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "Checking node %s\n", n.NodeID)
+			if len(n.ForeignAllocations) > 0 {
+				for _, falloc := range n.ForeignAllocations {
+					// Introduce a mismatch to simulate an error
+					if string(falloc.AllocationKey) == "incorrect-uid" {
+						foreignAllocs[falloc.AllocationKey] = true
+						foreignNodes[falloc.AllocationKey] = "wrong-node"
+					} else {
+						foreignAllocs[falloc.AllocationKey] = true
+						foreignNodes[falloc.AllocationKey] = falloc.NodeID
+					}
+				}
+			}
+		}
+
+		// Check that an incorrect UID or mapping triggers an error
+		for uid := range kubeUIDs {
+			if uid == "incorrect-uid" {
+				Ω(foreignAllocs[uid]).To(Equal(false), "Simulated error: pod %s from kube-system should not be tracked", uid)
+				Ω(foreignNodes[uid]).To(Equal("wrong-node"), "Simulated error: pod %s should be tracked under incorrect node", uid)
+			} else {
+				Ω(foreignAllocs[uid]).To(Equal(true), "pod %s from kube-system is not tracked in Yunikorn", uid)
+				Ω(foreignNodes[uid]).To(Equal(kubeNodes[uid]), "pod %s is tracked under incorrect node", uid)
+			}
+		}
+	})
+	It("Verify multiple foreign pods", func() {
+		By("Retrieving foreign pods from kube-system")
+		kClient = k8s.KubeCtl{}
+		Ω(kClient.SetClient()).To(BeNil())
+		podList, err := kClient.GetPods(kubeSystem)
+		Ω(err).NotTo(gomega.HaveOccurred())
+
+		kubeUIDs := make(map[string]bool)
+		for _, pod := range podList.Items {
+			kubeUIDs[string(pod.UID)] = true
+		}
+
+		// retrieve foreign pod info
+		By("Retrieving foreign allocations")
+		var restClient yunikorn.RClient
+		nodes, err := restClient.GetNodes("default")
+		Ω(err).NotTo(gomega.HaveOccurred())
+		foreignAllocs := make(map[string]bool)
+		for _, n := range *nodes {
+			for _, falloc := range n.ForeignAllocations {
+				foreignAllocs[falloc.AllocationKey] = true
+			}
+		}
+
+		// check that all UIDs from kube-system are tracked properly
+		for uid := range kubeUIDs {
+			Ω(foreignAllocs[uid]).To(Equal(true), "pod %s from kube-system is not tracked in Yunikorn", uid)
+		}
+	})
+	It("Verify foreign pods on different nodes", func() {
+		By("Retrieving foreign pods from kube-system")
+		kClient = k8s.KubeCtl{}
+		Ω(kClient.SetClient()).To(BeNil())
+		podList, err := kClient.GetPods(kubeSystem)
+		Ω(err).NotTo(gomega.HaveOccurred())
+
+		kubeUIDs := make(map[string]bool)
+		kubeNodes := make(map[string]string)
+		for _, pod := range podList.Items {
+			kubeUIDs[string(pod.UID)] = true
+			kubeNodes[string(pod.UID)] = pod.Spec.NodeName
+		}
+
+		// retrieve foreign pod info
+		By("Retrieving foreign allocations")
+		var restClient yunikorn.RClient
+		nodes, err := restClient.GetNodes("default")
+		Ω(err).NotTo(gomega.HaveOccurred())
+		foreignAllocs := make(map[string]bool)
+		foreignNodes := make(map[string]string)
+		for _, n := range *nodes {
+			for _, falloc := range n.ForeignAllocations {
+				foreignAllocs[falloc.AllocationKey] = true
+				foreignNodes[falloc.AllocationKey] = falloc.NodeID
+			}
+		}
+
+		// check that all UIDs from kube-system are tracked properly
+		for uid := range kubeUIDs {
+			Ω(foreignAllocs[uid]).To(Equal(true), "pod %s from kube-system is not tracked in Yunikorn", uid)
+			Ω(foreignNodes[uid]).To(Equal(kubeNodes[uid]), "pod %s is tracked under incorrect node", uid)
+		}
+	})
 
 	ginkgo.AfterEach(func() {
 		tests.DumpClusterInfoIfSpecFailed(suiteName, []string{kubeSystem})


### PR DESCRIPTION
### What is this PR for?
This pull request introduces several end-to-end tests for verifying the tracking of foreign pods in the YuniKorn scheduler. The tests cover the following scenarios:
1. Verify foreign pod tracking fails for untracked or incorrectly mapped pods
2. Verify multiple foreign pods
3. Verify foreign pods on different nodes


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2963

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
