### PR TITLE
[YUNIKORN-3128] Retry pending pods after bind errors

### DIFF
--- a/pkg/cache/bind_error.go
+++ b/pkg/cache/bind_error.go
@@ -111,7 +111,7 @@ func NewBindFailureConflictError(stage BindFailureStage, operation BindFailureOp
 		sReasons[i] = string(reason)
 	}
 
-	err := errors.New(fmt.Sprintf("pod %s has conflicting volume claims: %s", podName, strings.Join(sReasons, ", ")))
+	err := fmt.Errorf("pod %s has conflicting volume claims: %s", podName, strings.Join(sReasons, ", "))
 	return &BindFailureError{
 		details: BindFailureDetails{
 			Stage:           stage,

--- a/pkg/cache/bind_error.go
+++ b/pkg/cache/bind_error.go
@@ -1,0 +1,150 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
+)
+
+type BindFailureStage string
+
+const (
+	BindFailureStageAssumePod      BindFailureStage = "assume_pod"
+	BindFailureStageBindPodVolumes BindFailureStage = "bind_pod_volumes"
+	BindFailureStageBindPod        BindFailureStage = "bind_pod"
+)
+
+type BindFailureOperation string
+
+const (
+	BindFailureOperationGetPodVolumeClaims BindFailureOperation = "get_pod_volume_claims"
+	BindFailureOperationGetNodeInfo        BindFailureOperation = "get_node_info"
+	BindFailureOperationFindPodVolumes     BindFailureOperation = "find_pod_volumes"
+	BindFailureOperationAssumePodVolumes   BindFailureOperation = "assume_pod_volumes"
+	BindFailureOperationBindPodVolumes     BindFailureOperation = "bind_pod_volumes"
+	BindFailureOperationKubeBindPod        BindFailureOperation = "kube_bind_pod"
+)
+
+type BindFailureDetails struct {
+	Stage           BindFailureStage
+	Operation       BindFailureOperation
+	StatusReason    metav1.StatusReason
+	StatusCode      int32
+	ResourceKind    string
+	ResourceName    string
+	ConflictReasons volumebinding.ConflictReasons
+}
+
+type BindFailureError struct {
+	details BindFailureDetails
+	cause   error
+}
+
+func (e *BindFailureError) Error() string {
+	if e == nil || e.cause == nil {
+		return ""
+	}
+	return e.cause.Error()
+}
+
+func (e *BindFailureError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *BindFailureError) Details() BindFailureDetails {
+	if e == nil {
+		return BindFailureDetails{}
+	}
+
+	details := e.details
+	if len(e.details.ConflictReasons) > 0 {
+		details.ConflictReasons = append(volumebinding.ConflictReasons(nil), e.details.ConflictReasons...)
+	}
+	return details
+}
+
+func WrapBindFailureError(stage BindFailureStage, operation BindFailureOperation, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	details := BindFailureDetails{
+		Stage:     stage,
+		Operation: operation,
+	}
+	enrichBindFailureStatus(&details, err)
+
+	return &BindFailureError{
+		details: details,
+		cause:   err,
+	}
+}
+
+func NewBindFailureConflictError(stage BindFailureStage, operation BindFailureOperation, podName string,
+	reasons volumebinding.ConflictReasons) error {
+	sReasons := make([]string, len(reasons))
+	for i, reason := range reasons {
+		sReasons[i] = string(reason)
+	}
+
+	err := errors.New(fmt.Sprintf("pod %s has conflicting volume claims: %s", podName, strings.Join(sReasons, ", ")))
+	return &BindFailureError{
+		details: BindFailureDetails{
+			Stage:           stage,
+			Operation:       operation,
+			ConflictReasons: append(volumebinding.ConflictReasons(nil), reasons...),
+		},
+		cause: err,
+	}
+}
+
+func GetBindFailureDetails(err error) (BindFailureDetails, bool) {
+	var bindErr *BindFailureError
+	if !errors.As(err, &bindErr) {
+		return BindFailureDetails{}, false
+	}
+	return bindErr.Details(), true
+}
+
+func enrichBindFailureStatus(details *BindFailureDetails, err error) {
+	type apiStatus interface {
+		Status() metav1.Status
+	}
+
+	var statusErr apiStatus
+	if !errors.As(err, &statusErr) {
+		return
+	}
+
+	status := statusErr.Status()
+	details.StatusReason = status.Reason
+	details.StatusCode = status.Code
+	if status.Details != nil {
+		details.ResourceKind = status.Details.Kind
+		details.ResourceName = status.Details.Name
+	}
+}

--- a/pkg/cache/bind_error_classifier.go
+++ b/pkg/cache/bind_error_classifier.go
@@ -51,18 +51,10 @@ const (
 	BindFailureActionFailFast           BindFailureAction = "fail_fast"
 )
 
-type BindFailureConfidence string
-
-const (
-	BindFailureConfidenceHigh BindFailureConfidence = "high"
-	BindFailureConfidenceLow  BindFailureConfidence = "low"
-)
-
 type BindFailureDecision struct {
 	Scope      BindFailureScope
 	Durability BindFailureDurability
 	Action     BindFailureAction
-	Confidence BindFailureConfidence
 	Reason     string
 }
 
@@ -71,8 +63,7 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 		return BindFailureDecision{
 			Scope:      BindFailureScopeUnknown,
 			Durability: BindFailureDurabilityUnknown,
-			Action:     BindFailureActionFailFast,
-			Confidence: BindFailureConfidenceLow,
+			Action:     BindFailureActionRetrySameNode,
 			Reason:     "no error to classify",
 		}
 	}
@@ -84,7 +75,6 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 			Scope:      BindFailureScopePod,
 			Durability: BindFailureDurabilityPermanent,
 			Action:     BindFailureActionTreatAsSuccess,
-			Confidence: BindFailureConfidenceHigh,
 			Reason:     "pod bind is already recorded",
 		}
 	}
@@ -94,7 +84,6 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 			Scope:      BindFailureScopeUnknown,
 			Durability: BindFailureDurabilityTransient,
 			Action:     BindFailureActionRetrySameNode,
-			Confidence: BindFailureConfidenceHigh,
 			Reason:     "kubernetes API reported transient condition",
 		}
 	}
@@ -112,7 +101,6 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 					Scope:      BindFailureScopeNode,
 					Durability: BindFailureDurabilityPermanent,
 					Action:     BindFailureActionRetryDifferentNode,
-					Confidence: BindFailureConfidenceHigh,
 					Reason:     "target node was not found",
 				}
 			case "pod", "pods", "persistentvolumeclaim", "persistentvolumeclaims", "persistentvolume", "persistentvolumes":
@@ -120,7 +108,6 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 					Scope:      BindFailureScopePod,
 					Durability: BindFailureDurabilityPermanent,
 					Action:     BindFailureActionFailFast,
-					Confidence: BindFailureConfidenceHigh,
 					Reason:     "pod-scoped object required for binding was not found",
 				}
 			default:
@@ -128,7 +115,6 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 					Scope:      BindFailureScopeRequest,
 					Durability: BindFailureDurabilityPermanent,
 					Action:     BindFailureActionFailFast,
-					Confidence: BindFailureConfidenceLow,
 					Reason:     "resource required for request processing was not found",
 				}
 			}
@@ -140,7 +126,6 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 			Scope:      BindFailureScopePod,
 			Durability: BindFailureDurabilityPermanent,
 			Action:     BindFailureActionFailFast,
-			Confidence: BindFailureConfidenceHigh,
 			Reason:     "request payload or permissions are permanently invalid for this pod",
 		}
 	}
@@ -150,7 +135,6 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 			Scope:      BindFailureScopePod,
 			Durability: BindFailureDurabilityTransient,
 			Action:     BindFailureActionRetrySameNode,
-			Confidence: BindFailureConfidenceLow,
 			Reason:     "optimistic concurrency conflict while writing bind state",
 		}
 	}
@@ -158,9 +142,8 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 	return BindFailureDecision{
 		Scope:      BindFailureScopeUnknown,
 		Durability: BindFailureDurabilityUnknown,
-		Action:     BindFailureActionFailFast,
-		Confidence: BindFailureConfidenceLow,
-		Reason:     "no reliable classifier match",
+		Action:     BindFailureActionRetrySameNode,
+		Reason:     "no reliable classifier match, retrying by default",
 	}
 }
 
@@ -183,7 +166,6 @@ func classifyVolumeConflictReasons(reasons volumebinding.ConflictReasons) BindFa
 			Scope:      BindFailureScopePod,
 			Durability: BindFailureDurabilityPermanent,
 			Action:     BindFailureActionFailFast,
-			Confidence: BindFailureConfidenceHigh,
 			Reason:     "volume conflict reasons indicate pod-scoped incompatibility",
 		}
 	}
@@ -193,17 +175,15 @@ func classifyVolumeConflictReasons(reasons volumebinding.ConflictReasons) BindFa
 			Scope:      BindFailureScopeNode,
 			Durability: BindFailureDurabilityPermanent,
 			Action:     BindFailureActionRetryDifferentNode,
-			Confidence: BindFailureConfidenceHigh,
 			Reason:     "volume conflict reasons indicate node-scoped incompatibility",
 		}
 	}
 
 	return BindFailureDecision{
-		Scope:      BindFailureScopePod,
-		Durability: BindFailureDurabilityPermanent,
-		Action:     BindFailureActionFailFast,
-		Confidence: BindFailureConfidenceLow,
-		Reason:     "volume conflict reason is unknown, treating as pod-scoped",
+		Scope:      BindFailureScopeUnknown,
+		Durability: BindFailureDurabilityUnknown,
+		Action:     BindFailureActionRetrySameNode,
+		Reason:     "volume conflict reason is unknown, retrying by default",
 	}
 }
 
@@ -220,11 +200,9 @@ func isNodeScopedVolumeConflictReason(reason volumebinding.ConflictReason) bool 
 		return true
 	case strings.ToLower(volumebinding.ErrReasonNotEnoughSpace):
 		return true
-	case "nodevolumelimitsexceeded":
-		return true
 	}
 
-	return strings.Contains(normalized, "node")
+	return false
 }
 
 func isPodScopedVolumeConflictReason(reason volumebinding.ConflictReason) bool {
@@ -237,9 +215,7 @@ func isPodScopedVolumeConflictReason(reason volumebinding.ConflictReason) bool {
 		return true
 	}
 
-	return strings.Contains(normalized, "pvc") ||
-		strings.Contains(normalized, "persistentvolumeclaim") ||
-		strings.Contains(normalized, "non-existent pv")
+	return false
 }
 
 func isTransientBindFailure(err error) bool {

--- a/pkg/cache/bind_error_classifier.go
+++ b/pkg/cache/bind_error_classifier.go
@@ -1,0 +1,178 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+type BindFailureScope string
+
+const (
+	BindFailureScopeNode    BindFailureScope = "node"
+	BindFailureScopePod     BindFailureScope = "pod"
+	BindFailureScopeRequest BindFailureScope = "request"
+	BindFailureScopeUnknown BindFailureScope = "unknown"
+)
+
+type BindFailureDurability string
+
+const (
+	BindFailureDurabilityTransient BindFailureDurability = "transient"
+	BindFailureDurabilityPermanent BindFailureDurability = "permanent"
+	BindFailureDurabilityUnknown   BindFailureDurability = "unknown"
+)
+
+type BindFailureAction string
+
+const (
+	BindFailureActionRetrySameNode      BindFailureAction = "retry_same_node"
+	BindFailureActionRetryDifferentNode BindFailureAction = "retry_different_node"
+	BindFailureActionTreatAsSuccess     BindFailureAction = "treat_as_success"
+	BindFailureActionFailFast           BindFailureAction = "fail_fast"
+)
+
+type BindFailureConfidence string
+
+const (
+	BindFailureConfidenceHigh BindFailureConfidence = "high"
+	BindFailureConfidenceLow  BindFailureConfidence = "low"
+)
+
+type BindFailureDecision struct {
+	Scope      BindFailureScope
+	Durability BindFailureDurability
+	Action     BindFailureAction
+	Confidence BindFailureConfidence
+	Reason     string
+}
+
+func ClassifyBindFailure(err error) BindFailureDecision {
+	if err == nil {
+		return BindFailureDecision{
+			Scope:      BindFailureScopeUnknown,
+			Durability: BindFailureDurabilityUnknown,
+			Action:     BindFailureActionFailFast,
+			Confidence: BindFailureConfidenceLow,
+			Reason:     "no error to classify",
+		}
+	}
+
+	details, hasDetails := GetBindFailureDetails(err)
+
+	if hasDetails && details.Stage == BindFailureStageBindPod && apierrors.IsAlreadyExists(err) {
+		return BindFailureDecision{
+			Scope:      BindFailureScopePod,
+			Durability: BindFailureDurabilityPermanent,
+			Action:     BindFailureActionTreatAsSuccess,
+			Confidence: BindFailureConfidenceHigh,
+			Reason:     "pod bind is already recorded",
+		}
+	}
+
+	if isTransientBindFailure(err) {
+		return BindFailureDecision{
+			Scope:      BindFailureScopeUnknown,
+			Durability: BindFailureDurabilityTransient,
+			Action:     BindFailureActionRetrySameNode,
+			Confidence: BindFailureConfidenceHigh,
+			Reason:     "kubernetes API reported transient condition",
+		}
+	}
+
+	if hasDetails {
+		if len(details.ConflictReasons) > 0 {
+			return BindFailureDecision{
+				Scope:      BindFailureScopeNode,
+				Durability: BindFailureDurabilityPermanent,
+				Action:     BindFailureActionRetryDifferentNode,
+				Confidence: BindFailureConfidenceHigh,
+				Reason:     "volume conflict reasons indicate node-scoped incompatibility",
+			}
+		}
+
+		resourceKind := strings.ToLower(details.ResourceKind)
+		if apierrors.IsNotFound(err) {
+			switch resourceKind {
+			case "node", "nodes":
+				return BindFailureDecision{
+					Scope:      BindFailureScopeNode,
+					Durability: BindFailureDurabilityPermanent,
+					Action:     BindFailureActionRetryDifferentNode,
+					Confidence: BindFailureConfidenceHigh,
+					Reason:     "target node was not found",
+				}
+			case "pod", "pods", "persistentvolumeclaim", "persistentvolumeclaims", "persistentvolume", "persistentvolumes":
+				return BindFailureDecision{
+					Scope:      BindFailureScopePod,
+					Durability: BindFailureDurabilityPermanent,
+					Action:     BindFailureActionFailFast,
+					Confidence: BindFailureConfidenceHigh,
+					Reason:     "pod-scoped object required for binding was not found",
+				}
+			default:
+				return BindFailureDecision{
+					Scope:      BindFailureScopeRequest,
+					Durability: BindFailureDurabilityPermanent,
+					Action:     BindFailureActionFailFast,
+					Confidence: BindFailureConfidenceLow,
+					Reason:     "resource required for request processing was not found",
+				}
+			}
+		}
+	}
+
+	if apierrors.IsInvalid(err) || apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) || apierrors.IsBadRequest(err) {
+		return BindFailureDecision{
+			Scope:      BindFailureScopePod,
+			Durability: BindFailureDurabilityPermanent,
+			Action:     BindFailureActionFailFast,
+			Confidence: BindFailureConfidenceHigh,
+			Reason:     "request payload or permissions are permanently invalid for this pod",
+		}
+	}
+
+	if apierrors.IsConflict(err) {
+		return BindFailureDecision{
+			Scope:      BindFailureScopePod,
+			Durability: BindFailureDurabilityTransient,
+			Action:     BindFailureActionRetrySameNode,
+			Confidence: BindFailureConfidenceLow,
+			Reason:     "optimistic concurrency conflict while writing bind state",
+		}
+	}
+
+	return BindFailureDecision{
+		Scope:      BindFailureScopeUnknown,
+		Durability: BindFailureDurabilityUnknown,
+		Action:     BindFailureActionFailFast,
+		Confidence: BindFailureConfidenceLow,
+		Reason:     "no reliable classifier match",
+	}
+}
+
+func isTransientBindFailure(err error) bool {
+	return apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err)
+}

--- a/pkg/cache/bind_error_classifier.go
+++ b/pkg/cache/bind_error_classifier.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 )
 
 type BindFailureScope string
@@ -100,13 +101,7 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 
 	if hasDetails {
 		if len(details.ConflictReasons) > 0 {
-			return BindFailureDecision{
-				Scope:      BindFailureScopeNode,
-				Durability: BindFailureDurabilityPermanent,
-				Action:     BindFailureActionRetryDifferentNode,
-				Confidence: BindFailureConfidenceHigh,
-				Reason:     "volume conflict reasons indicate node-scoped incompatibility",
-			}
+			return classifyVolumeConflictReasons(details.ConflictReasons)
 		}
 
 		resourceKind := strings.ToLower(details.ResourceKind)
@@ -167,6 +162,84 @@ func ClassifyBindFailure(err error) BindFailureDecision {
 		Confidence: BindFailureConfidenceLow,
 		Reason:     "no reliable classifier match",
 	}
+}
+
+func classifyVolumeConflictReasons(reasons volumebinding.ConflictReasons) BindFailureDecision {
+	hasNodeScopedReason := false
+	hasPodScopedReason := false
+
+	for _, reason := range reasons {
+		if isPodScopedVolumeConflictReason(reason) {
+			hasPodScopedReason = true
+			continue
+		}
+		if isNodeScopedVolumeConflictReason(reason) {
+			hasNodeScopedReason = true
+		}
+	}
+
+	if hasPodScopedReason {
+		return BindFailureDecision{
+			Scope:      BindFailureScopePod,
+			Durability: BindFailureDurabilityPermanent,
+			Action:     BindFailureActionFailFast,
+			Confidence: BindFailureConfidenceHigh,
+			Reason:     "volume conflict reasons indicate pod-scoped incompatibility",
+		}
+	}
+
+	if hasNodeScopedReason {
+		return BindFailureDecision{
+			Scope:      BindFailureScopeNode,
+			Durability: BindFailureDurabilityPermanent,
+			Action:     BindFailureActionRetryDifferentNode,
+			Confidence: BindFailureConfidenceHigh,
+			Reason:     "volume conflict reasons indicate node-scoped incompatibility",
+		}
+	}
+
+	return BindFailureDecision{
+		Scope:      BindFailureScopePod,
+		Durability: BindFailureDurabilityPermanent,
+		Action:     BindFailureActionFailFast,
+		Confidence: BindFailureConfidenceLow,
+		Reason:     "volume conflict reason is unknown, treating as pod-scoped",
+	}
+}
+
+func isNodeScopedVolumeConflictReason(reason volumebinding.ConflictReason) bool {
+	normalized := strings.ToLower(strings.TrimSpace(string(reason)))
+	if normalized == "" {
+		return false
+	}
+
+	switch normalized {
+	case strings.ToLower(string(volumebinding.ErrReasonBindConflict)):
+		return true
+	case strings.ToLower(string(volumebinding.ErrReasonNodeConflict)):
+		return true
+	case strings.ToLower(volumebinding.ErrReasonNotEnoughSpace):
+		return true
+	case "nodevolumelimitsexceeded":
+		return true
+	}
+
+	return strings.Contains(normalized, "node")
+}
+
+func isPodScopedVolumeConflictReason(reason volumebinding.ConflictReason) bool {
+	normalized := strings.ToLower(strings.TrimSpace(string(reason)))
+	if normalized == "" {
+		return false
+	}
+
+	if normalized == strings.ToLower(volumebinding.ErrReasonPVNotExist) {
+		return true
+	}
+
+	return strings.Contains(normalized, "pvc") ||
+		strings.Contains(normalized, "persistentvolumeclaim") ||
+		strings.Contains(normalized, "non-existent pv")
 }
 
 func isTransientBindFailure(err error) bool {

--- a/pkg/cache/bind_error_classifier_test.go
+++ b/pkg/cache/bind_error_classifier_test.go
@@ -1,0 +1,102 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
+)
+
+func TestClassifyBindFailure_Transient(t *testing.T) {
+	err := WrapBindFailureError(
+		BindFailureStageBindPod,
+		BindFailureOperationKubeBindPod,
+		apierrors.NewTimeoutError("timed out", 1),
+	)
+
+	decision := ClassifyBindFailure(err)
+	assert.Equal(t, decision.Scope, BindFailureScopeUnknown)
+	assert.Equal(t, decision.Durability, BindFailureDurabilityTransient)
+	assert.Equal(t, decision.Action, BindFailureActionRetrySameNode)
+	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+}
+
+func TestClassifyBindFailure_NodeNotFound(t *testing.T) {
+	err := WrapBindFailureError(
+		BindFailureStageBindPod,
+		BindFailureOperationKubeBindPod,
+		apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, "node-a"),
+	)
+
+	decision := ClassifyBindFailure(err)
+	assert.Equal(t, decision.Scope, BindFailureScopeNode)
+	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
+	assert.Equal(t, decision.Action, BindFailureActionRetryDifferentNode)
+	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+}
+
+func TestClassifyBindFailure_ConflictReasons(t *testing.T) {
+	err := NewBindFailureConflictError(
+		BindFailureStageAssumePod,
+		BindFailureOperationFindPodVolumes,
+		"pod-a",
+		volumebinding.ConflictReasons{
+			volumebinding.ConflictReason("NodeVolumeLimitsExceeded"),
+		},
+	)
+
+	decision := ClassifyBindFailure(err)
+	assert.Equal(t, decision.Scope, BindFailureScopeNode)
+	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
+	assert.Equal(t, decision.Action, BindFailureActionRetryDifferentNode)
+	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+}
+
+func TestClassifyBindFailure_PodForbidden(t *testing.T) {
+	err := WrapBindFailureError(
+		BindFailureStageBindPod,
+		BindFailureOperationKubeBindPod,
+		apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "pod-a", errors.New("forbidden")),
+	)
+
+	decision := ClassifyBindFailure(err)
+	assert.Equal(t, decision.Scope, BindFailureScopePod)
+	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
+	assert.Equal(t, decision.Action, BindFailureActionFailFast)
+	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+}
+
+func TestClassifyBindFailure_AlreadyBoundTreatAsSuccess(t *testing.T) {
+	err := WrapBindFailureError(
+		BindFailureStageBindPod,
+		BindFailureOperationKubeBindPod,
+		apierrors.NewAlreadyExists(schema.GroupResource{Resource: "pods"}, "pod-a"),
+	)
+
+	decision := ClassifyBindFailure(err)
+	assert.Equal(t, decision.Scope, BindFailureScopePod)
+	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
+	assert.Equal(t, decision.Action, BindFailureActionTreatAsSuccess)
+	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+}

--- a/pkg/cache/bind_error_classifier_test.go
+++ b/pkg/cache/bind_error_classifier_test.go
@@ -40,7 +40,6 @@ func TestClassifyBindFailure_Transient(t *testing.T) {
 	assert.Equal(t, decision.Scope, BindFailureScopeUnknown)
 	assert.Equal(t, decision.Durability, BindFailureDurabilityTransient)
 	assert.Equal(t, decision.Action, BindFailureActionRetrySameNode)
-	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
 func TestClassifyBindFailure_TooManyRequestsIsTransient(t *testing.T) {
@@ -54,7 +53,6 @@ func TestClassifyBindFailure_TooManyRequestsIsTransient(t *testing.T) {
 	assert.Equal(t, decision.Scope, BindFailureScopeUnknown)
 	assert.Equal(t, decision.Durability, BindFailureDurabilityTransient)
 	assert.Equal(t, decision.Action, BindFailureActionRetrySameNode)
-	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
 func TestClassifyBindFailure_NodeNotFound(t *testing.T) {
@@ -68,7 +66,6 @@ func TestClassifyBindFailure_NodeNotFound(t *testing.T) {
 	assert.Equal(t, decision.Scope, BindFailureScopeNode)
 	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
 	assert.Equal(t, decision.Action, BindFailureActionRetryDifferentNode)
-	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
 func TestClassifyBindFailure_ConflictReasons(t *testing.T) {
@@ -77,7 +74,7 @@ func TestClassifyBindFailure_ConflictReasons(t *testing.T) {
 		BindFailureOperationFindPodVolumes,
 		"pod-a",
 		volumebinding.ConflictReasons{
-			volumebinding.ConflictReason("NodeVolumeLimitsExceeded"),
+			volumebinding.ConflictReason(volumebinding.ErrReasonNodeConflict),
 		},
 	)
 
@@ -85,7 +82,6 @@ func TestClassifyBindFailure_ConflictReasons(t *testing.T) {
 	assert.Equal(t, decision.Scope, BindFailureScopeNode)
 	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
 	assert.Equal(t, decision.Action, BindFailureActionRetryDifferentNode)
-	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
 func TestClassifyBindFailure_ConflictReasonsPodScoped(t *testing.T) {
@@ -102,7 +98,6 @@ func TestClassifyBindFailure_ConflictReasonsPodScoped(t *testing.T) {
 	assert.Equal(t, decision.Scope, BindFailureScopePod)
 	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
 	assert.Equal(t, decision.Action, BindFailureActionFailFast)
-	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
 func TestClassifyBindFailure_PodForbidden(t *testing.T) {
@@ -116,7 +111,6 @@ func TestClassifyBindFailure_PodForbidden(t *testing.T) {
 	assert.Equal(t, decision.Scope, BindFailureScopePod)
 	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
 	assert.Equal(t, decision.Action, BindFailureActionFailFast)
-	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
 func TestClassifyBindFailure_PodInvalid(t *testing.T) {
@@ -134,7 +128,6 @@ func TestClassifyBindFailure_PodInvalid(t *testing.T) {
 	assert.Equal(t, decision.Scope, BindFailureScopePod)
 	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
 	assert.Equal(t, decision.Action, BindFailureActionFailFast)
-	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
 func TestClassifyBindFailure_NotFoundPodOrPVC(t *testing.T) {
@@ -166,7 +159,6 @@ func TestClassifyBindFailure_NotFoundPodOrPVC(t *testing.T) {
 			assert.Equal(t, decision.Scope, BindFailureScopePod)
 			assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
 			assert.Equal(t, decision.Action, BindFailureActionFailFast)
-			assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 		})
 	}
 }
@@ -182,10 +174,9 @@ func TestClassifyBindFailure_AlreadyBoundTreatAsSuccess(t *testing.T) {
 	assert.Equal(t, decision.Scope, BindFailureScopePod)
 	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
 	assert.Equal(t, decision.Action, BindFailureActionTreatAsSuccess)
-	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
-func TestClassifyBindFailure_UnknownLowConfidence(t *testing.T) {
+func TestClassifyBindFailure_UnknownRetriesByDefault(t *testing.T) {
 	err := WrapBindFailureError(
 		BindFailureStageBindPod,
 		BindFailureOperationKubeBindPod,
@@ -195,6 +186,5 @@ func TestClassifyBindFailure_UnknownLowConfidence(t *testing.T) {
 	decision := ClassifyBindFailure(err)
 	assert.Equal(t, decision.Scope, BindFailureScopeUnknown)
 	assert.Equal(t, decision.Durability, BindFailureDurabilityUnknown)
-	assert.Equal(t, decision.Action, BindFailureActionFailFast)
-	assert.Equal(t, decision.Confidence, BindFailureConfidenceLow)
+	assert.Equal(t, decision.Action, BindFailureActionRetrySameNode)
 }

--- a/pkg/cache/bind_error_classifier_test.go
+++ b/pkg/cache/bind_error_classifier_test.go
@@ -25,6 +25,7 @@ import (
 	"gotest.tools/v3/assert"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 )
 
@@ -33,6 +34,20 @@ func TestClassifyBindFailure_Transient(t *testing.T) {
 		BindFailureStageBindPod,
 		BindFailureOperationKubeBindPod,
 		apierrors.NewTimeoutError("timed out", 1),
+	)
+
+	decision := ClassifyBindFailure(err)
+	assert.Equal(t, decision.Scope, BindFailureScopeUnknown)
+	assert.Equal(t, decision.Durability, BindFailureDurabilityTransient)
+	assert.Equal(t, decision.Action, BindFailureActionRetrySameNode)
+	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+}
+
+func TestClassifyBindFailure_TooManyRequestsIsTransient(t *testing.T) {
+	err := WrapBindFailureError(
+		BindFailureStageBindPod,
+		BindFailureOperationKubeBindPod,
+		apierrors.NewTooManyRequests("throttled", 1),
 	)
 
 	decision := ClassifyBindFailure(err)
@@ -73,6 +88,23 @@ func TestClassifyBindFailure_ConflictReasons(t *testing.T) {
 	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
+func TestClassifyBindFailure_ConflictReasonsPodScoped(t *testing.T) {
+	err := NewBindFailureConflictError(
+		BindFailureStageAssumePod,
+		BindFailureOperationFindPodVolumes,
+		"pod-a",
+		volumebinding.ConflictReasons{
+			volumebinding.ConflictReason(volumebinding.ErrReasonPVNotExist),
+		},
+	)
+
+	decision := ClassifyBindFailure(err)
+	assert.Equal(t, decision.Scope, BindFailureScopePod)
+	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
+	assert.Equal(t, decision.Action, BindFailureActionFailFast)
+	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+}
+
 func TestClassifyBindFailure_PodForbidden(t *testing.T) {
 	err := WrapBindFailureError(
 		BindFailureStageBindPod,
@@ -87,6 +119,58 @@ func TestClassifyBindFailure_PodForbidden(t *testing.T) {
 	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
 }
 
+func TestClassifyBindFailure_PodInvalid(t *testing.T) {
+	err := WrapBindFailureError(
+		BindFailureStageBindPod,
+		BindFailureOperationKubeBindPod,
+		apierrors.NewInvalid(
+			schema.GroupKind{Group: "", Kind: "Pod"},
+			"pod-a",
+			field.ErrorList{field.Invalid(field.NewPath("spec", "nodeName"), "", "node is invalid")},
+		),
+	)
+
+	decision := ClassifyBindFailure(err)
+	assert.Equal(t, decision.Scope, BindFailureScopePod)
+	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
+	assert.Equal(t, decision.Action, BindFailureActionFailFast)
+	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+}
+
+func TestClassifyBindFailure_NotFoundPodOrPVC(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "pod not found",
+			err: WrapBindFailureError(
+				BindFailureStageBindPod,
+				BindFailureOperationKubeBindPod,
+				apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "pod-a"),
+			),
+		},
+		{
+			name: "pvc not found",
+			err: WrapBindFailureError(
+				BindFailureStageBindPodVolumes,
+				BindFailureOperationGetPodVolumeClaims,
+				apierrors.NewNotFound(schema.GroupResource{Resource: "persistentvolumeclaims"}, "pvc-a"),
+			),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := ClassifyBindFailure(tc.err)
+			assert.Equal(t, decision.Scope, BindFailureScopePod)
+			assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
+			assert.Equal(t, decision.Action, BindFailureActionFailFast)
+			assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+		})
+	}
+}
+
 func TestClassifyBindFailure_AlreadyBoundTreatAsSuccess(t *testing.T) {
 	err := WrapBindFailureError(
 		BindFailureStageBindPod,
@@ -99,4 +183,18 @@ func TestClassifyBindFailure_AlreadyBoundTreatAsSuccess(t *testing.T) {
 	assert.Equal(t, decision.Durability, BindFailureDurabilityPermanent)
 	assert.Equal(t, decision.Action, BindFailureActionTreatAsSuccess)
 	assert.Equal(t, decision.Confidence, BindFailureConfidenceHigh)
+}
+
+func TestClassifyBindFailure_UnknownLowConfidence(t *testing.T) {
+	err := WrapBindFailureError(
+		BindFailureStageBindPod,
+		BindFailureOperationKubeBindPod,
+		errors.New("opaque bind failure"),
+	)
+
+	decision := ClassifyBindFailure(err)
+	assert.Equal(t, decision.Scope, BindFailureScopeUnknown)
+	assert.Equal(t, decision.Durability, BindFailureDurabilityUnknown)
+	assert.Equal(t, decision.Action, BindFailureActionFailFast)
+	assert.Equal(t, decision.Confidence, BindFailureConfidenceLow)
 }

--- a/pkg/cache/bind_error_test.go
+++ b/pkg/cache/bind_error_test.go
@@ -1,0 +1,91 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/test"
+	"github.com/apache/yunikorn-k8shim/pkg/dispatcher"
+)
+
+func TestWrapBindFailureError_PreservesMessageAndStatus(t *testing.T) {
+	baseErr := apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "test-pod")
+	wrappedErr := WrapBindFailureError(BindFailureStageBindPod, BindFailureOperationKubeBindPod, baseErr)
+
+	assert.Equal(t, wrappedErr.Error(), baseErr.Error())
+
+	details, ok := GetBindFailureDetails(wrappedErr)
+	assert.Assert(t, ok)
+	assert.Equal(t, details.Stage, BindFailureStageBindPod)
+	assert.Equal(t, details.Operation, BindFailureOperationKubeBindPod)
+	assert.Equal(t, details.StatusReason, metav1.StatusReasonNotFound)
+	assert.Equal(t, details.StatusCode, int32(404))
+	assert.Equal(t, details.ResourceKind, "pods")
+	assert.Equal(t, details.ResourceName, "test-pod")
+}
+
+func TestNewBindFailureConflictError_PreservesConflictReasons(t *testing.T) {
+	reasons := volumebinding.ConflictReasons{
+		volumebinding.ConflictReason("reason-a"),
+		volumebinding.ConflictReason("reason-b"),
+	}
+
+	err := NewBindFailureConflictError(
+		BindFailureStageAssumePod,
+		BindFailureOperationFindPodVolumes,
+		"pod-1",
+		reasons,
+	)
+
+	assert.Equal(t, err.Error(), "pod pod-1 has conflicting volume claims: reason-a, reason-b")
+
+	details, ok := GetBindFailureDetails(err)
+	assert.Assert(t, ok)
+	assert.Equal(t, details.Stage, BindFailureStageAssumePod)
+	assert.Equal(t, details.Operation, BindFailureOperationFindPodVolumes)
+	assert.Equal(t, len(details.ConflictReasons), 2)
+	assert.Equal(t, string(details.ConflictReasons[0]), "reason-a")
+	assert.Equal(t, string(details.ConflictReasons[1]), "reason-b")
+}
+
+func TestAssumePodConflictErrorContainsBindFailureDetails(t *testing.T) {
+	binder := test.NewVolumeBinderMock()
+	binder.SetConflictReasons("reason1", "reason2")
+	context := initAssumePodTest(binder)
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	err := context.AssumePod(pod1UID, fakeNodeName)
+	assert.Error(t, err, "pod pod1 has conflicting volume claims: reason1, reason2")
+
+	details, ok := GetBindFailureDetails(err)
+	assert.Assert(t, ok)
+	assert.Equal(t, details.Stage, BindFailureStageAssumePod)
+	assert.Equal(t, details.Operation, BindFailureOperationFindPodVolumes)
+	assert.Equal(t, len(details.ConflictReasons), 2)
+	assert.Equal(t, string(details.ConflictReasons[0]), "reason1")
+	assert.Equal(t, string(details.ConflictReasons[1]), "reason2")
+}

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
@@ -63,6 +64,8 @@ import (
 
 const registerNodeContextHandler = "RegisterNodeContextHandler"
 
+const failedNodeSuppressionTTL = 10 * time.Minute
+
 var (
 	ErrorPodNotFound  = errors.New("predicates were not run because pod was not found in cache")
 	ErrorNodeNotFound = errors.New("predicates were not run because node was not found in cache")
@@ -72,12 +75,14 @@ var (
 type Context struct {
 	applications   map[string]*Application        // apps
 	schedulerCache *schedulercache.SchedulerCache // external cache
-	apiProvider    client.APIProvider             // apis to interact with api-server, scheduler-core, etc
-	predManager    predicates.PredicateManager    // K8s predicates
-	namespace      string                         // yunikorn namespace
-	configMaps     []*v1.ConfigMap                // cached yunikorn configmaps
-	lock           *locking.RWMutex               // lock - used not only for context data but also to ensure that multiple event types are not executed concurrently
-	txnID          atomic.Uint64                  // transaction ID counter
+	failedNodes    map[string]map[string]time.Time
+	failedNodesMu  *locking.RWMutex
+	apiProvider    client.APIProvider          // apis to interact with api-server, scheduler-core, etc
+	predManager    predicates.PredicateManager // K8s predicates
+	namespace      string                      // yunikorn namespace
+	configMaps     []*v1.ConfigMap             // cached yunikorn configmaps
+	lock           *locking.RWMutex            // lock - used not only for context data but also to ensure that multiple event types are not executed concurrently
+	txnID          atomic.Uint64               // transaction ID counter
 	klogger        klog.Logger
 }
 
@@ -95,12 +100,14 @@ func NewContextWithBootstrapConfigMaps(apis client.APIProvider, bootstrapConfigM
 	// nodecontroller needs the cache
 	// predictor need the cache, volumebinder and informers
 	ctx := &Context{
-		applications: make(map[string]*Application),
-		apiProvider:  apis,
-		namespace:    schedulerconf.GetSchedulerConf().Namespace,
-		configMaps:   bootstrapConfigMaps,
-		lock:         &locking.RWMutex{},
-		klogger:      klog.NewKlogr(),
+		applications:  make(map[string]*Application),
+		apiProvider:   apis,
+		namespace:     schedulerconf.GetSchedulerConf().Namespace,
+		configMaps:    bootstrapConfigMaps,
+		failedNodes:   make(map[string]map[string]time.Time), // map of taskID to nodeName along with time of ttl expiry for retry
+		failedNodesMu: &locking.RWMutex{},
+		lock:          &locking.RWMutex{},
+		klogger:       klog.NewKlogr(),
 	}
 
 	// create the cache
@@ -686,6 +693,9 @@ func (ctx *Context) EventsToRegister(queueingHintFn fwk.QueueingHintFn) []fwk.Cl
 func (ctx *Context) IsPodFitNode(name, node string, allocate bool) error {
 	ctx.lock.RLock()
 	defer ctx.lock.RUnlock()
+	if ctx.isNodeSuppressedForTask(name, node) {
+		return fmt.Errorf("node %s is temporarily suppressed for allocation %s after a node-scoped bind failure", node, name)
+	}
 	pod := ctx.schedulerCache.GetPod(name)
 	if pod == nil {
 		return ErrorPodNotFound
@@ -750,6 +760,7 @@ func (ctx *Context) bindPodVolumes(pod *v1.Pod) error {
 			// retrieve the volume claims
 			podVolumeClaims, err := ctx.apiProvider.GetAPIs().VolumeBinder.GetPodVolumeClaims(ctx.klogger, pod)
 			if err != nil {
+				err = WrapBindFailureError(BindFailureStageBindPodVolumes, BindFailureOperationGetPodVolumeClaims, err)
 				log.Log(log.ShimContext).Error("Failed to get pod volume claims",
 					zap.String("podName", assumedPod.Name),
 					zap.Error(err))
@@ -759,6 +770,7 @@ func (ctx *Context) bindPodVolumes(pod *v1.Pod) error {
 			// get node information
 			node, err := ctx.schedulerCache.GetNodeInfo(assumedPod.Spec.NodeName)
 			if err != nil {
+				err = WrapBindFailureError(BindFailureStageBindPodVolumes, BindFailureOperationGetNodeInfo, err)
 				log.Log(log.ShimContext).Error("Failed to get node info",
 					zap.String("podName", assumedPod.Name),
 					zap.String("nodeName", assumedPod.Spec.NodeName),
@@ -769,6 +781,7 @@ func (ctx *Context) bindPodVolumes(pod *v1.Pod) error {
 			// retrieve volumes
 			volumes, reasons, err := ctx.apiProvider.GetAPIs().VolumeBinder.FindPodVolumes(ctx.klogger, pod, podVolumeClaims, node)
 			if err != nil {
+				err = WrapBindFailureError(BindFailureStageBindPodVolumes, BindFailureOperationFindPodVolumes, err)
 				log.Log(log.ShimContext).Error("Failed to find pod volumes",
 					zap.String("podName", assumedPod.Name),
 					zap.String("nodeName", assumedPod.Spec.NodeName),
@@ -776,12 +789,7 @@ func (ctx *Context) bindPodVolumes(pod *v1.Pod) error {
 				return err
 			}
 			if len(reasons) > 0 {
-				sReasons := make([]string, 0)
-				for _, reason := range reasons {
-					sReasons = append(sReasons, string(reason))
-				}
-				sReason := strings.Join(sReasons, ", ")
-				err = fmt.Errorf("pod %s has conflicting volume claims: %s", pod.Name, sReason)
+				err = NewBindFailureConflictError(BindFailureStageBindPodVolumes, BindFailureOperationFindPodVolumes, pod.Name, reasons)
 				log.Log(log.ShimContext).Error("Pod has conflicting volume claims",
 					zap.String("podName", assumedPod.Name),
 					zap.String("nodeName", assumedPod.Spec.NodeName),
@@ -798,6 +806,7 @@ func (ctx *Context) bindPodVolumes(pod *v1.Pod) error {
 			}
 			err = ctx.apiProvider.GetAPIs().VolumeBinder.BindPodVolumes(context.Background(), assumedPod, volumes)
 			if err != nil {
+				err = WrapBindFailureError(BindFailureStageBindPodVolumes, BindFailureOperationBindPodVolumes, err)
 				log.Log(log.ShimContext).Error("Failed to bind pod volumes",
 					zap.String("podName", assumedPod.Name),
 					zap.String("nodeName", assumedPod.Spec.NodeName),
@@ -832,6 +841,7 @@ func (ctx *Context) AssumePod(name, node string) error {
 			// retrieve the volume claims
 			podVolumeClaims, err := ctx.apiProvider.GetAPIs().VolumeBinder.GetPodVolumeClaims(ctx.klogger, pod)
 			if err != nil {
+				err = WrapBindFailureError(BindFailureStageAssumePod, BindFailureOperationGetPodVolumeClaims, err)
 				log.Log(log.ShimContext).Error("Failed to get pod volume claims",
 					zap.String("podName", assumedPod.Name),
 					zap.Error(err))
@@ -841,6 +851,7 @@ func (ctx *Context) AssumePod(name, node string) error {
 			// retrieve volumes
 			volumes, reasons, err := ctx.apiProvider.GetAPIs().VolumeBinder.FindPodVolumes(ctx.klogger, pod, podVolumeClaims, targetNode.Node())
 			if err != nil {
+				err = WrapBindFailureError(BindFailureStageAssumePod, BindFailureOperationFindPodVolumes, err)
 				log.Log(log.ShimContext).Error("Failed to find pod volumes",
 					zap.String("podName", assumedPod.Name),
 					zap.String("nodeName", node),
@@ -848,12 +859,7 @@ func (ctx *Context) AssumePod(name, node string) error {
 				return err
 			}
 			if len(reasons) > 0 {
-				sReasons := make([]string, len(reasons))
-				for i, reason := range reasons {
-					sReasons[i] = string(reason)
-				}
-				sReason := strings.Join(sReasons, ", ")
-				err = fmt.Errorf("pod %s has conflicting volume claims: %s", pod.Name, sReason)
+				err = NewBindFailureConflictError(BindFailureStageAssumePod, BindFailureOperationFindPodVolumes, pod.Name, reasons)
 				log.Log(log.ShimContext).Error("Pod has conflicting volume claims",
 					zap.String("podName", assumedPod.Name),
 					zap.String("nodeName", node),
@@ -862,6 +868,7 @@ func (ctx *Context) AssumePod(name, node string) error {
 			}
 			allBound, err = ctx.apiProvider.GetAPIs().VolumeBinder.AssumePodVolumes(ctx.klogger, pod, node, volumes)
 			if err != nil {
+				err = WrapBindFailureError(BindFailureStageAssumePod, BindFailureOperationAssumePodVolumes, err)
 				return err
 			}
 
@@ -885,6 +892,46 @@ func (ctx *Context) ForgetPod(name string) {
 		return
 	}
 	log.Log(log.ShimContext).Debug("unable to forget pod: not found in cache", zap.String("pod", name))
+}
+
+func (ctx *Context) rememberFailedNodeForTask(taskID, nodeID string) {
+	if taskID == "" || nodeID == "" {
+		return
+	}
+
+	ctx.failedNodesMu.Lock()
+	defer ctx.failedNodesMu.Unlock()
+	if _, ok := ctx.failedNodes[taskID]; !ok {
+		ctx.failedNodes[taskID] = make(map[string]time.Time)
+	}
+	ctx.failedNodes[taskID][nodeID] = time.Now().Add(failedNodeSuppressionTTL)
+}
+
+func (ctx *Context) clearFailedNodesForTask(taskID string) {
+	if taskID == "" {
+		return
+	}
+
+	ctx.failedNodesMu.Lock()
+	defer ctx.failedNodesMu.Unlock()
+	delete(ctx.failedNodes, taskID)
+}
+
+func (ctx *Context) isNodeSuppressedForTask(taskID, nodeID string) bool {
+	ctx.failedNodesMu.RLock()
+	defer ctx.failedNodesMu.RUnlock()
+
+	nodeMap, ok := ctx.failedNodes[taskID]
+	if !ok {
+		return false
+	}
+
+	expiry, ok := nodeMap[nodeID]
+	if !ok {
+		return false
+	}
+
+	return time.Now().Before(expiry)
 }
 
 func (ctx *Context) notifyTaskComplete(app *Application, taskID string) {

--- a/pkg/cache/scheduler_callback.go
+++ b/pkg/cache/scheduler_callback.go
@@ -65,18 +65,76 @@ func (callback *AsyncRMCallback) UpdateAllocation(response *si.AllocationRespons
 		}
 
 		task.setAllocationKey(alloc.AllocationKey)
+		task.setNodeName(alloc.NodeID)
 		backOff := wait.Backoff{
 			Steps:    30,
 			Duration: time.Second,
 			Cap:      30 * time.Second,
 		}
 		err := retry.OnError(backOff, func(err error) bool {
-			log.Log(log.ShimRMCallback).Error("AssumePod failed, retrying", zap.Error(err))
+			decision := ClassifyBindFailure(err)
+			if decision.Durability != BindFailureDurabilityTransient || decision.Action != BindFailureActionRetrySameNode {
+				log.Log(log.ShimRMCallback).Warn("AssumePod failed with non-retryable error",
+					zap.String("allocationKey", alloc.AllocationKey),
+					zap.String("applicationID", alloc.ApplicationID),
+					zap.String("nodeID", alloc.NodeID),
+					zap.String("failureScope", string(decision.Scope)),
+					zap.String("failureDurability", string(decision.Durability)),
+					zap.String("shadowAction", string(decision.Action)),
+					zap.String("decisionConfidence", string(decision.Confidence)),
+					zap.String("decisionReason", decision.Reason),
+					zap.Error(err))
+				return false
+			}
+
+			log.Log(log.ShimRMCallback).Warn("AssumePod failed with transient error, retrying",
+				zap.String("allocationKey", alloc.AllocationKey),
+				zap.String("applicationID", alloc.ApplicationID),
+				zap.String("nodeID", alloc.NodeID),
+				zap.String("failureScope", string(decision.Scope)),
+				zap.String("failureDurability", string(decision.Durability)),
+				zap.String("shadowAction", string(decision.Action)),
+				zap.String("decisionConfidence", string(decision.Confidence)),
+				zap.String("decisionReason", decision.Reason),
+				zap.Error(err))
 			return true
 		}, func() error {
 			return callback.context.AssumePod(alloc.AllocationKey, alloc.NodeID)
 		})
 		if err != nil {
+			decision := ClassifyBindFailure(err)
+			if task.rollbackNodeScopedBindFailureWithLock(err) {
+				callback.context.ForgetPod(alloc.AllocationKey)
+				log.Log(log.ShimRMCallback).Info("AssumePod failed with node-scoped error; rolling back allocation and retrying on a different node",
+					zap.String("allocationKey", alloc.AllocationKey),
+					zap.String("applicationID", alloc.ApplicationID),
+					zap.String("failedNodeID", alloc.NodeID),
+					zap.String("failureScope", string(decision.Scope)),
+					zap.String("failureDurability", string(decision.Durability)),
+					zap.String("shadowAction", string(decision.Action)),
+					zap.String("decisionConfidence", string(decision.Confidence)),
+					zap.String("decisionReason", decision.Reason),
+					zap.Error(err))
+				continue
+			}
+
+			fields := []zap.Field{
+				zap.String("allocationKey", alloc.AllocationKey),
+				zap.String("applicationID", alloc.ApplicationID),
+				zap.String("nodeID", alloc.NodeID),
+				zap.String("failureScope", string(decision.Scope)),
+				zap.String("failureDurability", string(decision.Durability)),
+				zap.String("shadowAction", string(decision.Action)),
+				zap.String("decisionConfidence", string(decision.Confidence)),
+				zap.String("decisionReason", decision.Reason),
+			}
+			if details, ok := GetBindFailureDetails(err); ok {
+				fields = append(fields,
+					zap.String("bindStage", string(details.Stage)),
+					zap.String("bindOperation", string(details.Operation)),
+				)
+			}
+			log.Log(log.ShimRMCallback).Warn("AssumePod failed after retries (classification in shadow mode)", fields...)
 			task.FailWithEvent(err.Error(), "AssumePodError")
 			return err
 		}

--- a/pkg/cache/scheduler_callback.go
+++ b/pkg/cache/scheduler_callback.go
@@ -73,7 +73,7 @@ func (callback *AsyncRMCallback) UpdateAllocation(response *si.AllocationRespons
 		}
 		err := retry.OnError(backOff, func(err error) bool {
 			decision := ClassifyBindFailure(err)
-			if decision.Durability != BindFailureDurabilityTransient || decision.Action != BindFailureActionRetrySameNode {
+			if decision.Action != BindFailureActionRetrySameNode {
 				log.Log(log.ShimRMCallback).Warn("AssumePod failed with non-retryable error",
 					zap.String("allocationKey", alloc.AllocationKey),
 					zap.String("applicationID", alloc.ApplicationID),
@@ -81,7 +81,6 @@ func (callback *AsyncRMCallback) UpdateAllocation(response *si.AllocationRespons
 					zap.String("failureScope", string(decision.Scope)),
 					zap.String("failureDurability", string(decision.Durability)),
 					zap.String("shadowAction", string(decision.Action)),
-					zap.String("decisionConfidence", string(decision.Confidence)),
 					zap.String("decisionReason", decision.Reason),
 					zap.Error(err))
 				return false
@@ -94,7 +93,6 @@ func (callback *AsyncRMCallback) UpdateAllocation(response *si.AllocationRespons
 				zap.String("failureScope", string(decision.Scope)),
 				zap.String("failureDurability", string(decision.Durability)),
 				zap.String("shadowAction", string(decision.Action)),
-				zap.String("decisionConfidence", string(decision.Confidence)),
 				zap.String("decisionReason", decision.Reason),
 				zap.Error(err))
 			return true
@@ -112,7 +110,6 @@ func (callback *AsyncRMCallback) UpdateAllocation(response *si.AllocationRespons
 					zap.String("failureScope", string(decision.Scope)),
 					zap.String("failureDurability", string(decision.Durability)),
 					zap.String("shadowAction", string(decision.Action)),
-					zap.String("decisionConfidence", string(decision.Confidence)),
 					zap.String("decisionReason", decision.Reason),
 					zap.Error(err))
 				continue
@@ -125,7 +122,6 @@ func (callback *AsyncRMCallback) UpdateAllocation(response *si.AllocationRespons
 				zap.String("failureScope", string(decision.Scope)),
 				zap.String("failureDurability", string(decision.Durability)),
 				zap.String("shadowAction", string(decision.Action)),
-				zap.String("decisionConfidence", string(decision.Confidence)),
 				zap.String("decisionReason", decision.Reason),
 			}
 			if details, ok := GetBindFailureDetails(err); ok {

--- a/pkg/cache/scheduler_callback_test.go
+++ b/pkg/cache/scheduler_callback_test.go
@@ -20,6 +20,7 @@ package cache
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -27,10 +28,14 @@ import (
 
 	"gotest.tools/v3/assert"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sEvents "k8s.io/client-go/tools/events"
+	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 
 	"github.com/apache/yunikorn-k8shim/pkg/client"
 	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
@@ -110,6 +115,273 @@ func TestUpdateAllocation_NewTask_AssumePodFails(t *testing.T) {
 		return task.GetTaskState() == TaskStates().Failed
 	}, 10*time.Millisecond, time.Second)
 	assert.NilError(t, err, "task has not transitioned to Failed state")
+}
+
+func TestUpdateAllocation_NewTask_AssumePodTransientFailureIsRetried(t *testing.T) {
+	callback, context := initCallbackTest(t, false, false)
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	binder := newTransientAssumePodBinder(1, apierrors.NewTimeoutError("transient assume error", 1))
+	setVolumeBinder(context, binder)
+
+	err := callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        fakeNodeName,
+			},
+		},
+	})
+	assert.NilError(t, err, "error updating allocation")
+	assert.Equal(t, binder.AssumeAttempts(), int32(2))
+
+	task := context.getTask(appID, taskUID1)
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Bound
+	}, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "task has not transitioned to Bound state")
+}
+
+func TestUpdateAllocation_NewTask_AssumePodPermanentFailureNotRetried(t *testing.T) {
+	callback, context := initCallbackTest(t, false, false)
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	binder := newTransientAssumePodBinder(1,
+		apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "pod-a", errors.New("forbidden")))
+	setVolumeBinder(context, binder)
+
+	err := callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        fakeNodeName,
+			},
+		},
+	})
+	assert.Assert(t, err != nil, "expected update allocation error for permanent assume failure")
+	assert.Equal(t, binder.AssumeAttempts(), int32(1))
+
+	task := context.getTask(appID, taskUID1)
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Failed
+	}, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "task has not transitioned to Failed state")
+}
+
+func TestUpdateAllocation_NewTask_TransientBindFailureIsRetried(t *testing.T) {
+	callback, context := initCallbackTest(t, false, false)
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	mockAPI := context.apiProvider.(*client.MockedAPIProvider) //nolint:errcheck
+	var bindAttempts atomic.Int32
+	mockAPI.MockBindFn(func(_ *v1.Pod, _ string) error {
+		if bindAttempts.Add(1) <= 2 {
+			return apierrors.NewTimeoutError("transient bind error", 1)
+		}
+		return nil
+	})
+
+	err := callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        fakeNodeName,
+			},
+		},
+	})
+	assert.NilError(t, err, "error updating allocation")
+
+	task := context.getTask(appID, taskUID1)
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Bound
+	}, 10*time.Millisecond, 2*time.Second)
+	assert.NilError(t, err, "task has not transitioned to Bound state")
+	assert.Equal(t, bindAttempts.Load(), int32(3))
+}
+
+func TestUpdateAllocation_NewTask_PermanentBindFailureNotRetried(t *testing.T) {
+	callback, context := initCallbackTest(t, false, false)
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	mockAPI := context.apiProvider.(*client.MockedAPIProvider) //nolint:errcheck
+	var bindAttempts atomic.Int32
+	mockAPI.MockBindFn(func(pod *v1.Pod, _ string) error {
+		bindAttempts.Add(1)
+		return apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, pod.Name, errors.New("forbidden"))
+	})
+
+	err := callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        fakeNodeName,
+			},
+		},
+	})
+	assert.NilError(t, err, "error updating allocation")
+
+	task := context.getTask(appID, taskUID1)
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Failed
+	}, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "task has not transitioned to Failed state")
+	assert.Equal(t, bindAttempts.Load(), int32(1))
+}
+
+func TestUpdateAllocation_NewTask_NodeScopedPermanentAssumeFailureRollsBackAndRetriesDifferentNode(t *testing.T) {
+	callback, context := initCallbackTest(t, false, false)
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+	recorder := k8sEvents.NewFakeRecorder(1024)
+	events.SetRecorder(recorder)
+	defer events.SetRecorder(events.NewMockedRecorder())
+
+	secondNode := "fake-node-2"
+	context.addNode(&v1.Node{ObjectMeta: apis.ObjectMeta{Name: secondNode, Namespace: "default", UID: "uid_0002"}})
+
+	binder := newTransientAssumePodBinder(1, apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, fakeNodeName))
+	setVolumeBinder(context, binder)
+
+	mockAPI := context.apiProvider.(*client.MockedAPIProvider) //nolint:errcheck
+	var rollbackSent atomic.Bool
+	mockAPI.MockSchedulerAPIUpdateAllocationFn(func(request *si.AllocationRequest) error {
+		if len(request.Allocations) == 1 {
+			tags := request.Allocations[0].AllocationTags
+			if tags[constants.AllocationTagRollback] == constants.True {
+				rollbackSent.Store(true)
+			}
+		}
+		return nil
+	})
+
+	err := callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        fakeNodeName,
+			},
+		},
+	})
+	assert.NilError(t, err, "error updating allocation")
+	assert.Equal(t, binder.AssumeAttempts(), int32(1))
+
+	task := context.getTask(appID, taskUID1)
+	err = utils.WaitForCondition(rollbackSent.Load, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "expected rollback update request")
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Scheduling
+	}, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "task should return to Scheduling state")
+	assert.Assert(t, !context.schedulerCache.IsAssumedPod(taskUID1), "assumed pod should be forgotten after rollback")
+
+	rollbackEvent := ""
+	err = utils.WaitForCondition(func() bool {
+		select {
+		case event := <-recorder.Events:
+			if strings.Contains(event, "NodeScopedBindFailureRetry") {
+				rollbackEvent = event
+				return true
+			}
+		default:
+		}
+		return false
+	}, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "expected NodeScopedBindFailureRetry event")
+	assert.Assert(t, strings.Contains(rollbackEvent, fakeNodeName), "event should include failed node name: %s", rollbackEvent)
+
+	err = context.IsPodFitNode(taskUID1, fakeNodeName, true)
+	assert.Assert(t, err != nil, "failed node should be suppressed after node-scoped assume failure")
+
+	err = callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        secondNode,
+			},
+		},
+	})
+	assert.NilError(t, err, "error updating allocation for retry on second node")
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Bound
+	}, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "task has not transitioned to Bound state after retry")
+	assert.Equal(t, task.GetNodeName(), secondNode)
+}
+
+func TestUpdateAllocation_NewTask_NodeScopedPermanentBindFailureRollsBackAndRetriesDifferentNode(t *testing.T) {
+	callback, context := initCallbackTest(t, false, false)
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	secondNode := "fake-node-2"
+	context.addNode(&v1.Node{ObjectMeta: apis.ObjectMeta{Name: secondNode, Namespace: "default", UID: "uid_0002"}})
+
+	mockAPI := context.apiProvider.(*client.MockedAPIProvider) //nolint:errcheck
+	var rollbackSent atomic.Bool
+	mockAPI.MockSchedulerAPIUpdateAllocationFn(func(request *si.AllocationRequest) error {
+		if len(request.Allocations) == 1 {
+			tags := request.Allocations[0].AllocationTags
+			if tags[constants.AllocationTagRollback] == constants.True {
+				rollbackSent.Store(true)
+			}
+		}
+		return nil
+	})
+	mockAPI.MockBindFn(func(_ *v1.Pod, hostID string) error {
+		if hostID == fakeNodeName {
+			return apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, hostID)
+		}
+		return nil
+	})
+
+	err := callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        fakeNodeName,
+			},
+		},
+	})
+	assert.NilError(t, err, "error updating allocation")
+
+	task := context.getTask(appID, taskUID1)
+	err = utils.WaitForCondition(rollbackSent.Load, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "expected rollback update request")
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Scheduling
+	}, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "task should return to Scheduling state")
+	assert.Assert(t, !context.schedulerCache.IsAssumedPod(taskUID1), "assumed pod should be forgotten after rollback")
+
+	err = context.IsPodFitNode(taskUID1, fakeNodeName, true)
+	assert.Assert(t, err != nil, "failed node should be suppressed after node-scoped bind failure")
+
+	err = callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        secondNode,
+			},
+		},
+	})
+	assert.NilError(t, err, "error updating allocation for retry on second node")
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Bound
+	}, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "task has not transitioned to Bound state after retry")
+	assert.Equal(t, task.GetNodeName(), secondNode)
 }
 
 func TestUpdateAllocation_NewTask_PodAlreadyAssigned(t *testing.T) {
@@ -520,6 +792,33 @@ func TestCallbackGetStateDump(t *testing.T) {
 var _ predicates.PredicateManager = &mockPredicateManager{}
 
 type mockPredicateManager struct{}
+
+type transientAssumePodBinder struct {
+	*test.VolumeBinderMock
+	failUntil int32
+	failure   error
+	attempts  atomic.Int32
+}
+
+func newTransientAssumePodBinder(failUntil int32, failure error) *transientAssumePodBinder {
+	return &transientAssumePodBinder{
+		VolumeBinderMock: test.NewVolumeBinderMock(),
+		failUntil:        failUntil,
+		failure:          failure,
+	}
+}
+
+func (b *transientAssumePodBinder) AssumePodVolumes(klogger klog.Logger, pod *v1.Pod, node string, volumes *volumebinding.PodVolumes) (bool, error) {
+	attempt := b.attempts.Add(1)
+	if attempt <= b.failUntil {
+		return false, b.failure
+	}
+	return b.VolumeBinderMock.AssumePodVolumes(klogger, pod, node, volumes)
+}
+
+func (b *transientAssumePodBinder) AssumeAttempts() int32 {
+	return b.attempts.Load()
+}
 
 func (m *mockPredicateManager) EventsToRegister(_ fwk.QueueingHintFn) []fwk.ClusterEventWithHint {
 	return nil

--- a/pkg/cache/scheduler_callback_test.go
+++ b/pkg/cache/scheduler_callback_test.go
@@ -205,6 +205,68 @@ func TestUpdateAllocation_NewTask_TransientBindFailureIsRetried(t *testing.T) {
 	assert.Equal(t, bindAttempts.Load(), int32(3))
 }
 
+func TestUpdateAllocation_NewTask_UnknownBindFailureRetriesUpToLimitThenFails(t *testing.T) {
+	callback, context := initCallbackTest(t, false, false)
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	mockAPI := context.apiProvider.(*client.MockedAPIProvider) //nolint:errcheck
+	var bindAttempts atomic.Int32
+	mockAPI.MockBindFn(func(_ *v1.Pod, _ string) error {
+		bindAttempts.Add(1)
+		return errors.New("opaque bind error")
+	})
+
+	err := callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        fakeNodeName,
+			},
+		},
+	})
+	assert.NilError(t, err, "error updating allocation")
+
+	task := context.getTask(appID, taskUID1)
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Failed
+	}, 10*time.Millisecond, 3*time.Second)
+	assert.NilError(t, err, "task has not transitioned to Failed state")
+	assert.Equal(t, bindAttempts.Load(), int32(transientBindFailureRetryBackoff.Steps))
+}
+
+func TestUpdateAllocation_NewTask_IdempotentBindConflictTreatedAsSuccess(t *testing.T) {
+	callback, context := initCallbackTest(t, false, false)
+	defer dispatcher.UnregisterAllEventHandlers()
+	defer dispatcher.Stop()
+
+	mockAPI := context.apiProvider.(*client.MockedAPIProvider) //nolint:errcheck
+	var bindAttempts atomic.Int32
+	mockAPI.MockBindFn(func(pod *v1.Pod, _ string) error {
+		bindAttempts.Add(1)
+		return apierrors.NewAlreadyExists(schema.GroupResource{Resource: "pods"}, pod.Name)
+	})
+
+	err := callback.UpdateAllocation(&si.AllocationResponse{
+		New: []*si.Allocation{
+			{
+				ApplicationID: appID,
+				AllocationKey: taskUID1,
+				NodeID:        fakeNodeName,
+			},
+		},
+	})
+	assert.NilError(t, err, "error updating allocation")
+
+	task := context.getTask(appID, taskUID1)
+	err = utils.WaitForCondition(func() bool {
+		return task.GetTaskState() == TaskStates().Bound
+	}, 10*time.Millisecond, time.Second)
+	assert.NilError(t, err, "task has not transitioned to Bound state")
+	assert.Equal(t, bindAttempts.Load(), int32(1))
+}
+
 func TestUpdateAllocation_NewTask_PermanentBindFailureNotRetried(t *testing.T) {
 	callback, context := initCallbackTest(t, false, false)
 	defer dispatcher.UnregisterAllEventHandlers()

--- a/pkg/cache/scheduler_callback_test.go
+++ b/pkg/cache/scheduler_callback_test.go
@@ -233,7 +233,7 @@ func TestUpdateAllocation_NewTask_UnknownBindFailureRetriesUpToLimitThenFails(t 
 		return task.GetTaskState() == TaskStates().Failed
 	}, 10*time.Millisecond, 3*time.Second)
 	assert.NilError(t, err, "task has not transitioned to Failed state")
-	assert.Equal(t, bindAttempts.Load(), int32(transientBindFailureRetryBackoff.Steps))
+	assert.Equal(t, int(bindAttempts.Load()), transientBindFailureRetryBackoff.Steps)
 }
 
 func TestUpdateAllocation_NewTask_IdempotentBindConflictTreatedAsSuccess(t *testing.T) {

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -700,7 +700,6 @@ func (task *Task) logBindFailure(message string, err error) {
 		zap.String("failureScope", string(decision.Scope)),
 		zap.String("failureDurability", string(decision.Durability)),
 		zap.String("shadowAction", string(decision.Action)),
-		zap.String("decisionConfidence", string(decision.Confidence)),
 		zap.String("decisionReason", decision.Reason),
 	)
 
@@ -710,19 +709,8 @@ func (task *Task) logBindFailure(message string, err error) {
 func (task *Task) retryTransientBindFailure(operation string, run func() error) error {
 	return retry.OnError(transientBindFailureRetryBackoff, func(err error) bool {
 		decision := ClassifyBindFailure(err)
-		if decision.Durability == BindFailureDurabilityTransient && decision.Action == BindFailureActionRetrySameNode {
+		if decision.Action == BindFailureActionRetrySameNode {
 			log.Log(log.ShimCacheTask).Warn("retrying transient bind failure",
-				zap.String("taskID", task.taskID),
-				zap.String("operation", operation),
-				zap.String("failureScope", string(decision.Scope)),
-				zap.String("failureDurability", string(decision.Durability)),
-				zap.String("decisionReason", decision.Reason),
-				zap.Error(err))
-			return true
-		}
-
-		if decision.Scope == BindFailureScopeUnknown && decision.Confidence == BindFailureConfidenceLow {
-			log.Log(log.ShimCacheTask).Warn("retrying low-confidence bind failure with bounded fallback",
 				zap.String("taskID", task.taskID),
 				zap.String("operation", operation),
 				zap.String("failureScope", string(decision.Scope)),

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -27,6 +27,8 @@ import (
 	"github.com/looplab/fsm"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
 	"github.com/apache/yunikorn-k8shim/pkg/common"
@@ -61,6 +63,14 @@ type Task struct {
 	pod             *v1.Pod
 
 	lock *locking.RWMutex
+}
+
+var transientBindFailureRetryBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 100 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Cap:      2 * time.Second,
 }
 
 func NewTask(tid string, app *Application, ctx *Context, pod *v1.Pod) *Task {
@@ -347,9 +357,16 @@ func (task *Task) postTaskPending() {
 // If successful, we move task to next state BOUND, otherwise we fail the task
 func (task *Task) postTaskAllocated() {
 	go func() {
+		forgetAssumedPod := false
+
 		// we need to obtain task's lock first,
 		// this ensures no other threads modifying task state at the time being
 		task.lock.Lock()
+		defer func() {
+			if forgetAssumedPod {
+				task.context.ForgetPod(task.taskID)
+			}
+		}()
 		defer task.lock.Unlock()
 
 		// post a message to indicate the pod gets its allocation
@@ -361,8 +378,15 @@ func (task *Task) postTaskAllocated() {
 		log.Log(log.ShimCacheTask).Debug("bind pod volumes",
 			zap.String("podName", task.pod.Name),
 			zap.String("podUID", string(task.pod.UID)))
-		if err := task.context.bindPodVolumes(task.pod); err != nil {
-			log.Log(log.ShimCacheTask).Error("bind volumes to pod failed", zap.String("taskID", task.taskID), zap.Error(err))
+		err := task.retryTransientBindFailure("bind pod volumes", func() error {
+			return task.context.bindPodVolumes(task.pod)
+		})
+		if err != nil {
+			task.logBindFailure("bind volumes to pod failed", err)
+			if task.rollbackNodeScopedBindFailure(err) {
+				forgetAssumedPod = true
+				return
+			}
 			task.failWithEvent(fmt.Sprintf("bind volumes to pod failed, name: %s, %s", task.alias, err.Error()), "PodVolumesBindFailure")
 			return
 		}
@@ -370,8 +394,16 @@ func (task *Task) postTaskAllocated() {
 			zap.String("podName", task.pod.Name),
 			zap.String("podUID", string(task.pod.UID)))
 
-		if err := task.context.apiProvider.GetAPIs().KubeClient.Bind(task.pod, task.nodeName); err != nil {
-			log.Log(log.ShimCacheTask).Error("bind pod to node failed", zap.String("taskID", task.taskID), zap.Error(err))
+		err = task.retryTransientBindFailure("bind pod to node", func() error {
+			bindErr := task.context.apiProvider.GetAPIs().KubeClient.Bind(task.pod, task.nodeName)
+			return WrapBindFailureError(BindFailureStageBindPod, BindFailureOperationKubeBindPod, bindErr)
+		})
+		if err != nil {
+			task.logBindFailure("bind pod to node failed", err)
+			if task.rollbackNodeScopedBindFailure(err) {
+				forgetAssumedPod = true
+				return
+			}
 			task.failWithEvent(fmt.Sprintf("bind pod to node failed, name: %s, %s", task.alias, err.Error()), "PodBindFailure")
 			return
 		}
@@ -409,6 +441,7 @@ func (task *Task) beforeTaskAllocated(eventSrc string, allocationKey string, nod
 }
 
 func (task *Task) postTaskBound() {
+	task.context.clearFailedNodesForTask(task.taskID)
 	if task.placeholder {
 		log.Log(log.ShimCacheTask).Info("placeholder is bound",
 			zap.String("appID", task.applicationID),
@@ -433,6 +466,7 @@ func (task *Task) postTaskRejected() {
 // this is done as a before hook because the releaseAllocation() call needs to
 // send different requests to scheduler-core, depending on current task state
 func (task *Task) beforeTaskFail() {
+	task.context.clearFailedNodesForTask(task.taskID)
 	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
 		v1.EventTypeNormal, "TaskFailed", "TaskFailed",
 		"Task %s is failed", task.alias)
@@ -443,6 +477,7 @@ func (task *Task) beforeTaskFail() {
 // this is done as a before hook because the releaseAllocation() call needs to
 // send different requests to scheduler-core, depending on current task state
 func (task *Task) beforeTaskCompleted() {
+	task.context.clearFailedNodesForTask(task.taskID)
 	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
 		v1.EventTypeNormal, "TaskCompleted", "TaskCompleted",
 		"Task %s is completed", task.alias)
@@ -595,6 +630,12 @@ func (task *Task) setAllocationKey(allocationKey string) {
 	task.allocationKey = allocationKey
 }
 
+func (task *Task) setNodeName(nodeName string) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+	task.nodeName = nodeName
+}
+
 func (task *Task) FailWithEvent(errorMessage, actionReason string) {
 	task.lock.RLock()
 	defer task.lock.RUnlock()
@@ -605,6 +646,128 @@ func (task *Task) failWithEvent(errorMessage, actionReason string) {
 	events.GetRecorder().Eventf(task.pod.DeepCopy(),
 		nil, v1.EventTypeWarning, actionReason, actionReason, errorMessage)
 	dispatcher.Dispatch(NewFailTaskEvent(task.applicationID, task.taskID, errorMessage))
+}
+
+func (task *Task) logBindFailure(message string, err error) {
+	fields := []zap.Field{
+		zap.String("taskID", task.taskID),
+		zap.Error(err),
+	}
+
+	if details, ok := GetBindFailureDetails(err); ok {
+		fields = append(fields,
+			zap.String("bindStage", string(details.Stage)),
+			zap.String("bindOperation", string(details.Operation)),
+		)
+		if details.StatusReason != "" {
+			fields = append(fields, zap.String("k8sReason", string(details.StatusReason)))
+		}
+		if details.StatusCode != 0 {
+			fields = append(fields, zap.Int32("k8sStatusCode", details.StatusCode))
+		}
+		if details.ResourceKind != "" {
+			fields = append(fields, zap.String("resourceKind", details.ResourceKind))
+		}
+		if details.ResourceName != "" {
+			fields = append(fields, zap.String("resourceName", details.ResourceName))
+		}
+		if len(details.ConflictReasons) > 0 {
+			reasons := make([]string, len(details.ConflictReasons))
+			for i, reason := range details.ConflictReasons {
+				reasons[i] = string(reason)
+			}
+			fields = append(fields, zap.Strings("volumeConflictReasons", reasons))
+		}
+	}
+
+	decision := ClassifyBindFailure(err)
+	fields = append(fields,
+		zap.String("failureScope", string(decision.Scope)),
+		zap.String("failureDurability", string(decision.Durability)),
+		zap.String("shadowAction", string(decision.Action)),
+		zap.String("decisionConfidence", string(decision.Confidence)),
+		zap.String("decisionReason", decision.Reason),
+	)
+
+	log.Log(log.ShimCacheTask).Error(message, fields...)
+}
+
+func (task *Task) retryTransientBindFailure(operation string, run func() error) error {
+	return retry.OnError(transientBindFailureRetryBackoff, func(err error) bool {
+		decision := ClassifyBindFailure(err)
+		if decision.Durability != BindFailureDurabilityTransient || decision.Action != BindFailureActionRetrySameNode {
+			return false
+		}
+
+		log.Log(log.ShimCacheTask).Warn("retrying transient bind failure",
+			zap.String("taskID", task.taskID),
+			zap.String("operation", operation),
+			zap.String("failureScope", string(decision.Scope)),
+			zap.String("failureDurability", string(decision.Durability)),
+			zap.String("decisionReason", decision.Reason),
+			zap.Error(err))
+		return true
+	}, run)
+}
+
+func (task *Task) rollbackNodeScopedBindFailure(bindErr error) bool {
+	decision := ClassifyBindFailure(bindErr)
+	if decision.Durability != BindFailureDurabilityPermanent ||
+		decision.Scope != BindFailureScopeNode ||
+		decision.Action != BindFailureActionRetryDifferentNode {
+		return false
+	}
+
+	failedNode := task.nodeName
+	rollbackRequest := common.CreateAllocationRollbackForTask(
+		task.applicationID,
+		task.taskID,
+		task.application.partition,
+		task.resource,
+		task.pod,
+	)
+	if err := task.context.apiProvider.GetAPIs().SchedulerAPI.UpdateAllocation(rollbackRequest); err != nil {
+		log.Log(log.ShimCacheTask).Error("failed to rollback allocation after node-scoped bind failure",
+			zap.String("taskID", task.taskID),
+			zap.String("nodeID", failedNode),
+			zap.Error(err))
+		return false
+	}
+
+	task.context.rememberFailedNodeForTask(task.taskID, failedNode)
+	task.allocationKey = ""
+	task.nodeName = ""
+	task.schedulingState = TaskSchedPending
+	if task.sm.Current() == TaskStates().Allocated {
+		if err := task.sm.Event(context.Background(), TaskRetry.String(), task, []interface{}{}); err != nil {
+			log.Log(log.ShimCacheTask).Error("failed to move task to scheduling state after node-scoped bind failure rollback",
+				zap.String("taskID", task.taskID),
+				zap.String("nodeID", failedNode),
+				zap.Error(err))
+			return false
+		}
+	} else if task.sm.Current() != TaskStates().Scheduling {
+		log.Log(log.ShimCacheTask).Error("unexpected task state for node-scoped bind failure rollback",
+			zap.String("taskID", task.taskID),
+			zap.String("taskState", task.sm.Current()),
+			zap.String("nodeID", failedNode))
+		return false
+	}
+
+	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
+		v1.EventTypeNormal, "NodeScopedBindFailureRetry", "NodeScopedBindFailureRetry",
+		"Retrying pod %s on a different node after bind failure on node %s", task.alias, failedNode)
+	log.Log(log.ShimCacheTask).Info("rolled back allocation for node-scoped bind failure",
+		zap.String("taskID", task.taskID),
+		zap.String("failedNode", failedNode),
+		zap.String("decisionReason", decision.Reason))
+	return true
+}
+
+func (task *Task) rollbackNodeScopedBindFailureWithLock(bindErr error) bool {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+	return task.rollbackNodeScopedBindFailure(bindErr)
 }
 
 func (task *Task) SetTaskPod(pod *v1.Pod) {

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -400,6 +400,9 @@ func (task *Task) postTaskAllocated() {
 		})
 		if err != nil {
 			task.logBindFailure("bind pod to node failed", err)
+			if task.handleBindFailureAsSuccess(err) {
+				return
+			}
 			if task.rollbackNodeScopedBindFailure(err) {
 				forgetAssumedPod = true
 				return
@@ -695,19 +698,51 @@ func (task *Task) logBindFailure(message string, err error) {
 func (task *Task) retryTransientBindFailure(operation string, run func() error) error {
 	return retry.OnError(transientBindFailureRetryBackoff, func(err error) bool {
 		decision := ClassifyBindFailure(err)
-		if decision.Durability != BindFailureDurabilityTransient || decision.Action != BindFailureActionRetrySameNode {
-			return false
+		if decision.Durability == BindFailureDurabilityTransient && decision.Action == BindFailureActionRetrySameNode {
+			log.Log(log.ShimCacheTask).Warn("retrying transient bind failure",
+				zap.String("taskID", task.taskID),
+				zap.String("operation", operation),
+				zap.String("failureScope", string(decision.Scope)),
+				zap.String("failureDurability", string(decision.Durability)),
+				zap.String("decisionReason", decision.Reason),
+				zap.Error(err))
+			return true
 		}
 
-		log.Log(log.ShimCacheTask).Warn("retrying transient bind failure",
-			zap.String("taskID", task.taskID),
-			zap.String("operation", operation),
-			zap.String("failureScope", string(decision.Scope)),
-			zap.String("failureDurability", string(decision.Durability)),
-			zap.String("decisionReason", decision.Reason),
-			zap.Error(err))
-		return true
+		if decision.Scope == BindFailureScopeUnknown && decision.Confidence == BindFailureConfidenceLow {
+			log.Log(log.ShimCacheTask).Warn("retrying low-confidence bind failure with bounded fallback",
+				zap.String("taskID", task.taskID),
+				zap.String("operation", operation),
+				zap.String("failureScope", string(decision.Scope)),
+				zap.String("failureDurability", string(decision.Durability)),
+				zap.String("decisionReason", decision.Reason),
+				zap.Error(err))
+			return true
+		}
+
+		return false
 	}, run)
+}
+
+func (task *Task) handleBindFailureAsSuccess(bindErr error) bool {
+	decision := ClassifyBindFailure(bindErr)
+	if decision.Action != BindFailureActionTreatAsSuccess {
+		return false
+	}
+
+	log.Log(log.ShimCacheTask).Info("treating idempotent bind failure as success",
+		zap.String("taskID", task.taskID),
+		zap.String("failureScope", string(decision.Scope)),
+		zap.String("failureDurability", string(decision.Durability)),
+		zap.String("decisionReason", decision.Reason),
+		zap.Error(bindErr))
+
+	dispatcher.Dispatch(NewBindTaskEvent(task.applicationID, task.taskID))
+	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
+		v1.EventTypeNormal, "PodBindSuccessful", "PodBindSuccessful",
+		"Pod %s is already bound to node %s", task.alias, task.nodeName)
+	task.schedulingState = TaskSchedAllocated
+	return true
 }
 
 func (task *Task) rollbackNodeScopedBindFailure(bindErr error) bool {

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -484,7 +484,7 @@ func (task *Task) beforeTaskCompleted() {
 	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
 		v1.EventTypeNormal, "TaskCompleted", "TaskCompleted",
 		"Task %s is completed", task.alias)
-  task.releaseAllocation(false)
+	task.releaseAllocation(false)
 }
 
 // releaseAllocation sends the release request for the Allocation to the core.

--- a/pkg/cache/task_state.go
+++ b/pkg/cache/task_state.go
@@ -348,11 +348,6 @@ func eventDesc(states *TStates) fsm.Events {
 			Dst:  states.Scheduling,
 		},
 		{
-			Name: TaskRetry.String(),
-			Src:  []string{states.Scheduling},
-			Dst:  states.Scheduling,
-		},
-		{
 			Name: TaskBound.String(),
 			Src:  []string{states.Allocated},
 			Dst:  states.Bound,

--- a/pkg/cache/task_state.go
+++ b/pkg/cache/task_state.go
@@ -41,6 +41,7 @@ const (
 	InitTask TaskEventType = iota
 	SubmitTask
 	TaskAllocated
+	TaskRetry
 	TaskRejected
 	TaskBound
 	CompleteTask
@@ -50,7 +51,7 @@ const (
 )
 
 func (ae TaskEventType) String() string {
-	return [...]string{"InitTask", "SubmitTask", "TaskAllocated", "TaskRejected", "TaskBound", "CompleteTask", "TaskFail", "KillTask", "TaskKilled"}[ae]
+	return [...]string{"InitTask", "SubmitTask", "TaskAllocated", "TaskRetry", "TaskRejected", "TaskBound", "CompleteTask", "TaskFail", "KillTask", "TaskKilled"}[ae]
 }
 
 // ------------------------
@@ -340,6 +341,16 @@ func eventDesc(states *TStates) fsm.Events {
 			Name: TaskAllocated.String(),
 			Src:  []string{states.Completed},
 			Dst:  states.Completed,
+		},
+		{
+			Name: TaskRetry.String(),
+			Src:  []string{states.Allocated},
+			Dst:  states.Scheduling,
+		},
+		{
+			Name: TaskRetry.String(),
+			Src:  []string{states.Scheduling},
+			Dst:  states.Scheduling,
 		},
 		{
 			Name: TaskBound.String(),

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -25,6 +25,7 @@ import (
 // Common
 const True = "true"
 const False = "false"
+const AllocationTagRollback = DomainYuniKornInternal + "allocation-rollback"
 
 // Kubernetes
 const Label = "label"

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -114,6 +114,26 @@ func CreateAllocationForTask(appID, taskID, nodeID string, resource *si.Resource
 	}
 }
 
+func CreateAllocationRollbackForTask(appID, taskID, partition string, resource *si.Resource, pod *v1.Pod) *si.AllocationRequest {
+	tags := CreateTagsForTask(pod)
+	tags[common.CreationTime] = strconv.FormatInt(pod.CreationTimestamp.Unix(), 10)
+	tags[constants.AllocationTagRollback] = constants.True
+
+	allocation := si.Allocation{
+		AllocationKey:    taskID,
+		ApplicationID:    appID,
+		PartitionName:    partition,
+		AllocationTags:   tags,
+		ResourcePerAlloc: resource,
+		Priority:         CreatePriorityForTask(pod),
+	}
+
+	return &si.AllocationRequest{
+		Allocations: []*si.Allocation{&allocation},
+		RmID:        conf.GetSchedulerConf().ClusterID,
+	}
+}
+
 func CreateAllocationForForeignPod(pod *v1.Pod) *si.AllocationRequest {
 	podType := common.AllocTypeDefault
 	for _, ref := range pod.OwnerReferences {

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/apache/yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/common"
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
@@ -106,6 +107,34 @@ func TestCreateUpdateRequestForTask(t *testing.T) {
 
 	assert.Equal(t, tags[common.DomainK8s+common.GroupLabel+"label1"], "val1")
 	assert.Equal(t, tags[common.DomainK8s+common.GroupLabel+"label2"], "val2")
+}
+
+func TestCreateAllocationRollbackForTask(t *testing.T) {
+	res := NewResourceBuilder().Build()
+	pod := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name:              "pod-rollback-test",
+			UID:               "UID-rollback",
+			Namespace:         "default",
+			CreationTimestamp: apis.NewTime(time.Unix(10, 0)),
+		},
+	}
+
+	request := CreateAllocationRollbackForTask("app-rollback", "task-rollback", "default", res, pod)
+	assert.Assert(t, request != nil)
+	assert.Equal(t, len(request.Allocations), 1)
+
+	allocation := request.Allocations[0]
+	assert.Equal(t, allocation.AllocationKey, "task-rollback")
+	assert.Equal(t, allocation.ApplicationID, "app-rollback")
+	assert.Equal(t, allocation.PartitionName, "default")
+	assert.Equal(t, allocation.NodeID, "")
+	assert.Equal(t, allocation.AllocationTags[constants.AllocationTagRollback], constants.True)
+	assert.Equal(t, allocation.AllocationTags[common.CreationTime], "10")
 }
 
 func TestCreateTagsForTask(t *testing.T) {

--- a/test/e2e/predicates/predicates_test.go
+++ b/test/e2e/predicates/predicates_test.go
@@ -423,14 +423,14 @@ var _ = Describe("Predicates", func() {
 		err = kClient.TaintNode(nodeName, taintKey, taintValue, taintEffect)
 		Ω(err).NotTo(HaveOccurred())
 		defer func() {
-			err := kClient.UntaintNode(nodeName, taintKey)
-			Ω(err).NotTo(HaveOccurred())
+			untaintErr := kClient.UntaintNode(nodeName, taintKey)
+			Ω(untaintErr).NotTo(HaveOccurred())
 		}()
 
 		ginkgo.By("Trying to apply a random label on the found node.")
 		labelKey := fmt.Sprintf("kubernetes.io/e2e-label-key-%s", common.RandSeq(10))
 		labelValue := LABELVALUE
-		err := kClient.SetNodeLabel(nodeName, labelKey, labelValue)
+		err = kClient.SetNodeLabel(nodeName, labelKey, labelValue)
 		Ω(err).NotTo(HaveOccurred())
 		exists, existsErr := kClient.IsNodeLabelExists(nodeName, labelKey)
 		Ω(existsErr).NotTo(HaveOccurred())
@@ -465,10 +465,10 @@ var _ = Describe("Predicates", func() {
 
 		err = restClient.WaitForAllocationLog("default", "root."+ns, initPod.Labels["applicationId"], podNameNoTolerations, 60)
 		Ω(err).NotTo(HaveOccurred())
-		log, err := restClient.GetAllocationLog("default", "root."+ns, initPod.Labels["applicationId"], podNameNoTolerations)
-		Ω(err).NotTo(HaveOccurred())
-		Ω(log).NotTo(BeNil(), "Log can't be empty")
-		logEntries := yunikorn.AllocLogToStrings(log)
+		allocationLog, getLogErr := restClient.GetAllocationLog("default", "root."+ns, initPod.Labels["applicationId"], podNameNoTolerations)
+		Ω(getLogErr).NotTo(HaveOccurred())
+		Ω(allocationLog).NotTo(BeNil(), "Log can't be empty")
+		logEntries := yunikorn.AllocLogToStrings(allocationLog)
 		Ω(logEntries).To(ContainElement(MatchRegexp(".*taint.*")), "Log entry message mismatch")
 
 		// Remove taint off the node and verify the pod is scheduled on node.
@@ -476,8 +476,8 @@ var _ = Describe("Predicates", func() {
 		Ω(err).NotTo(HaveOccurred())
 		Ω(kClient.WaitForPodRunning(ns, podNameNoTolerations, time.Duration(60)*time.Second)).NotTo(HaveOccurred())
 
-		labelPod, err := kClient.GetPod(podNameNoTolerations, ns)
-		Ω(err).NotTo(HaveOccurred())
+		labelPod, getPodErr := kClient.GetPod(podNameNoTolerations, ns)
+		Ω(getPodErr).NotTo(HaveOccurred())
 		Ω(labelPod.Spec.NodeName).Should(Equal(nodeName))
 	})
 
@@ -557,7 +557,7 @@ var _ = Describe("Predicates", func() {
 		}
 
 		defer func() {
-			_ = wait.PollUntilContextTimeout(context.TODO(), time.Second, 2*time.Minute, false, func(context.Context) (bool, error) {
+			pollErr := wait.PollUntilContextTimeout(context.TODO(), time.Second, 2*time.Minute, false, func(context.Context) (bool, error) {
 				latestNodes, getErr := kClient.GetNodes()
 				if getErr != nil {
 					return false, nil
@@ -569,6 +569,7 @@ var _ = Describe("Predicates", func() {
 				}
 				return false, nil
 			})
+			Ω(pollErr).NotTo(HaveOccurred())
 		}()
 
 		By("Untainting fallback nodes to allow retry on a different node")

--- a/test/e2e/predicates/predicates_test.go
+++ b/test/e2e/predicates/predicates_test.go
@@ -19,13 +19,16 @@
 package predicates_test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	tests "github.com/apache/yunikorn-k8shim/test/e2e"
 	"github.com/apache/yunikorn-k8shim/test/e2e/framework/configmanager"
@@ -36,6 +39,36 @@ import (
 
 // variable populated in BeforeEach, never modified afterwards
 var workerNodes []string
+
+func getSchedulableComputeNodes(k *k8s.KubeCtl) ([]string, error) {
+	nodes, err := k.GetNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	schedulable := make([]string, 0)
+	for _, node := range nodes.Items {
+		n := node
+		if k8s.IsMasterNode(&n) || !k8s.IsComputeNode(&n) || n.Spec.Unschedulable {
+			continue
+		}
+
+		hasNoScheduleTaint := false
+		for _, taint := range n.Spec.Taints {
+			if taint.Effect == v1.TaintEffectNoSchedule {
+				hasNoScheduleTaint = true
+				break
+			}
+		}
+		if hasNoScheduleTaint {
+			continue
+		}
+
+		schedulable = append(schedulable, n.Name)
+	}
+
+	return schedulable, nil
+}
 
 func getNodeThatCanRunPodWithoutToleration(k *k8s.KubeCtl, namespace string) string {
 	By("Trying to launch a pod without a toleration to get a node which can launch it.")
@@ -446,6 +479,111 @@ var _ = Describe("Predicates", func() {
 		labelPod, err := kClient.GetPod(podNameNoTolerations, ns)
 		Ω(err).NotTo(HaveOccurred())
 		Ω(labelPod.Spec.NodeName).Should(Equal(nodeName))
+	})
+
+	It("Verify_NodeScoped_BindFailure_Retries_On_Different_Node", func() {
+		nodeNames, nodeErr := getSchedulableComputeNodes(&kClient)
+		Ω(nodeErr).NotTo(HaveOccurred())
+		if len(nodeNames) < 2 {
+			ginkgo.Skip("Node-scoped bind failure retry test requires at least 2 schedulable compute nodes")
+		}
+
+		primaryNode := nodeNames[0]
+		fallbackNodes := nodeNames[1:]
+
+		taintKey := fmt.Sprintf("kubernetes.io/e2e-bind-failure-%s", common.RandSeq(6))
+		taintValue := "blocked"
+
+		By(fmt.Sprintf("Tainting fallback nodes to force initial scheduling onto %s", primaryNode))
+		err = kClient.TaintNodes(fallbackNodes, taintKey, taintValue, v1.TaintEffectNoSchedule)
+		Ω(err).NotTo(HaveOccurred())
+		defer func() {
+			err = kClient.UntaintNodes(fallbackNodes, taintKey)
+			Ω(err).NotTo(HaveOccurred())
+		}()
+
+		candidatePodName := ""
+		for attempt := 1; attempt <= 3; attempt++ {
+			podName := fmt.Sprintf("bind-retry-%d-%s", attempt, common.RandSeq(4))
+			podConf := k8s.SleepPodConfig{
+				Name: podName,
+				NS:   ns,
+				CPU:  10,
+				Mem:  20,
+				Time: 300,
+				Labels: map[string]string{
+					"app": "bind-failure-retry-" + common.RandSeq(5),
+				},
+			}
+
+			podObj, podErr := k8s.InitSleepPod(podConf)
+			Ω(podErr).NotTo(HaveOccurred())
+			createdPod, createErr := kClient.CreatePod(podObj, ns)
+			Ω(createErr).NotTo(HaveOccurred())
+
+			appID := createdPod.Labels["applicationId"]
+			pollErr := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 30*time.Second, false,
+				func(context.Context) (bool, error) {
+					appInfo, infoErr := restClient.GetAppInfo("default", "root."+ns, appID)
+					if infoErr != nil {
+						return false, nil
+					}
+					return len(appInfo.Allocations) > 0, nil
+				})
+			Ω(pollErr).NotTo(HaveOccurred())
+
+			latestPod, getErr := kClient.GetPod(podName, ns)
+			Ω(getErr).NotTo(HaveOccurred())
+			if latestPod.Spec.NodeName == "" {
+				candidatePodName = podName
+				break
+			}
+
+			By(fmt.Sprintf("Attempt %d observed pod already bound, retrying with a new pod", attempt))
+			err = kClient.DeletePod(podName, ns)
+			Ω(err).NotTo(HaveOccurred())
+			err = kClient.WaitForPodTerminated(ns, podName, 60*time.Second)
+			Ω(err).NotTo(HaveOccurred())
+		}
+
+		if candidatePodName == "" {
+			ginkgo.Skip("Unable to catch the pre-bind allocation window in this environment")
+		}
+
+		By(fmt.Sprintf("Deleting node %s to trigger node-scoped bind failure", primaryNode))
+		err = kClient.GetClient().CoreV1().Nodes().Delete(context.TODO(), primaryNode, metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			Ω(err).NotTo(HaveOccurred())
+		}
+
+		defer func() {
+			_ = wait.PollUntilContextTimeout(context.TODO(), time.Second, 2*time.Minute, false, func(context.Context) (bool, error) {
+				latestNodes, getErr := kClient.GetNodes()
+				if getErr != nil {
+					return false, nil
+				}
+				for _, node := range latestNodes.Items {
+					if node.Name == primaryNode {
+						return true, nil
+					}
+				}
+				return false, nil
+			})
+		}()
+
+		By("Untainting fallback nodes to allow retry on a different node")
+		err = kClient.UntaintNodes(fallbackNodes, taintKey)
+		Ω(err).NotTo(HaveOccurred())
+
+		err = kClient.WaitForPodEvent(ns, candidatePodName, "NodeScopedBindFailureRetry", 2*time.Minute)
+		Ω(err).NotTo(HaveOccurred())
+
+		err = kClient.WaitForPodRunning(ns, candidatePodName, 2*time.Minute)
+		Ω(err).NotTo(HaveOccurred())
+
+		runningPod, getErr := kClient.GetPod(candidatePodName, ns)
+		Ω(getErr).NotTo(HaveOccurred())
+		Ω(runningPod.Spec.NodeName).NotTo(Equal(primaryNode))
 	})
 
 	// Tests for Pod Affinity & Anti Affinity


### PR DESCRIPTION
### Description
Short description of this pull request, can be as simple as the commit message used.
First time contributing? Check out the contributing guide: https://yunikorn.apache.org/community/how_to_contribute


### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-XXXXX

- [ ] I have created a Jira issue for this pull request.
- [ ] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
