### PR TITLE
[YUNIKORN-3089] Fix stale New apps when pods are deleted before core accept

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -59,6 +59,8 @@ type Application struct {
 	placeholderTimeoutInSec    int64
 	schedulingStyle            string
 	originatingTask            *Task // Original Pod which creates the requests
+	releaseableTasks           []*Task
+	context                    *Context
 }
 
 const transitionErr = "no transition"
@@ -85,6 +87,7 @@ func NewApplication(appID, queueName, user string, groups []string, tags map[str
 		schedulerAPI:            scheduler,
 		placeholderTimeoutInSec: 0,
 		schedulingStyle:         constants.SchedulingPolicyStyleParamDefault,
+		releaseableTasks:        make([]*Task, 0),
 	}
 	return app
 }
@@ -206,6 +209,10 @@ func (app *Application) setOriginatingTask(task *Task) {
 	app.lock.Lock()
 	defer app.lock.Unlock()
 	app.originatingTask = task
+}
+
+func (app *Application) setContext(ctx *Context) {
+	app.context = ctx
 }
 
 func (app *Application) GetOriginatingTask() *Task {
@@ -578,6 +585,7 @@ func (app *Application) onReservationStateChange() {
 
 func (app *Application) handleRejectApplicationEvent(reason string) {
 	log.Log(log.ShimCacheApplication).Info("app is rejected by scheduler", zap.String("appID", app.applicationID))
+	app.clearReleaseableTasks()
 	// for rejected apps, we directly move them to failed state
 	dispatcher.Dispatch(NewFailApplicationEvent(app.applicationID,
 		fmt.Sprintf("%s: %s", constants.ApplicationRejectedFailure, reason)))
@@ -609,6 +617,7 @@ func (app *Application) handleFailApplicationEvent(errMsg string) {
 	go func() {
 		getPlaceholderManager().cleanUp(app)
 	}()
+	app.clearReleaseableTasks()
 	log.Log(log.ShimCacheApplication).Info("failApplication reason", zap.String("applicationID", app.applicationID), zap.String("errMsg", errMsg))
 	// unallocated task states include New, Pending and Scheduling
 	unalloc := app.getTasks(TaskStates().New)
@@ -688,5 +697,61 @@ func (app *Application) removeCompletedTasks() {
 		if task.isTerminated() {
 			app.removeTask(task.taskID)
 		}
+	}
+}
+
+func (app *Application) tryAddReleasableTask(task *Task) bool {
+	app.lock.Lock()
+	defer app.lock.Unlock()
+
+	current := app.sm.Current()
+	if current == ApplicationStates().New ||
+		current == ApplicationStates().Submitted {
+		for _, existing := range app.releaseableTasks {
+			if existing.taskID == task.taskID {
+				return true
+			}
+		}
+		app.releaseableTasks = append(app.releaseableTasks, task)
+		return true
+	}
+
+	return false
+}
+
+func (app *Application) clearReleaseableTasks() {
+	app.releaseableTasks = nil
+}
+
+// flushReleaseableTasks replays deferred task releases after the application has been accepted
+// by the scheduler core. Must be called while the application lock is held.
+func (app *Application) flushReleaseableTasks() {
+	if len(app.releaseableTasks) == 0 {
+		return
+	}
+	tasks := app.releaseableTasks
+	app.releaseableTasks = nil
+
+	if app.AreAllTasksTerminated() {
+		app.removeFromSchedulerCore()
+		if app.context != nil {
+			app.context.removeApplication(app.applicationID)
+		}
+		return
+	}
+
+	for _, task := range tasks {
+		task.releaseAllocation(true)
+	}
+}
+
+func (app *Application) removeFromSchedulerCore() {
+	log.Log(log.ShimCacheApplication).Info("removing application from scheduler core",
+		zap.String("appID", app.applicationID))
+	request := common.CreateUpdateRequestForRemoveApplication(app.applicationID, app.partition)
+	if err := app.schedulerAPI.UpdateApplication(request); err != nil {
+		log.Log(log.ShimCacheApplication).Warn("failed to remove application from scheduler core",
+			zap.String("appID", app.applicationID),
+			zap.Error(err))
 	}
 }

--- a/pkg/cache/application_state.go
+++ b/pkg/cache/application_state.go
@@ -455,6 +455,10 @@ func newAppState() *fsm.FSM { //nolint:funlen
 					zap.String("destination", event.Dst),
 					zap.String("event", event.Event))
 			},
+			states.Accepted: func(_ context.Context, event *fsm.Event) {
+				app := event.Args[0].(*Application) //nolint:errcheck
+				app.flushReleaseableTasks()
+			},
 			states.Reserving: func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				app.onReserving()

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -1328,7 +1328,74 @@ func TestTaskRemoval(t *testing.T) {
 	assert.Equal(t, 0, len(app.getTasks(TaskStates().Completed)))
 }
 
+func TestDeferredReleaseOnAccept(t *testing.T) {
+	context := initContextForTest()
+	mockedAPI, ok := context.apiProvider.(*client.MockedAPIProvider)
+	assert.Assert(t, ok, "expecting MockedAPIProvider")
+
+	removeCalled := false
+	mockScheduler := newMockSchedulerAPI()
+	mockScheduler.UpdateApplicationFn = func(request *si.ApplicationRequest) error {
+		if len(request.New) > 0 {
+			return nil
+		}
+		if len(request.Remove) == 1 {
+			removeCalled = true
+			assert.Equal(t, request.Remove[0].ApplicationID, "deferred-app")
+			assert.Equal(t, request.Remove[0].PartitionName, constants.DefaultPartition)
+		}
+		return nil
+	}
+
+	mockedAPI.MockSchedulerAPIUpdateAllocationFn(func(request *si.AllocationRequest) error {
+		t.Fatal("unexpected allocation update during deferred release flow")
+		return nil
+	})
+
+	pod := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name: "pod-deferred-release",
+			UID:  "task-deferred-01",
+		},
+		Spec: v1.PodSpec{},
+	}
+
+	app := NewApplication("deferred-app", "root.default", "testuser", testGroups, map[string]string{}, mockScheduler)
+	context.addApplicationToContext(app)
+	task := NewTask("task-deferred-01", app, context, pod)
+	app.addTask(task)
+
+	err := app.handle(NewSubmitApplicationEvent(app.applicationID))
+	assert.NilError(t, err)
+	assert.Equal(t, app.GetApplicationState(), ApplicationStates().Submitted)
+
+	err = task.handle(NewSimpleTaskEvent(app.applicationID, task.taskID, CompleteTask))
+	assert.NilError(t, err)
+	assert.Equal(t, task.GetTaskState(), TaskStates().Completed)
+	assert.Equal(t, mockedAPI.GetSchedulerAPIUpdateAllocationCount(), int32(0))
+
+	err = app.handle(NewSimpleApplicationEvent(app.applicationID, AcceptApplication))
+	assert.NilError(t, err)
+	assert.Equal(t, app.GetApplicationState(), ApplicationStates().Accepted)
+	assert.Assert(t, removeCalled, "expected RemoveApplication request to scheduler core")
+	assert.Assert(t, context.GetApplication(app.applicationID) == nil, "app should be removed from shim cache")
+}
+
+func TestTryAddReleasableTaskDedupe(t *testing.T) {
+	app := NewApplication("app-dedupe", "root.default", "testuser", testGroups, map[string]string{}, newMockSchedulerAPI())
+	task := &Task{taskID: "task01"}
+
+	assert.Assert(t, app.tryAddReleasableTask(task))
+	assert.Assert(t, app.tryAddReleasableTask(task))
+	assert.Equal(t, len(app.releaseableTasks), 1)
+}
+
 func (ctx *Context) addApplicationToContext(app *Application) {
+	app.setContext(ctx)
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 	ctx.applications[app.applicationID] = app

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -990,6 +990,7 @@ func (ctx *Context) addApplication(request *AddApplicationRequest) *Application 
 		request.Metadata.Groups,
 		request.Metadata.Tags,
 		ctx.apiProvider.GetAPIs().SchedulerAPI)
+	app.setContext(ctx)
 	app.setTaskGroups(request.Metadata.TaskGroups)
 	app.setTaskGroupsDefinition(request.Metadata.Tags[constants.AnnotationTaskGroups])
 	app.setSchedulingParamsDefinition(request.Metadata.Tags[constants.AnnotationSchedulingPolicyParam])
@@ -1039,6 +1040,10 @@ func (ctx *Context) getApplication(appID string) *Application {
 func (ctx *Context) RemoveApplication(appID string) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
+	ctx.removeApplication(appID)
+}
+
+func (ctx *Context) removeApplication(appID string) {
 	if _, exist := ctx.applications[appID]; !exist {
 		log.Log(log.ShimContext).Debug("Attempted to remove non-existent application", zap.String("appID", appID))
 		return

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -404,7 +404,7 @@ func (task *Task) beforeTaskAllocated(eventSrc string, allocationKey string, nod
 			zap.String("currentTaskState", eventSrc),
 			zap.String("allocationKey", allocationKey),
 			zap.String("allocatedNode", nodeID))
-		task.releaseAllocation()
+		task.releaseAllocation(false)
 	}
 }
 
@@ -436,22 +436,29 @@ func (task *Task) beforeTaskFail() {
 	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
 		v1.EventTypeNormal, "TaskFailed", "TaskFailed",
 		"Task %s is failed", task.alias)
-	task.releaseAllocation()
+	task.releaseAllocation(false)
 }
 
 // beforeTaskCompleted releases the allocation or ask from scheduler core
 // this is done as a before hook because the releaseAllocation() call needs to
 // send different requests to scheduler-core, depending on current task state
 func (task *Task) beforeTaskCompleted() {
+	task.releaseAllocation(false)
+
 	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
 		v1.EventTypeNormal, "TaskCompleted", "TaskCompleted",
 		"Task %s is completed", task.alias)
-	task.releaseAllocation()
 }
 
 // releaseAllocation sends the release request for the Allocation to the core.
-func (task *Task) releaseAllocation() {
+func (task *Task) releaseAllocation(force bool) {
 	terminationType := common.GetTerminationTypeFromString(task.terminationType)
+
+	if !force && task.shouldAppRelease() {
+		log.Log(log.ShimCacheTask).Info("not releasing task right now, app has not been accepted",
+			zap.String("appState", task.application.sm.Current()))
+		return
+	}
 
 	// scheduler api might be nil in some tests
 	if task.context.apiProvider.GetAPIs().SchedulerAPI != nil {
@@ -496,6 +503,12 @@ func (task *Task) releaseAllocation() {
 			log.Log(log.ShimCacheTask).Debug("failed to send scheduling request to scheduler", zap.Error(err))
 		}
 	}
+}
+
+func (task *Task) shouldAppRelease() bool {
+	task.lock.Unlock()
+	defer task.lock.Lock()
+	return task.application.tryAddReleasableTask(task)
 }
 
 // some sanity checks before sending task for scheduling,

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -224,6 +224,7 @@ func TestReleaseTaskAllocation(t *testing.T) {
 	})
 
 	// complete
+	task.application.sm.SetState(ApplicationStates().Running)
 	event4 := NewSimpleTaskEvent(app.applicationID, task.taskID, CompleteTask)
 	err = task.handle(event4)
 	assert.NilError(t, err, "failed to handle CompleteTask event")
@@ -324,6 +325,7 @@ func TestReleaseTaskAsk(t *testing.T) {
 	})
 
 	// complete
+	task.application.sm.SetState(ApplicationStates().Running)
 	event4 := NewSimpleTaskEvent(app.applicationID, task.taskID, CompleteTask)
 	err = task.handle(event4)
 	assert.NilError(t, err, "failed to handle CompleteTask event")


### PR DESCRIPTION
### Description
Defer task releases until the application is accepted, then remove empty apps from the core and shim cache instead of sending a lost allocation release during the New/Submitted window.

### Type of change
Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3089

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
