### PR TITLE
[YUNIKORN-2634] Deprecate user resolution handling via the label

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -341,14 +341,18 @@ func GetUserFromPod(pod *v1.Pod) (string, []string) {
 
 	// Label is processed for backwards compatibility
 	userLabelKey := conf.GetSchedulerConf().UserLabelKey
+	if userLabelKey != "" {
+		log.Log(log.Deprecation).Warn("'userLabelKey' config is deprecated, use 'user.info' annotation")
+	}
 	// UserLabelKey should not be empty
-	if len(userLabelKey) == 0 {
+	if userLabelKey == "" {
 		userLabelKey = constants.DefaultUserLabel
 	}
-	// User name to be defined in labels
+	// Username to be defined in labels
 	if username := GetPodLabelValue(pod, userLabelKey); username != "" && len(username) > 0 {
-		log.Log(log.ShimUtils).Info("Found user name from pod labels.",
-			zap.String("userLabel", userLabelKey), zap.String("user", username))
+		log.Log(log.Deprecation).Warn("Found user name from pod label",
+			zap.String("userLabel", userLabelKey),
+			zap.String("user", username))
 		return username, nil
 	}
 	value := constants.DefaultUser

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -54,8 +54,8 @@ const (
 // Defined loggers: when adding new loggers, ids must be sequential, and all must be added to the loggers slice in the same order
 var (
 	Shim                  = &LoggerHandle{id: 0, name: "shim"}
-	Test        = &LoggerHandle{id: 1, name: "test"}
-	Deprecation = &LoggerHandle{id: 2, name: "deprecation"}
+	Test                  = &LoggerHandle{id: 1, name: "test"}
+	Deprecation           = &LoggerHandle{id: 2, name: "deprecation"}
 	Admission             = &LoggerHandle{id: 3, name: "admission"}
 	AdmissionClient       = &LoggerHandle{id: 4, name: "admission.client"}
 	AdmissionConf         = &LoggerHandle{id: 5, name: "admission.conf"}
@@ -80,7 +80,7 @@ var (
 	ShimPredicates        = &LoggerHandle{id: 24, name: "shim.predicates"}
 	ShimFramework         = &LoggerHandle{id: 25, name: "shim.framework"}
 	ShimPlaceHolderConfig = &LoggerHandle{id: 26, name: "shim.placeholder.config"}
-	Kubernetes  = &LoggerHandle{id: 27, name: "kubernetes"}
+	Kubernetes            = &LoggerHandle{id: 27, name: "kubernetes"}
 )
 
 // this tracks all the known logger handles, used to preallocate the real logger instances when configuration changes

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -54,8 +54,8 @@ const (
 // Defined loggers: when adding new loggers, ids must be sequential, and all must be added to the loggers slice in the same order
 var (
 	Shim                  = &LoggerHandle{id: 0, name: "shim"}
-	Kubernetes            = &LoggerHandle{id: 1, name: "kubernetes"}
-	Test                  = &LoggerHandle{id: 2, name: "test"}
+	Test        = &LoggerHandle{id: 1, name: "test"}
+	Deprecation = &LoggerHandle{id: 2, name: "deprecation"}
 	Admission             = &LoggerHandle{id: 3, name: "admission"}
 	AdmissionClient       = &LoggerHandle{id: 4, name: "admission.client"}
 	AdmissionConf         = &LoggerHandle{id: 5, name: "admission.conf"}
@@ -80,15 +80,16 @@ var (
 	ShimPredicates        = &LoggerHandle{id: 24, name: "shim.predicates"}
 	ShimFramework         = &LoggerHandle{id: 25, name: "shim.framework"}
 	ShimPlaceHolderConfig = &LoggerHandle{id: 26, name: "shim.placeholder.config"}
+	Kubernetes  = &LoggerHandle{id: 27, name: "kubernetes"}
 )
 
 // this tracks all the known logger handles, used to preallocate the real logger instances when configuration changes
 var loggers = []*LoggerHandle{
-	Shim, Kubernetes, Test,
+	Shim, Test, Deprecation,
 	Admission, AdmissionClient, AdmissionConf, AdmissionWebhook, AdmissionUtils, ShimContext, ShimFSM,
 	ShimCacheApplication, ShimCacheAppMgmt, ShimCacheNode, ShimCacheTask, ShimCacheExternal, ShimCachePlaceholder,
 	ShimRMCallback, ShimClient, ShimResources, ShimUtils, ShimConfig, ShimDispatcher,
-	ShimScheduler, ShimSchedulerPlugin, ShimPredicates, ShimFramework, ShimPlaceHolderConfig,
+	ShimScheduler, ShimSchedulerPlugin, ShimPredicates, ShimFramework, ShimPlaceHolderConfig, Kubernetes,
 }
 
 // structure to hold all current logger configuration state

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -54,17 +54,17 @@ const (
 // Defined loggers: when adding new loggers, ids must be sequential, and all must be added to the loggers slice in the same order
 var (
 	Shim                  = &LoggerHandle{id: 0, name: "shim"}
-	Test                  = &LoggerHandle{id: 1, name: "test"}
-	Deprecation           = &LoggerHandle{id: 2, name: "deprecation"}
-	Admission             = &LoggerHandle{id: 3, name: "admission"}
-	AdmissionClient       = &LoggerHandle{id: 4, name: "admission.client"}
-	AdmissionConf         = &LoggerHandle{id: 5, name: "admission.conf"}
-	AdmissionWebhook      = &LoggerHandle{id: 6, name: "admission.webhook"}
-	AdmissionUtils        = &LoggerHandle{id: 7, name: "admission.utils"}
-	ShimContext           = &LoggerHandle{id: 8, name: "shim.context"}
-	ShimFSM               = &LoggerHandle{id: 9, name: "shim.fsm"}
-	ShimCacheApplication  = &LoggerHandle{id: 10, name: "shim.cache.application"}
-	ShimCacheAppMgmt      = &LoggerHandle{id: 11, name: "shim.cache.appmgmt"}
+	Kubernetes            = &LoggerHandle{id: 1, name: "kubernetes"}
+	Test                  = &LoggerHandle{id: 2, name: "test"}
+	Deprecation           = &LoggerHandle{id: 3, name: "deprecation"}
+	Admission             = &LoggerHandle{id: 4, name: "admission"}
+	AdmissionClient       = &LoggerHandle{id: 5, name: "admission.client"}
+	AdmissionConf         = &LoggerHandle{id: 6, name: "admission.conf"}
+	AdmissionWebhook      = &LoggerHandle{id: 7, name: "admission.webhook"}
+	AdmissionUtils        = &LoggerHandle{id: 8, name: "admission.utils"}
+	ShimContext           = &LoggerHandle{id: 9, name: "shim.context"}
+	ShimFSM               = &LoggerHandle{id: 10, name: "shim.fsm"}
+	ShimCacheApplication  = &LoggerHandle{id: 11, name: "shim.cache.application"}
 	ShimCacheNode         = &LoggerHandle{id: 12, name: "shim.cache.node"}
 	ShimCacheTask         = &LoggerHandle{id: 13, name: "shim.cache.task"}
 	ShimCacheExternal     = &LoggerHandle{id: 14, name: "shim.cache.external"}
@@ -76,20 +76,18 @@ var (
 	ShimConfig            = &LoggerHandle{id: 20, name: "shim.config"}
 	ShimDispatcher        = &LoggerHandle{id: 21, name: "shim.dispatcher"}
 	ShimScheduler         = &LoggerHandle{id: 22, name: "shim.scheduler"}
-	ShimSchedulerPlugin   = &LoggerHandle{id: 23, name: "shim.scheduler.plugin"}
-	ShimPredicates        = &LoggerHandle{id: 24, name: "shim.predicates"}
-	ShimFramework         = &LoggerHandle{id: 25, name: "shim.framework"}
-	ShimPlaceHolderConfig = &LoggerHandle{id: 26, name: "shim.placeholder.config"}
-	Kubernetes            = &LoggerHandle{id: 27, name: "kubernetes"}
+	ShimPredicates        = &LoggerHandle{id: 23, name: "shim.predicates"}
+	ShimFramework         = &LoggerHandle{id: 24, name: "shim.framework"}
+	ShimPlaceHolderConfig = &LoggerHandle{id: 25, name: "shim.placeholder.config"}
 )
 
 // this tracks all the known logger handles, used to preallocate the real logger instances when configuration changes
 var loggers = []*LoggerHandle{
-	Shim, Test, Deprecation,
+	Shim, Kubernetes, Test, Deprecation,
 	Admission, AdmissionClient, AdmissionConf, AdmissionWebhook, AdmissionUtils, ShimContext, ShimFSM,
-	ShimCacheApplication, ShimCacheAppMgmt, ShimCacheNode, ShimCacheTask, ShimCacheExternal, ShimCachePlaceholder,
+	ShimCacheApplication, ShimCacheNode, ShimCacheTask, ShimCacheExternal, ShimCachePlaceholder,
 	ShimRMCallback, ShimClient, ShimResources, ShimUtils, ShimConfig, ShimDispatcher,
-	ShimScheduler, ShimSchedulerPlugin, ShimPredicates, ShimFramework, ShimPlaceHolderConfig, Kubernetes,
+	ShimScheduler, ShimPredicates, ShimFramework, ShimPlaceHolderConfig,
 }
 
 // structure to hold all current logger configuration state

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -38,7 +38,7 @@ func TestLoggerIds(t *testing.T) {
 	_ = Log(Test)
 
 	// validate logger count
-	assert.Equal(t, 28, len(loggers), "wrong logger count")
+	assert.Equal(t, 26, len(loggers), "wrong logger count")
 
 	// validate that all loggers are populated and have sequential ids
 	for i := 0; i < len(loggers); i++ {

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -38,7 +38,7 @@ func TestLoggerIds(t *testing.T) {
 	_ = Log(Test)
 
 	// validate logger count
-	assert.Equal(t, 27, len(loggers), "wrong logger count")
+	assert.Equal(t, 28, len(loggers), "wrong logger count")
 
 	// validate that all loggers are populated and have sequential ids
 	for i := 0; i < len(loggers); i++ {


### PR DESCRIPTION
### Description
Add the deprecation logger like it is available in the core. Log the usage of the 'userLabelKey' in the config via the deprecation logger at the WARN level. Log the retrieval of the username from a pod using the deprecation logger at the WARN level.

### Type of change
- [X] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-2634

- [X] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [X] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [X] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A