### PR TITLE
[YUNIKORN-3031] Add support for .spec.schedulingGates

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -336,6 +336,7 @@ func (ctx *Context) updateYuniKornPod(appID string, oldPod, pod *v1.Pod) {
 		log.Log(log.ShimContext).Info("pod is waiting for scheduling gates", zap.String("name", pod.Name), zap.Strings("gates", gates))
 	}
 
+	// always call UpdatePod() first to make sure the pod instance is the latest in the cache
 	if ctx.schedulerCache.UpdatePod(pod) && !hasGates {
 		// pod was accepted; ensure the application and task objects have been created
 		ctx.ensureAppAndTaskCreated(pod, app)

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -202,7 +202,7 @@ func (ctx *Context) updateNodeInternal(node *v1.Node, register bool) {
 			if applicationID == "" {
 				ctx.updateForeignPod(pod)
 			} else {
-				ctx.updateYuniKornPod(applicationID, pod)
+				ctx.updateYuniKornPod(applicationID, nil, pod)
 			}
 		}
 
@@ -284,7 +284,7 @@ func (ctx *Context) AddPod(obj interface{}) {
 	ctx.UpdatePod(nil, obj)
 }
 
-func (ctx *Context) UpdatePod(_, newObj interface{}) {
+func (ctx *Context) UpdatePod(oldObj, newObj interface{}) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 	pod, err := utils.Convert2Pod(newObj)
@@ -292,15 +292,23 @@ func (ctx *Context) UpdatePod(_, newObj interface{}) {
 		log.Log(log.ShimContext).Error("failed to update pod", zap.Error(err))
 		return
 	}
+	var oldPod *v1.Pod
+	if oldObj != nil {
+		oldPod, err = utils.Convert2Pod(oldObj)
+		if err != nil {
+			log.Log(log.ShimContext).Error("failed to update pod", zap.Error(err))
+			return
+		}
+	}
 	applicationID := utils.GetApplicationIDFromPod(pod)
 	if applicationID == "" {
 		ctx.updateForeignPod(pod)
 	} else {
-		ctx.updateYuniKornPod(applicationID, pod)
+		ctx.updateYuniKornPod(applicationID, oldPod, pod)
 	}
 }
 
-func (ctx *Context) updateYuniKornPod(appID string, pod *v1.Pod) {
+func (ctx *Context) updateYuniKornPod(appID string, oldPod, pod *v1.Pod) {
 	taskID := string(pod.UID)
 	app := ctx.getApplication(appID)
 	if app != nil {
@@ -317,7 +325,18 @@ func (ctx *Context) updateYuniKornPod(appID string, pod *v1.Pod) {
 		return
 	}
 
-	if ctx.schedulerCache.UpdatePod(pod) {
+	hasGates := len(pod.Spec.SchedulingGates) > 0
+	if hasGates && oldPod == nil {
+		gates := make([]string, 0, len(pod.Spec.SchedulingGates))
+		for _, gate := range pod.Spec.SchedulingGates {
+			gates = append(gates, gate.Name)
+		}
+		events.GetRecorder().Eventf(pod.DeepCopy(), nil, v1.EventTypeNormal, "Scheduling", "Scheduling",
+			"waiting for scheduling gates: %s", strings.Join(gates, ","))
+		log.Log(log.ShimContext).Info("pod is waiting for scheduling gates", zap.String("name", pod.Name), zap.Strings("gates", gates))
+	}
+
+	if ctx.schedulerCache.UpdatePod(pod) && !hasGates {
 		// pod was accepted; ensure the application and task objects have been created
 		ctx.ensureAppAndTaskCreated(pod, app)
 	}


### PR DESCRIPTION
### What is this PR for?
Add support for `.spec.schedulingGates`. Pod is not scheduled as long as there is at least one gate defined.


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3031

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
