### PR TITLE
flag to disable k8s events

### DIFF
--- a/pkg/common/events/recorder.go
+++ b/pkg/common/events/recorder.go
@@ -27,8 +27,7 @@ import (
 var eventRecorder atomic.Pointer[events.EventRecorder]
 
 func init() {
-	r := events.EventRecorder(NewMockedRecorder())
-	eventRecorder.Store(&r)
+	UseMockedRecorder()
 }
 
 func GetRecorder() events.EventRecorder {
@@ -37,4 +36,16 @@ func GetRecorder() events.EventRecorder {
 
 func SetRecorder(recorder events.EventRecorder) {
 	eventRecorder.Store(&recorder)
+}
+
+func UseMockedRecorder() {
+	SetRecorder(NewMockedRecorder())
+}
+
+func ConfigureRecorder(recorder events.EventRecorder, disabled bool) {
+	if disabled {
+		UseMockedRecorder()
+		return
+	}
+	SetRecorder(recorder)
 }

--- a/pkg/common/events/recorder_configure_test.go
+++ b/pkg/common/events/recorder_configure_test.go
@@ -1,0 +1,57 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package events
+
+import (
+	"reflect"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type testRecorder struct{}
+
+func (tr *testRecorder) Event(runtime.Object, string, string, string) {}
+
+func (tr *testRecorder) Eventf(runtime.Object, runtime.Object, string, string, string, string, ...interface{}) {
+}
+
+func (tr *testRecorder) AnnotatedEventf(runtime.Object, map[string]string, string, string, string, ...interface{}) {
+}
+
+func (tr *testRecorder) PastEventf(runtime.Object, metav1.Time, string, string, string, ...interface{}) {
+}
+
+func TestConfigureRecorderDisabledUsesMockedRecorder(t *testing.T) {
+	defer UseMockedRecorder()
+
+	ConfigureRecorder(&testRecorder{}, true)
+
+	assert.Equal(t, reflect.TypeOf(GetRecorder()), reflect.TypeOf(&MockedRecorder{}))
+}
+
+func TestConfigureRecorderEnabledUsesProvidedRecorder(t *testing.T) {
+	defer UseMockedRecorder()
+
+	ConfigureRecorder(&testRecorder{}, false)
+
+	assert.Equal(t, reflect.TypeOf(GetRecorder()), reflect.TypeOf(&testRecorder{}))
+}

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -65,6 +65,7 @@ const (
 	CMSvcEventChannelCapacity         = PrefixService + "eventChannelCapacity"
 	CMSvcDispatchTimeout              = PrefixService + "dispatchTimeout"
 	CMSvcDisableGangScheduling        = PrefixService + "disableGangScheduling"
+	CMSvcDisableKubernetesEvents      = PrefixService + "disableKubernetesEvents"
 	CMSvcEnableConfigHotRefresh       = PrefixService + "enableConfigHotRefresh"
 	CMSvcPlaceholderImage             = PrefixService + "placeholderImage"
 	CMSvcPlaceholderRunAsUser         = PrefixService + "placeholderRunAsUser"
@@ -90,6 +91,7 @@ const (
 	DefaultDispatchTimeout                 = 300 * time.Second
 	DefaultOperatorPlugins                 = "general"
 	DefaultDisableGangScheduling           = false
+	DefaultDisableKubernetesEvents         = false
 	DefaultEnableConfigHotRefresh          = true
 	DefaultKubeQPS                         = 1000
 	DefaultKubeBurst                       = 1000
@@ -126,6 +128,7 @@ type SchedulerConf struct {
 	KubeBurst                int                `json:"kubeBurst"`
 	EnableConfigHotRefresh   bool               `json:"enableConfigHotRefresh"`
 	DisableGangScheduling    bool               `json:"disableGangScheduling"`
+	DisableKubernetesEvents  bool               `json:"disableKubernetesEvents"`
 	UserLabelKey             string             `json:"userLabelKey"`
 	PlaceHolderConfig        *PlaceHolderConfig `json:"placeHolderConfig"`
 	InstanceTypeNodeLabelKey string             `json:"instanceTypeNodeLabelKey"`
@@ -160,6 +163,7 @@ func (conf *SchedulerConf) Clone() *SchedulerConf {
 		KubeBurst:                conf.KubeBurst,
 		EnableConfigHotRefresh:   conf.EnableConfigHotRefresh,
 		DisableGangScheduling:    conf.DisableGangScheduling,
+		DisableKubernetesEvents:  conf.DisableKubernetesEvents,
 		UserLabelKey:             conf.UserLabelKey,
 		PlaceHolderConfig:        conf.PlaceHolderConfig,
 		InstanceTypeNodeLabelKey: conf.InstanceTypeNodeLabelKey,
@@ -219,6 +223,7 @@ func handleNonReloadableConfig(old *SchedulerConf, new *SchedulerConf) {
 	checkNonReloadableInt(CMKubeQPS, &old.KubeQPS, &new.KubeQPS)
 	checkNonReloadableInt(CMKubeBurst, &old.KubeBurst, &new.KubeBurst)
 	checkNonReloadableBool(CMSvcDisableGangScheduling, &old.DisableGangScheduling, &new.DisableGangScheduling)
+	checkNonReloadableBool(CMSvcDisableKubernetesEvents, &old.DisableKubernetesEvents, &new.DisableKubernetesEvents)
 	checkNonReloadableString(CMSvcNodeInstanceTypeNodeLabelKey, &old.InstanceTypeNodeLabelKey, &new.InstanceTypeNodeLabelKey)
 	checkNonReloadableBool(AMFilteringGenerateUniqueAppIds, &old.GenerateUniqueAppIds, &new.GenerateUniqueAppIds)
 	checkNonReloadableInt64(CMSvcPlaceholderRunAsUser, &old.PlaceHolderConfig.RunAsUser, &new.PlaceHolderConfig.RunAsUser)
@@ -333,6 +338,7 @@ func CreateDefaultConfig() *SchedulerConf {
 		KubeBurst:                DefaultKubeBurst,
 		EnableConfigHotRefresh:   DefaultEnableConfigHotRefresh,
 		DisableGangScheduling:    DefaultDisableGangScheduling,
+		DisableKubernetesEvents:  DefaultDisableKubernetesEvents,
 		UserLabelKey:             constants.DefaultUserLabel,
 		InstanceTypeNodeLabelKey: constants.DefaultNodeInstanceTypeNodeLabelKey,
 		GenerateUniqueAppIds:     DefaultAMFilteringGenerateUniqueAppIds,
@@ -360,6 +366,7 @@ func parseConfig(config map[string]string, prev *SchedulerConf) (*SchedulerConf,
 	parser.intVar(&conf.EventChannelCapacity, CMSvcEventChannelCapacity)
 	parser.durationVar(&conf.DispatchTimeout, CMSvcDispatchTimeout)
 	parser.boolVar(&conf.DisableGangScheduling, CMSvcDisableGangScheduling)
+	parser.boolVar(&conf.DisableKubernetesEvents, CMSvcDisableKubernetesEvents)
 	parser.boolVar(&conf.EnableConfigHotRefresh, CMSvcEnableConfigHotRefresh)
 	parser.stringVar(&conf.PlaceHolderConfig.Image, CMSvcPlaceholderImage)
 	parser.int64Var(&conf.PlaceHolderConfig.RunAsUser, CMSvcPlaceholderRunAsUser)

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -74,6 +74,7 @@ func assertDefaults(t *testing.T, conf *SchedulerConf) {
 	assert.Equal(t, conf.DispatchTimeout, DefaultDispatchTimeout)
 	assert.Equal(t, conf.KubeQPS, DefaultKubeQPS)
 	assert.Equal(t, conf.KubeBurst, DefaultKubeBurst)
+	assert.Equal(t, conf.DisableKubernetesEvents, DefaultDisableKubernetesEvents)
 	assert.Equal(t, conf.UserLabelKey, constants.DefaultUserLabel)
 }
 
@@ -138,6 +139,7 @@ func TestParseConfigMap(t *testing.T) {
 		{CMSvcEventChannelCapacity, "EventChannelCapacity", 1234},
 		{CMSvcDispatchTimeout, "DispatchTimeout", 3 * time.Minute},
 		{CMSvcDisableGangScheduling, "DisableGangScheduling", true},
+		{CMSvcDisableKubernetesEvents, "DisableKubernetesEvents", true},
 		{CMSvcEnableConfigHotRefresh, "EnableConfigHotRefresh", false},
 		{CMSvcPlaceholderImage, "PlaceHolderConfig.Image", "test-image"},
 		{CMSvcPlaceholderRunAsUser, "PlaceHolderConfig.RunAsUser", int64(1001)},
@@ -173,6 +175,7 @@ func TestUpdateConfigMapNonReloadable(t *testing.T) {
 		{CMSvcEventChannelCapacity, "EventChannelCapacity", 1234, false},
 		{CMSvcDispatchTimeout, "DispatchTimeout", 3 * time.Minute, false},
 		{CMSvcDisableGangScheduling, "DisableGangScheduling", true, false},
+		{CMSvcDisableKubernetesEvents, "DisableKubernetesEvents", true, false},
 		{CMSvcNodeInstanceTypeNodeLabelKey, "InstanceTypeNodeLabelKey", "node.kubernetes.io/instance-type", false},
 		{CMSvcPlaceholderImage, "PlaceHolderConfig.Image", "test-image", false},
 		{CMSvcPlaceholderRunAsUser, "PlaceHolderConfig.RunAsUser", int64(1001), false},

--- a/pkg/plugin/scheduler_plugin.go
+++ b/pkg/plugin/scheduler_plugin.go
@@ -302,7 +302,7 @@ func NewSchedulerPlugin(_ context.Context, _ runtime.Object, handle framework.Ha
 	p := &YuniKornSchedulerPlugin{
 		context: context,
 	}
-	events.SetRecorder(handle.EventRecorder())
+	events.ConfigureRecorder(handle.EventRecorder(), conf.GetSchedulerConf().DisableKubernetesEvents)
 	return p, nil
 }
 

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -73,15 +73,19 @@ func NewShimScheduler(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, b
 	context := cache.NewContextWithBootstrapConfigMaps(apiFactory, bootstrapConfigMaps)
 	rmCallback := cache.NewAsyncRMCallback(context)
 
-	eventBroadcaster := k8events.NewBroadcaster(&k8events.EventSinkImpl{
-		Interface: kubeClient.GetClientSet().EventsV1()})
-	err := eventBroadcaster.StartRecordingToSinkWithContext(ctx.Background())
-	if err != nil {
-		log.Log(log.Shim).Error("Could not create event broadcaster",
-			zap.Error(err))
+	if configs.DisableKubernetesEvents {
+		events.UseMockedRecorder()
 	} else {
-		eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, constants.SchedulerName)
-		events.SetRecorder(eventRecorder)
+		eventBroadcaster := k8events.NewBroadcaster(&k8events.EventSinkImpl{
+			Interface: kubeClient.GetClientSet().EventsV1()})
+		err := eventBroadcaster.StartRecordingToSinkWithContext(ctx.Background())
+		if err != nil {
+			log.Log(log.Shim).Error("Could not create event broadcaster",
+				zap.Error(err))
+		} else {
+			eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, constants.SchedulerName)
+			events.SetRecorder(eventRecorder)
+		}
 	}
 
 	return newShimSchedulerInternal(context, apiFactory, rmCallback)


### PR DESCRIPTION
Adds a flag to disable emitting kubernetes events. In environments under significant load, yunikorn can contribute to emitting millions of events which takes a toll on etcd.

Use it by setting:

service.disableKubernetesEvents: "true"

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - http://yunikorn.apache.org/community/how_to_contribute   


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
