### PR TITLE
[YUNIKORN-3107] Decrease K8s versions in e2e test matrix

### DIFF
--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -1,48 +1,12 @@
-name: Pre-commit checks
+name: Weekly K8s intermediate versions e2e test
 
 on:
-  pull_request:
-    branches:
-      - master
-  workflow_dispatch: {}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+    schedule:
+      - cron: '0 0 * * 0' # Every Sunday at 00:00 UTC
+    workflow_dispatch: {}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: .go_version
-      - name: Check license
-        run: make license-check
-      - name: Go lint
-        run: make lint
-      - name: Run Version Check
-        run: make pseudo
-      - name: Run ShellCheck
-        run: make check_scripts
-      - name: Unit tests
-        run: make test
-      - name: Code coverage
-        uses: codecov/codecov-action@v4
-        with:
-          files: build/coverage.txt
-          # After codecov/codecov-action@v4, tokenless uploading of coverage files to non-public repo is unsupported.
-          # To enable codecov analysis in your forked repo. Please configure CODECOV_TOKEN in your repository secrets.
-          # Ref: https://docs.codecov.com/docs/adding-the-codecov-token
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  e2e-tests:
-    needs: build
+  weekly-e2e:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -52,6 +16,12 @@ jobs:
             v1.33.1,
             v1.32.2,
             v1.31.6,
+            v1.30.10,
+            v1.29.14,
+            v1.28.15,
+            v1.27.16,
+            v1.26.15,
+            v1.25.16,
             v1.24.17,
           ]
         plugin: ["", "--plugin"]


### PR DESCRIPTION
### What is this PR for?
Currently, there are 10 k8s versions in e2e test matrix, which leads to significant overhead for PR runs.
As previously discussed in our [community thread](https://lists.apache.org/thread/77ls2y34fo36g0pwykmw407282q5mlnh), a viable approach is to trim the test versions for every PR run to 3 newest + 1 oldest , while adding a cron job to test all intermediate versions weekly.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3107
