### PR TITLE
[YUNIKORN-2850] Watch configmap only in yunikorn's deployed namespace

### DIFF
--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -91,12 +91,12 @@ type APIFactory struct {
 
 func NewAPIFactory(scheduler api.SchedulerAPI, informerFactory informers.SharedInformerFactory, configs *conf.SchedulerConf, testMode bool) *APIFactory {
 	kubeClient := NewKubeClient(configs.KubeConfig)
-
+	namespaceInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient.GetClientSet(), 0, informers.WithNamespace(configs.Namespace))
 	// init informers
 	// volume informers are also used to get the Listers for the predicates
 	podInformer := informerFactory.Core().V1().Pods()
 	nodeInformer := informerFactory.Core().V1().Nodes()
-	configMapInformer := informerFactory.Core().V1().ConfigMaps()
+	configMapInformer := namespaceInformerFactory.Core().V1().ConfigMaps()
 	pvInformer := informerFactory.Core().V1().PersistentVolumes()
 	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
 	storageInformer := informerFactory.Storage().V1().StorageClasses()


### PR DESCRIPTION
### What is this PR for?
Currently, Yunikorn uses configmap informer to handle configuration hot reload.

However, In current implementation informer watches all namespaces even only need to watch namespace in which yunikorn is deployed. It causes in efficient behavior when sync and cache configmap states. If there is too many unrelated configmap in other namespace cause long recovery time to list and memory presure to handle configmap caches which is redundant.

So, If we could replace configmap informer to namespace restricted one, it would improve startup / recovery time and reduce memory usage.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2850
