### PR TITLE
Bump go to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,9 +18,7 @@
 
 module github.com/apache/yunikorn-k8shim
 
-go 1.22.0
-
-toolchain go1.22.5
+go 1.23
 
 require (
 	github.com/apache/yunikorn-core v0.0.0-20241114184223-ac32595a9712


### PR DESCRIPTION
### What is this PR for?
Bump go version to 1.23 for shim. I forgot to update go.mod here: https://github.com/apache/yunikorn-k8shim/pull/950/files


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3037

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
