### PR TITLE
Remove extra text from license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -174,33 +174,6 @@
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
 --------------------------------------------------------------------------------
 This product bundles various third-party components under other open source
 licenses. This section summarizes those components and their licenses.


### PR DESCRIPTION
The Apache 2.0 license on the website shows that it ends after "END OF TERMS AND CONDITIONS" https://www.apache.org/licenses/LICENSE-2.0

<img width="1401" alt="387383537-f56c8594-5c32-41d5-a5b7-f4a587125ca2" src="https://github.com/user-attachments/assets/ca29c9a4-b520-401f-9e6c-ce2b3464e942">

This text exists because it's been mistakenly copied and pasted from https://www.apache.org/licenses/LICENSE-2.0.txt where it includes placeholder text and the intent seems to be reproducing the application instructions as seen on https://www.apache.org/licenses/LICENSE-2.0 rather than as text that's intended to be included in the license.

The text removed in this PR diverges slightly from the text on https://www.apache.org/licenses/LICENSE-2.0#apply

> How to apply the Apache License to your work
>
> Include a copy of the Apache License, typically in a file called LICENSE, in your work, and consider also including a NOTICE file that references the License.
>
> To apply the Apache License to specific files in your work, attach the following boilerplate declaration, replacing the fields enclosed by brackets "[]" with your own identifying information. (Don't include the brackets!) Enclose the text in the appropriate comment syntax for the file format. We also recommend that you include a file or class name and description of purpose on the same "printed page" as the copyright notice for easier identification within third-party archives.

The text on the website ⬆️  seems to indicate that placing the Apache 2.0 license text in a `LICENSE` is sufficient for a project. The text given in the text file ⬇️  does not mention a LICENSE file and instead seems to imply that the full text of the Apache 2.0 license is not required, but use the "boilerplate" after swapping out the placeholders.

Looking at other high profile projects that use the Apache 2.0 license it looks like their understanding matches mine, here's Rust https://github.com/rust-lang/rust/blob/fda68927475070696fcc9d1f5c9c990f0e1af87a/LICENSE-APACHE. Here's a discussion from 5 years ago on whether to remove the appendix from there https://github.com/rust-lang/rust/pull/67734.

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - http://yunikorn.apache.org/community/how_to_contribute   


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
