### PR TITLE
[YUNIKORN-3324] Remove pod "ignore-application" annotation

### DIFF
--- a/pkg/admission/admission_controller.go
+++ b/pkg/admission/admission_controller.go
@@ -199,8 +199,6 @@ func (c *AdmissionController) processPod(req *admissionv1.AdmissionRequest, name
 	if c.shouldLabelNamespace(namespace) {
 		patch = c.updateLabels(namespace, &pod, patch)
 		patch = c.updatePreemptionInfo(&pod, patch)
-	} else {
-		patch = disableYuniKorn(namespace, &pod, patch)
 	}
 	log.Log(log.Admission).Info("generated patch",
 		zap.String("namespace", namespace),
@@ -428,23 +426,6 @@ func (c *AdmissionController) updateLabels(namespace string, pod *v1.Pod, patch 
 	patch = append(patch, common.PatchOperation{
 		Op:    "add",
 		Path:  "/metadata/labels",
-		Value: result,
-	})
-
-	return patch
-}
-
-func disableYuniKorn(namespace string, pod *v1.Pod, patch []common.PatchOperation) []common.PatchOperation {
-	log.Log(log.Admission).Info("disabling yunikorn on pod since namespace is set to no-label",
-		zap.String("podName", pod.Name),
-		zap.String("generateName", pod.GenerateName),
-		zap.String("namespace", namespace))
-
-	result := updatePodAnnotation(pod, constants.AnnotationIgnoreApplication, constants.True)
-
-	patch = append(patch, common.PatchOperation{
-		Op:    "add",
-		Path:  "/metadata/annotations",
 		Value: result,
 	})
 

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -112,9 +112,6 @@ const NamespaceMaxApps = DomainYuniKorn + "namespace.maxApps"
 // AnnotationAllowPreemption set on PriorityClass, opt out of preemption for pods with this priority class
 const AnnotationAllowPreemption = DomainYuniKorn + "allow-preemption"
 
-// AnnotationIgnoreApplication set on Pod prevents by admission controller, prevents YuniKorn from honoring application ID
-const AnnotationIgnoreApplication = DomainYuniKorn + "ignore-application"
-
 // AnnotationGenerateAppID adds application ID to workloads in the namespace even if not set in the admission config.
 // Overrides the regexp behaviour if set, checked before the regexp is evaluated.
 // true: add an application ID label

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -686,24 +686,6 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			},
 			Spec: v1.PodSpec{SchedulerName: "default"},
 		}, "", false},
-		{"AppID defined but ignore-application set", &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					constants.AnnotationApplicationID:     appIDInAnnotation,
-					constants.AnnotationIgnoreApplication: "true",
-				},
-			},
-			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
-		}, appIDInAnnotation, false},
-		{"AppID defined and ignore-application invalid", &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					constants.AnnotationApplicationID:     appIDInAnnotation,
-					constants.AnnotationIgnoreApplication: "invalid",
-				},
-			},
-			Spec: v1.PodSpec{SchedulerName: constants.SchedulerName},
-		}, appIDInAnnotation, false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Description
Remove `AnnotationIgnoreApplication` constant, `disableYuniKorn` admission controller logic, and related unit tests as `yunikorn.apache.org/ignore-application` annotation is no longer supported.


### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [X] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3324

- [] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [X] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A