### PR TITLE
[YUNIKORN-2981] Support filtering schedulerName

### DIFF
--- a/pkg/admission/admission_controller.go
+++ b/pkg/admission/admission_controller.go
@@ -202,6 +202,8 @@ func (c *AdmissionController) processPod(req *admissionv1.AdmissionRequest, name
 			zap.String("from", pod.Spec.SchedulerName),
 			zap.String("to", constants.SchedulerName))
 		patch = updateSchedulerName(patch)
+	} else if pod.Spec.SchedulerName == "" {
+		patch = updateSchedulerName(patch)
 	}
 
 	if c.shouldLabelNamespace(namespace) {

--- a/pkg/admission/admission_controller.go
+++ b/pkg/admission/admission_controller.go
@@ -198,11 +198,10 @@ func (c *AdmissionController) processPod(req *admissionv1.AdmissionRequest, name
 	// Only override default-scheduler unless override is enabled
 	if pod.Spec.SchedulerName == "default-scheduler" ||
 		(c.conf.GetOverrideCustomSchedulers() && pod.Spec.SchedulerName != constants.SchedulerName) {
+		log.Log(log.Admission).Info("updating scheduler name",
+			zap.String("from", pod.Spec.SchedulerName),
+			zap.String("to", constants.SchedulerName))
 		patch = updateSchedulerName(patch)
-	} else {
-		log.Log(log.Admission).Info("bypassing scheduler name update",
-			zap.String("schedulerName", pod.Spec.SchedulerName),
-			zap.Bool("overrideCustomSchedulers", c.conf.GetOverrideCustomSchedulers()))
 	}
 
 	if c.shouldLabelNamespace(namespace) {

--- a/pkg/admission/admission_controller.go
+++ b/pkg/admission/admission_controller.go
@@ -196,13 +196,12 @@ func (c *AdmissionController) processPod(req *admissionv1.AdmissionRequest, name
 	}
 
 	// Only override default-scheduler unless override is enabled
-	if pod.Spec.SchedulerName == "default-scheduler" ||
-		(c.conf.GetOverrideCustomSchedulers() && pod.Spec.SchedulerName != constants.SchedulerName) {
+	if c.conf.GetOverrideCustomSchedulers() && pod.Spec.SchedulerName != constants.SchedulerName {
 		log.Log(log.Admission).Info("updating scheduler name",
 			zap.String("from", pod.Spec.SchedulerName),
 			zap.String("to", constants.SchedulerName))
 		patch = updateSchedulerName(patch)
-	} else if pod.Spec.SchedulerName == "" {
+	} else if pod.Spec.SchedulerName == "" || pod.Spec.SchedulerName == "default-scheduler" {
 		patch = updateSchedulerName(patch)
 	}
 

--- a/pkg/admission/conf/am_conf.go
+++ b/pkg/admission/conf/am_conf.go
@@ -48,11 +48,13 @@ const (
 	AMWebHookSchedulerServiceAddress = WebHookPrefix + "schedulerServiceAddress"
 
 	// filtering configuration
-	AMFilteringProcessNamespaces    = FilteringPrefix + "processNamespaces"
-	AMFilteringBypassNamespaces     = FilteringPrefix + "bypassNamespaces"
-	AMFilteringLabelNamespaces      = FilteringPrefix + "labelNamespaces"
-	AMFilteringNoLabelNamespaces    = FilteringPrefix + "noLabelNamespaces"
-	AMFilteringGenerateUniqueAppIds = FilteringPrefix + "generateUniqueAppId"
+	AMFilteringProcessNamespaces     = FilteringPrefix + "processNamespaces"
+	AMFilteringBypassNamespaces      = FilteringPrefix + "bypassNamespaces"
+	AMFilteringLabelNamespaces       = FilteringPrefix + "labelNamespaces"
+	AMFilteringNoLabelNamespaces     = FilteringPrefix + "noLabelNamespaces"
+	AMFilteringGenerateUniqueAppIds  = FilteringPrefix + "generateUniqueAppId"
+	AMFilteringProcessSchedulerNames = FilteringPrefix + "processSchedulerNames"
+	AMFilteringBypassSchedulerNames  = FilteringPrefix + "bypassSchedulerNames"
 
 	// access control configuration
 	AMAccessControlBypassAuth       = AccessControlPrefix + "bypassAuth"
@@ -68,11 +70,13 @@ const (
 	DefaultWebHookSchedulerServiceAddress = "yunikorn-service:9080"
 
 	// filtering defaults
-	DefaultFilteringProcessNamespaces    = ""
-	DefaultFilteringBypassNamespaces     = "^kube-system$"
-	DefaultFilteringLabelNamespaces      = ""
-	DefaultFilteringNoLabelNamespaces    = ""
-	DefaultFilteringGenerateUniqueAppIds = false
+	DefaultFilteringProcessNamespaces     = ""
+	DefaultFilteringBypassNamespaces      = "^kube-system$"
+	DefaultFilteringLabelNamespaces       = ""
+	DefaultFilteringNoLabelNamespaces     = ""
+	DefaultFilteringGenerateUniqueAppIds  = false
+	DefaultFilteringProcessSchedulerNames = ""
+	DefaultFilteringBypassSchedulerNames  = ""
 
 	// access control defaults
 	DefaultAccessControlBypassAuth       = false
@@ -96,6 +100,8 @@ type AdmissionControllerConf struct {
 	labelNamespaces         []*regexp.Regexp
 	noLabelNamespaces       []*regexp.Regexp
 	generateUniqueAppIds    bool
+	processSchedulerNames   []*regexp.Regexp
+	bypassSchedulerNames    []*regexp.Regexp
 	bypassAuth              bool
 	trustControllers        bool
 	systemUsers             []*regexp.Regexp
@@ -220,6 +226,18 @@ func (acc *AdmissionControllerConf) GetExternalGroups() []*regexp.Regexp {
 	return acc.externalGroups
 }
 
+func (acc *AdmissionControllerConf) GetProcessSchedulerNames() []*regexp.Regexp {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.processSchedulerNames
+}
+
+func (acc *AdmissionControllerConf) GetBypassSchedulerNames() []*regexp.Regexp {
+	acc.lock.RLock()
+	defer acc.lock.RUnlock()
+	return acc.bypassSchedulerNames
+}
+
 type configMapUpdateHandler struct {
 	conf *AdmissionControllerConf
 }
@@ -315,6 +333,8 @@ func (acc *AdmissionControllerConf) updateConfigMaps(configMaps []*v1.ConfigMap,
 	acc.labelNamespaces = parseConfigRegexps(configs, AMFilteringLabelNamespaces, DefaultFilteringLabelNamespaces)
 	acc.noLabelNamespaces = parseConfigRegexps(configs, AMFilteringNoLabelNamespaces, DefaultFilteringNoLabelNamespaces)
 	acc.generateUniqueAppIds = parseConfigBool(configs, AMFilteringGenerateUniqueAppIds, DefaultFilteringGenerateUniqueAppIds)
+	acc.processSchedulerNames = parseConfigRegexps(configs, AMFilteringProcessSchedulerNames, DefaultFilteringProcessSchedulerNames)
+	acc.bypassSchedulerNames = parseConfigRegexps(configs, AMFilteringBypassSchedulerNames, DefaultFilteringBypassSchedulerNames)
 
 	// access control
 	acc.bypassAuth = parseConfigBool(configs, AMAccessControlBypassAuth, DefaultAccessControlBypassAuth)
@@ -346,6 +366,8 @@ func (acc *AdmissionControllerConf) dumpConfigurationInternal() {
 		zap.Strings("bypassNamespaces", regexpsString(acc.bypassNamespaces)),
 		zap.Strings("labelNamespaces", regexpsString(acc.labelNamespaces)),
 		zap.Strings("noLabelNamespaces", regexpsString(acc.noLabelNamespaces)),
+		zap.Strings("processSchedulerNames", regexpsString(acc.processSchedulerNames)),
+		zap.Strings("bypassSchedulerNames", regexpsString(acc.bypassSchedulerNames)),
 		zap.Bool("bypassAuth", acc.bypassAuth),
 		zap.Bool("trustControllers", acc.trustControllers),
 		zap.Strings("systemUsers", regexpsString(acc.systemUsers)),


### PR DESCRIPTION
### What is this PR for?
Implements scheduler name filtering in Yunikorn's admission controller to support environments with multiple schedulers 

Key changes:
- Added new configuration options:
  - `admissionController.filtering.overrideCustomSchedulers` 
- Modified admission controller logic to:
  - update pod scheduler to `yunikorn` forcely if `admissionController.filtering.overrideCustomSchedulers` is true or pod scheduler name is `default-scheduler`


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2981

### How should this be tested?
1. Set up Yunikonr with
```
admissionController:
  filtering:
    overrideCustomSchedulers: true
```
2. Set up default-scheduler pods  - Verify pod scheduler turn to yunikorn
3. Set up pods with other scheduler name and turn on overrideCustomSchedulers - Verify pod scheduler turn to yunikorn
4. Set up pods with other scheduler name and turn off overrideCustomSchedulers - Verify pod scheduler wont change

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
