### PR TITLE
[YUNIKORN-3039] Add support for pod-level resource requests

### DIFF
--- a/pkg/cmd/schedulerplugin/main.go
+++ b/pkg/cmd/schedulerplugin/main.go
@@ -24,9 +24,12 @@ import (
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 
 	"github.com/apache/yunikorn-k8shim/pkg/plugin"
+	"github.com/apache/yunikorn-k8shim/pkg/plugin/predicates"
 )
 
 func main() {
+	predicates.EnableOptionalKubernetesFeatureGates()
+
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(plugin.SchedulerPluginName, plugin.NewSchedulerPlugin))
 

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/apache/yunikorn-k8shim/pkg/client"
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/yunikorn-k8shim/pkg/plugin/predicates"
 
 	"github.com/apache/yunikorn-core/pkg/entrypoint"
 	"github.com/apache/yunikorn-k8shim/pkg/conf"
@@ -36,6 +37,8 @@ import (
 
 func main() {
 	log.Log(log.Shim).Info(conf.GetBuildInfoString())
+
+	predicates.EnableOptionalKubernetesFeatureGates()
 
 	configMaps, err := client.LoadBootstrapConfigMaps()
 	if err != nil {

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -27,6 +27,7 @@ import (
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8res "k8s.io/component-helpers/resource"
 
+	"github.com/apache/yunikorn-k8shim/pkg/plugin/predicates"
 	siCommon "github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
@@ -373,8 +374,73 @@ func siResourceFromList(list v1.ResourceList) *si.Resource {
 	return builder.Build()
 }
 
+func TestGetPodResourcesWithPodLevelRequests(t *testing.T) {
+	// ensure required K8s feature gates are enabled
+	predicates.EnableOptionalKubernetesFeatureGates()
+
+	containers := make([]v1.Container, 0)
+
+	// container 01
+	c1Resources := make(map[v1.ResourceName]resource.Quantity)
+	c1Resources[v1.ResourceMemory] = resource.MustParse("500M")
+	c1Resources[v1.ResourceCPU] = resource.MustParse("1")
+	c1Resources["nvidia.com/gpu"] = resource.MustParse("1")
+	containers = append(containers, v1.Container{
+		Name: "container-01",
+		Resources: v1.ResourceRequirements{
+			Requests: c1Resources,
+		},
+	})
+
+	// container 02
+	c2Resources := make(map[v1.ResourceName]resource.Quantity)
+	c2Resources[v1.ResourceMemory] = resource.MustParse("1024M")
+	c2Resources[v1.ResourceCPU] = resource.MustParse("2")
+	c2Resources["nvidia.com/gpu"] = resource.MustParse("4")
+	containers = append(containers, v1.Container{
+		Name: "container-02",
+		Resources: v1.ResourceRequirements{
+			Requests: c2Resources,
+		},
+	})
+
+	// pod
+	pod := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name: "pod-resource-test-00001",
+			UID:  "UID-00001",
+		},
+		Spec: v1.PodSpec{
+			Resources: &v1.ResourceRequirements{
+				Requests: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceMemory: resource.MustParse("128M"),
+					v1.ResourceCPU:    resource.MustParse("5"),
+					"invalid":         resource.MustParse("1"),
+				},
+			},
+			Containers: containers,
+		},
+	}
+
+	// verify cpu and memory overrides
+	res := GetPodResource(pod)
+	assert.Equal(t, res.Resources[siCommon.Memory].GetValue(), int64(128*1000*1000))
+	assert.Equal(t, res.Resources[siCommon.CPU].GetValue(), int64(5000))
+	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
+	assert.Equal(t, res.Resources["pods"].GetValue(), int64(1))
+	_, invalidOk := res.Resources["invalid"]
+	assert.Assert(t, !invalidOk, "invalid should not be present")
+}
+
 //nolint:funlen
 func TestGetPodResourcesWithInPlacePodVerticalScaling(t *testing.T) {
+	// ensure required K8s feature gates are enabled
+	predicates.EnableOptionalKubernetesFeatureGates()
+
 	containers := make([]v1.Container, 0)
 
 	// container 01

--- a/pkg/plugin/predicates/predicate_manager_test.go
+++ b/pkg/plugin/predicates/predicate_manager_test.go
@@ -29,10 +29,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
@@ -1105,6 +1107,12 @@ func newPodWithPort(hostPorts ...int) *v1.Pod {
 			},
 		},
 	}
+}
+
+func TestEnableOptionalKubernetesFeatureGates(t *testing.T) {
+	EnableOptionalKubernetesFeatureGates()
+	assert.Assert(t, feature.DefaultFeatureGate.Enabled(features.PodLevelResources), "pod level resources not enabled")
+	assert.Assert(t, feature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling), "in-place pod vertical scaling not enabled")
 }
 
 func TestRunGeneralPredicates(t *testing.T) {

--- a/scripts/kind-1.32.yaml
+++ b/scripts/kind-1.32.yaml
@@ -19,6 +19,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   "InPlacePodVerticalScaling": true
+  "PodLevelResources": true
 nodes:
   - role: control-plane
   - role: worker

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -47,12 +47,12 @@ function verlt() {
 function update_kind_config() {
   # use a different kind config for different cluster versions
   version=$(echo "$1" | sed 's/.*://' | sed 's/^v//')
-  if verlt "${version}" "1.27"; then
-    # 1.26 or earlier
+  if verlt "${version}" "1.32"; then
+    # 1.31 or earlier
     KIND_CONFIG=./scripts/kind.yaml
   else
-    # 1.27 or later; enable InPlacePodVerticalScaling feature flag
-    KIND_CONFIG=./scripts/kind-pod-resize.yaml
+    # 1.32 or later; enable InPlacePodVerticalScaling and PodLevelResources feature flags
+    KIND_CONFIG=./scripts/kind-1.32.yaml
   fi
 }
 


### PR DESCRIPTION
### What is this PR for?
Kubernetes v1.32 adds alpha-level support for pod-level resource specifications. Add support for this feature in YuniKorn to ensure that our calculations match what Kubernetes uses.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3039

### How should this be tested?
Unit tests added as well as manual testing on a 1.32 cluster with alpha features enabled.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
