### PR TITLE
[YUNIKORN-3269] Respect Kubernetes node cordon state

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -219,9 +219,11 @@ func (ctx *Context) updateNodeInternal(node *v1.Node, register bool) {
 			}
 		}
 
-		// if node was registered in-line, enable it in the core
-		if err := ctx.enableNode(node); err != nil {
-			log.Log(log.ShimContext).Warn("Failed to enable node", zap.Error(err))
+		// if node is not cordoned, enable it in the core
+		if !node.Spec.Unschedulable {
+			if err := ctx.enableNode(node); err != nil {
+				log.Log(log.ShimContext).Warn("Failed to enable node", zap.Error(err))
+			}
 		}
 	} else {
 		// existing node
@@ -236,7 +238,22 @@ func (ctx *Context) updateNodeInternal(node *v1.Node, register bool) {
 				log.Log(log.ShimContext).Warn("Failed to update cached node capacity", zap.String("nodeName", node.Name))
 			}
 		}
+		if err := ctx.updateNodeSchedulability(prevNode, node); err != nil {
+			log.Log(log.ShimContext).Warn("Failed to update node schedulability", zap.Error(err))
+		}
 	}
+}
+
+func (ctx *Context) updateNodeSchedulability(prevNode, node *v1.Node) error {
+	if prevNode.Spec.Unschedulable == node.Spec.Unschedulable {
+		return nil
+	}
+	action := si.NodeInfo_DRAIN_TO_SCHEDULABLE
+	if node.Spec.Unschedulable {
+		action = si.NodeInfo_DRAIN_NODE
+	}
+	request := common.CreateUpdateRequestForDeleteOrRestoreNode(node.Name, action)
+	return ctx.apiProvider.GetAPIs().SchedulerAPI.UpdateNode(request)
 }
 
 func (ctx *Context) deleteNode(obj interface{}) {
@@ -1405,7 +1422,7 @@ func (ctx *Context) InitializeState() error {
 
 	// Step 4: Enable nodes. At this point all allocations and asks have been processed, so it is safe to allow the
 	// core to begin scheduling.
-	err = ctx.enableNodes(acceptedNodes)
+	err = ctx.enableNodes(filterSchedulableNodes(acceptedNodes))
 	if err != nil {
 		log.Log(log.ShimContext).Error("failed to enable nodes", zap.Error(err))
 		return err
@@ -1644,6 +1661,16 @@ func (ctx *Context) enableNodes(nodes []*v1.Node) error {
 		return err
 	}
 	return nil
+}
+
+func filterSchedulableNodes(nodes []*v1.Node) []*v1.Node {
+	schedulableNodes := make([]*v1.Node, 0, len(nodes))
+	for _, node := range nodes {
+		if node != nil && !node.Spec.Unschedulable {
+			schedulableNodes = append(schedulableNodes, node)
+		}
+	}
+	return schedulableNodes
 }
 
 func (ctx *Context) finalizeNodes(existingNodes []*v1.Node) error {

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -212,6 +212,110 @@ func TestUpdateNodes(t *testing.T) {
 	ctx.updateNode(&oldNode, &newNode)
 }
 
+func TestAddCordonedNodeDoesNotEnable(t *testing.T) {
+	ctx, apiProvider := initContextAndAPIProviderForTest()
+	dispatcher.Start()
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	actions := make([]si.NodeInfo_ActionFromRM, 0)
+	apiProvider.MockSchedulerAPIUpdateNodeFn(func(request *si.NodeRequest) error {
+		for _, node := range request.Nodes {
+			actions = append(actions, node.Action)
+			if node.Action == si.NodeInfo_CREATE_DRAIN {
+				dispatcher.Dispatch(CachedSchedulerNodeEvent{
+					NodeID: node.NodeID,
+					Event:  NodeAccepted,
+				})
+			}
+		}
+		return nil
+	})
+
+	node := v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      Host1,
+			Namespace: "default",
+			UID:       uid1,
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: true,
+		},
+	}
+
+	ctx.addNode(&node)
+
+	assert.Equal(t, len(actions), 1)
+	assert.Equal(t, actions[0], si.NodeInfo_CREATE_DRAIN)
+}
+
+func TestUpdateNodeSchedulability(t *testing.T) {
+	ctx, apiProvider := initContextAndAPIProviderForTest()
+	dispatcher.Start()
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	actions := make([]si.NodeInfo_ActionFromRM, 0)
+	apiProvider.MockSchedulerAPIUpdateNodeFn(func(request *si.NodeRequest) error {
+		for _, node := range request.Nodes {
+			actions = append(actions, node.Action)
+			if node.Action == si.NodeInfo_CREATE_DRAIN {
+				dispatcher.Dispatch(CachedSchedulerNodeEvent{
+					NodeID: node.NodeID,
+					Event:  NodeAccepted,
+				})
+			}
+		}
+		return nil
+	})
+
+	node := v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      Host1,
+			Namespace: "default",
+			UID:       uid1,
+		},
+	}
+
+	ctx.addNode(&node)
+	assert.Equal(t, len(actions), 2)
+	assert.Equal(t, actions[0], si.NodeInfo_CREATE_DRAIN)
+	assert.Equal(t, actions[1], si.NodeInfo_DRAIN_TO_SCHEDULABLE)
+
+	cordoned := node.DeepCopy()
+	cordoned.Spec.Unschedulable = true
+	ctx.updateNode(&node, cordoned)
+	assert.Equal(t, len(actions), 3)
+	assert.Equal(t, actions[2], si.NodeInfo_DRAIN_NODE)
+
+	cordonedCopy := cordoned.DeepCopy()
+	ctx.updateNode(cordoned, cordonedCopy)
+	assert.Equal(t, len(actions), 3)
+
+	uncordoned := cordoned.DeepCopy()
+	uncordoned.Spec.Unschedulable = false
+	ctx.updateNode(cordoned, uncordoned)
+	assert.Equal(t, len(actions), 4)
+	assert.Equal(t, actions[3], si.NodeInfo_DRAIN_TO_SCHEDULABLE)
+}
+
+func TestFilterSchedulableNodes(t *testing.T) {
+	node1 := &v1.Node{
+		ObjectMeta: apis.ObjectMeta{Name: Host1},
+	}
+	node2 := &v1.Node{
+		ObjectMeta: apis.ObjectMeta{Name: Host2},
+		Spec: v1.NodeSpec{
+			Unschedulable: true,
+		},
+	}
+
+	nodes := filterSchedulableNodes([]*v1.Node{node1, nil, node2})
+
+	assert.Equal(t, len(nodes), 1)
+	assert.Equal(t, nodes[0].Name, Host1)
+}
+
 func TestDeleteNodes(t *testing.T) {
 	ctx, apiProvider := initContextAndAPIProviderForTest()
 	dispatcher.Start()
@@ -1998,6 +2102,47 @@ func TestInitializeState(t *testing.T) {
 	// pod3 is an orphan, should not be found
 	task3 := context.getTask(appID3, podName3)
 	assert.Assert(t, task3 == nil, "pod3 was found")
+}
+
+func TestInitializeStateDoesNotEnableCordonedNodes(t *testing.T) {
+	context, apiProvider := initContextAndAPIProviderForTest()
+	apiProvider.RunEventHandler()
+	nodeLister, ok := apiProvider.GetAPIs().NodeInformer.Lister().(*test.NodeListerMock)
+	assert.Assert(t, ok, "unable to get mock node lister")
+
+	dispatcher.Start()
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	actionsByNode := make(map[string][]si.NodeInfo_ActionFromRM)
+	apiProvider.MockSchedulerAPIUpdateNodeFn(func(request *si.NodeRequest) error {
+		for _, node := range request.Nodes {
+			actionsByNode[node.NodeID] = append(actionsByNode[node.NodeID], node.Action)
+			if node.Action == si.NodeInfo_CREATE_DRAIN {
+				dispatcher.Dispatch(CachedSchedulerNodeEvent{
+					NodeID: node.NodeID,
+					Event:  NodeAccepted,
+				})
+			}
+		}
+		return nil
+	})
+
+	schedulableNode := nodeForTest(nodeName1, "10G", "4")
+	cordonedNode := nodeForTest(nodeName2, "10G", "4")
+	cordonedNode.Spec.Unschedulable = true
+	nodeLister.AddNode(schedulableNode)
+	nodeLister.AddNode(cordonedNode)
+
+	err := context.InitializeState()
+	assert.NilError(t, err, "InitializeState failed")
+
+	assert.Assert(t, context.schedulerCache.GetNode(nodeName1) != nil, "schedulable node was not cached")
+	assert.Assert(t, context.schedulerCache.GetNode(nodeName2) != nil, "cordoned node was not cached")
+
+	cordonedActions := actionsByNode[nodeName2]
+	assert.Equal(t, len(cordonedActions), 1)
+	assert.Equal(t, cordonedActions[0], si.NodeInfo_CREATE_DRAIN)
 }
 
 func TestPodAdoption(t *testing.T) {


### PR DESCRIPTION
### What is this PR for?
This PR makes the Kubernetes shim respect node cordon state when registering and updating nodes.

Cordoned nodes are still registered with scheduler-core, but remain drained until Kubernetes marks them schedulable again. Dynamic cordon and uncordon updates now send the matching scheduler-core node actions.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3269

### How should this be tested?
Added unit tests for:
* adding a cordoned node without enabling it for scheduling
* dynamically cordoning and uncordoning a node
* ignoring node updates when the schedulability state is unchanged
* filtering cordoned nodes during startup initialization

Validation:
* `go test -count=1 ./pkg/cache`

### Screenshots (if appropriate)
N/A

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
