### PR TITLE
[YUNIKORN-3315] Remove old placeholder flags and processing

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -77,11 +77,6 @@ const PlaceholderContainerImage = "registry.k8s.io/pause:3.7"
 const PlaceholderContainerName = "pause"
 const PlaceholderPodRestartPolicy = "Never"
 
-// Deprecated: should remove old placeholder flags in 1.7.0
-const OldLabelPlaceholderFlag = "placeholder"
-
-// Deprecated: should remove old placeholder flags in 1.7.0
-const OldAnnotationPlaceholderFlag = DomainYuniKorn + "placeholder"
 const AnnotationPlaceholderFlag = DomainYuniKornInternal + "placeholder"
 const AnnotationTaskGroupName = DomainYuniKorn + "task-group-name"
 const AnnotationTaskGroups = DomainYuniKorn + "task-groups"

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -421,27 +421,5 @@ func GetPlaceholderFlagFromPodSpec(pod *v1.Pod) bool {
 		}
 	}
 
-	// Deprecated: Support for old placeholder flags should be removed in version 1.7.0.
-	if value := GetPodAnnotationValue(pod, constants.OldAnnotationPlaceholderFlag); value != "" { // nolint:staticcheck
-		if v, err := strconv.ParseBool(value); err == nil {
-			log.Log(log.ShimUtils).Warn("Using deprecated placeholder annotation. The support for old placeholder flag will be removed in version 1.7.0",
-				zap.String("podName", pod.Name),
-				zap.String("annotation", constants.OldAnnotationPlaceholderFlag), // nolint:staticcheck
-				zap.String("value", value))
-			return v
-		}
-	}
-
-	// Deprecated: Support for old placeholder flags should be removed in version 1.7.0.
-	if value := GetPodLabelValue(pod, constants.OldLabelPlaceholderFlag); value != "" { // nolint:staticcheck
-		if v, err := strconv.ParseBool(value); err == nil {
-			log.Log(log.ShimUtils).Warn("Using deprecated placeholder label. The support for old placeholder flag will be removed in version 1.7.0",
-				zap.String("podName", pod.Name),
-				zap.String("label", constants.OldLabelPlaceholderFlag), // nolint:staticcheck
-				zap.String("value", value))
-			return v
-		}
-	}
-
 	return false
 }

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -1199,49 +1199,6 @@ func TestGetPlaceholderFlagFromPodSpec(t *testing.T) {
 				},
 			},
 		}, true},
-		{"Setting by deprecated annotation", &v1.Pod{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Pod",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-01",
-				UID:  "UID-01",
-				Annotations: map[string]string{
-					constants.OldAnnotationPlaceholderFlag: "true", // nolint:staticcheck
-				},
-			},
-		}, true},
-		{"Setting by deprecated label", &v1.Pod{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Pod",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-01",
-				UID:  "UID-01",
-				Labels: map[string]string{
-					constants.OldLabelPlaceholderFlag: "true", // nolint:staticcheck
-				},
-			},
-		}, true},
-		{"Set new placeholder annotation and old placeholder label/annotation together, new annotation has higher priority", &v1.Pod{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Pod",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pod-01",
-				UID:  "UID-01",
-				Labels: map[string]string{
-					constants.OldLabelPlaceholderFlag: "false", // nolint:staticcheck
-				},
-				Annotations: map[string]string{
-					constants.AnnotationPlaceholderFlag:    "true",
-					constants.OldAnnotationPlaceholderFlag: "false", // nolint:staticcheck
-				},
-			},
-		}, true},
 		{"Pod without placeholder annotation", &v1.Pod{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Pod",


### PR DESCRIPTION
### Description
Remove deprecated placeholder flags (`OldLabelPlaceholderFlag` and `OldAnnotationPlaceholderFlag`) and their associated fallback logic in `yunikorn-k8shim`.


### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [ ] Feature
- [X] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3315

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A
