### PR TITLE
[YUNIKORN-2811] Warn if a pod has inconsistent metadata in the shim

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -392,6 +392,9 @@ func (app *Application) scheduleTasks(taskScheduleCondition func(t *Task) bool) 
 		if taskScheduleCondition(task) {
 			// for each new task, we do a sanity check before moving the state to Pending_Schedule
 			if err := task.sanityCheckBeforeScheduling(); err == nil {
+				// check inconsistent pod metadata before submitting the task
+				task.checkPodMetadataBeforeScheduling()
+
 				// note, if we directly trigger submit task event, it may spawn too many duplicate
 				// events, because a task might be submitted multiple times before its state transits to PENDING.
 				if handleErr := task.handle(

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -21,7 +21,6 @@ package utils
 import (
 	"bytes"
 	"compress/gzip"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -724,159 +723,30 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 	}
 }
 
-func TestCheckAppIdInPod(t *testing.T) {
-	testCases := []struct {
-		name     string
-		pod      *v1.Pod
-		expected error
-	}{
-		{
-			name: "consistent app ID",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						constants.CanonicalLabelApplicationID: "app-123",
-						constants.SparkLabelAppID:             "app-123",
-						constants.LabelApplicationID:          "app-123",
-					},
-					Annotations: map[string]string{
-						constants.AnnotationApplicationID: "app-123",
-					},
-				},
-			},
-			expected: nil,
-		},
-		{
-			name: "inconsistent app ID in labels",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						constants.CanonicalLabelApplicationID: "app-123",
-						constants.SparkLabelAppID:             "app-456",
-					},
-				},
-			},
-			expected: errors.New("label spark-app-selector: \"app-456\" doesn't match label yunikorn.apache.org/app-id: \"app-123\""),
-		},
-		{
-			name: "inconsistent app ID between label and annotation",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						constants.CanonicalLabelApplicationID: "app-123",
-					},
-					Annotations: map[string]string{
-						constants.AnnotationApplicationID: "app-456",
-					},
-				},
-			},
-			expected: errors.New("annotation yunikorn.apache.org/app-id: \"app-456\" doesn't match label yunikorn.apache.org/app-id: \"app-123\""),
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := CheckAppIdInPod(tc.pod)
-			if tc.expected != nil {
-				assert.ErrorContains(t, err, tc.expected.Error())
-			} else {
-				assert.NilError(t, err)
-			}
-		})
-	}
-}
-
-func TestCheckQueueNameInPod(t *testing.T) {
-	testCases := []struct {
-		name     string
-		pod      *v1.Pod
-		expected error
-	}{
-		{
-			name: "consistent queue name",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						constants.CanonicalLabelQueueName: "root.a",
-						constants.LabelQueueName:          "root.a",
-					},
-					Annotations: map[string]string{
-						constants.AnnotationQueueName: "root.a",
-					},
-				},
-			},
-			expected: nil,
-		},
-		{
-			name: "inconsistent app ID in labels",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						constants.CanonicalLabelQueueName: "root.a",
-						constants.LabelQueueName:          "root.b",
-					},
-				},
-			},
-			expected: errors.New("label queue: \"root.b\" doesn't match label yunikorn.apache.org/queue: \"root.a\""),
-		},
-		{
-			name: "inconsistent app ID between label and annotation",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						constants.CanonicalLabelQueueName: "root.a",
-					},
-					Annotations: map[string]string{
-						constants.AnnotationQueueName: "root.b",
-					},
-				},
-			},
-			expected: errors.New("annotation yunikorn.apache.org/queue: \"root.b\" doesn't match label yunikorn.apache.org/queue: \"root.a\""),
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := CheckQueueNameInPod(tc.pod)
-			if tc.expected != nil {
-				assert.ErrorContains(t, err, tc.expected.Error())
-			} else {
-				assert.NilError(t, err)
-			}
-		})
-	}
-}
-
-func TestValidatePodLabelAnnotation(t *testing.T) {
+func TestGetIgnoredLabelAnnotationInPod(t *testing.T) {
 	labelKeys := []string{"labelKey1", "labelKey2"}
 	annotationKeys := []string{"annotationKey1", "annotationKey2"}
 
 	testCases := []struct {
-		name     string
-		pod      *v1.Pod
-		expected error
+		name                      string
+		pod                       *v1.Pod
+		currentValue              string
+		labelKeys                 []string
+		annotationKeys            []string
+		expectedIgnoredLabel      map[string]string
+		expectedIgnoredAnnotation map[string]string
 	}{
 		{
-			name:     "empty pod",
-			pod:      &v1.Pod{},
-			expected: nil,
+			name:                      "empty pod",
+			pod:                       &v1.Pod{},
+			currentValue:              "",
+			labelKeys:                 labelKeys,
+			annotationKeys:            annotationKeys,
+			expectedIgnoredLabel:      map[string]string{},
+			expectedIgnoredAnnotation: map[string]string{},
 		},
 		{
-			name: "pod with all values are consistent",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"labelKey1": "value1",
-						"labelKey2": "value1",
-					},
-					Annotations: map[string]string{
-						"annotationKey1": "value1",
-						"annotationKey2": "value1",
-					},
-				},
-			},
-			expected: nil,
-		},
-		{
-			name: "pod with inconsistent value in labels",
+			name: "have ignored label",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -885,24 +755,14 @@ func TestValidatePodLabelAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expected: errors.New("label labelKey2: \"value2\" doesn't match label labelKey1: \"value1\""),
+			currentValue:              "value1",
+			labelKeys:                 labelKeys,
+			annotationKeys:            annotationKeys,
+			expectedIgnoredLabel:      map[string]string{"labelKey2": "value2"},
+			expectedIgnoredAnnotation: map[string]string{},
 		},
 		{
-			name: "pod with inconsistent value between label and annotation",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"labelKey1": "value1",
-					},
-					Annotations: map[string]string{
-						"annotationKey1": "value2",
-					},
-				},
-			},
-			expected: errors.New("annotation annotationKey1: \"value2\" doesn't match label labelKey1: \"value1\""),
-		},
-		{
-			name: "pod with inconsistent value in annotations",
+			name: "have ignored annotation",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -911,18 +771,39 @@ func TestValidatePodLabelAnnotation(t *testing.T) {
 					},
 				},
 			},
-			expected: errors.New("annotation annotationKey2: \"value2\" doesn't match annotation annotationKey1: \"value1\""),
+			currentValue:              "value1",
+			labelKeys:                 labelKeys,
+			annotationKeys:            annotationKeys,
+			expectedIgnoredLabel:      map[string]string{},
+			expectedIgnoredAnnotation: map[string]string{"annotationKey2": "value2"},
+		},
+		{
+			name: "have both ignored label and annotation",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"labelKey1": "value1",
+						"labelKey2": "value2",
+					},
+					Annotations: map[string]string{
+						"annotationKey1": "value1",
+						"annotationKey2": "value2",
+					},
+				},
+			},
+			currentValue:              "value1",
+			labelKeys:                 labelKeys,
+			annotationKeys:            annotationKeys,
+			expectedIgnoredLabel:      map[string]string{"labelKey2": "value2"},
+			expectedIgnoredAnnotation: map[string]string{"annotationKey2": "value2"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidatePodLabelAnnotation(tc.pod, labelKeys, annotationKeys)
-			if tc.expected != nil {
-				assert.ErrorContains(t, err, tc.expected.Error())
-			} else {
-				assert.NilError(t, err)
-			}
+			ignoredLabel, ignoredAnnotation := GetIgnoredLabelAnnotationInPod(tc.pod, tc.currentValue, tc.labelKeys, tc.annotationKeys)
+			assert.DeepEqual(t, ignoredLabel, tc.expectedIgnoredLabel)
+			assert.DeepEqual(t, ignoredAnnotation, tc.expectedIgnoredAnnotation)
 		})
 	}
 }


### PR DESCRIPTION
### What is this PR for?
Checks for inconsistent pod metadata in shim before submitting tasks to the scheduler. Log a warning message if metadata is inconsistent.
Log in below format: (Could also check the screenshot below)

- Found multiple 'queue' value in pod. { podName: pod-with-inconsistent-metadata-2, fianlValue: root.sandbox, ignored: [(Annotation) yunikorn.apache.org/queue: dummy-queue-annotation] }


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2811


### How should this be tested?
1. make test
2. set yunikorn config & submit below sleep pod 
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: yunikorn-configs
  namespace: yunikorn
data:
  queues.yaml: |
    partitions:
      - name: default
        queues:
          - name: root
            submitacl: '*'
            queues:
              - name: sandbox
        placementrules:
          - name: provided
            create: true
```
```
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: sleep
    yunikorn.apache.org/app-id: "application-sleep-00001"
    yunikorn.apache.org/queue: "root.sandbox"

    applicationId: "dummy-app-label"
    spark-app-selector: "dummy-app-label-spark"
    queue: "dummy-queue-label"
  annotations:
    yunikorn.apache.org/app-id: "dummy-app-annotation"
    yunikorn.apache.org/queue: "dummy-queue-annotation"
  name: pod-with-inconsistent-metadata
spec:
  schedulerName: yunikorn
  restartPolicy: Never
  containers:
    - name: sleep-6000s
      image: "alpine:latest"
      command: ["sleep", "6000"]
      resources:
        requests:
          cpu: "100m"
          memory: "500M"

---

apiVersion: v1
kind: Pod
metadata:
  labels:
    app: sleep
    yunikorn.apache.org/app-id: "application-sleep-00001"
    yunikorn.apache.org/queue: "root.sandbox"

    queue: "dummy-queue-label"
  annotations:
    yunikorn.apache.org/queue: "dummy-queue-annotation"
  name: pod-with-inconsistent-metadata-2
spec:
  schedulerName: yunikorn
  restartPolicy: Never
  containers:
    - name: sleep-6000s
      image: "alpine:latest"
      command: ["sleep", "6000"]
      resources:
        requests:
          cpu: "100m"
          memory: "500M"

```

3. validate pod event & pod logs

Result: 
(Pod log)
```
2025-04-06T17:42:57.415Z	WARN	shim.cache.task	cache/task.go:566	Found multiple 'app-id' value in pod. { podName: pod-with-inconsistent-metadata, fianlValue: application-sleep-00001, ignored: [(Label) spark-app-selector: dummy-app-label-spark, (Annotation) yunikorn.apache.org/app-id: dummy-app-annotation] }
2025-04-06T17:42:57.415Z	WARN	shim.cache.task	cache/task.go:566	Found multiple 'queue' value in pod. { podName: pod-with-inconsistent-metadata, fianlValue: root.sandbox, ignored: [(Annotation) yunikorn.apache.org/queue: dummy-queue-annotation] }
```
(Event log)
```                                                                                                                                                                        │
│   Type     Reason             Age   From      Message                                                                                                                              │
│   ----     ------             ----  ----      -------                                                                                                                              │
│   Warning  Scheduling         7s    yunikorn  Found multiple 'queue' value in pod. { podName: pod-with-inconsistent-metadata-2, fianlValue: root.sandbox, ignored: [(Annotation) yunikorn.apache.org/queue: dummy-queue-annotation] }
```
```
| Type     Reason             Age                    From      Message
│   ----     ------             ----  ----      -------                                                                                                                              │
│   Warning  Scheduling         9m50s (x2 over 9m50s)  yunikorn  Found multiple 'app-id' value in pod. { podName: pod-with-inconsistent-metadata, fianlValue: application-sleep-00001, ignored: [(Label) spark-app-selector: dummy-app-label-spark, (Annotation) yunikorn.apache.org/app-id: dummy-app-annotation] }
```


### Screenshots (if appropriate)
<img width="1428" alt="image" src="https://github.com/user-attachments/assets/1030a22c-122f-4562-ba57-6d83bb77db7e" />

<img width="1441" alt="image" src="https://github.com/user-attachments/assets/ceeeeaf8-93cb-4e4c-b266-f73859139dc6" />



### Questions:
NA
