### PR TITLE
[YUNIKORN-3311] Remove user label processing code

### DIFF
--- a/pkg/cache/metadata.go
+++ b/pkg/cache/metadata.go
@@ -102,7 +102,7 @@ func getAppMetadata(pod *v1.Pod) (ApplicationMetadata, bool) {
 		tags[constants.AppTagImagePullSecrets] = strings.Join(arr, ",")
 	}
 
-	// get the user from Pod Labels
+	// get the user from pod annotation
 	user, groups := utils.GetUserFromPod(pod)
 
 	var taskGroups []TaskGroup = nil

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -57,7 +57,6 @@ const AppTagNamespace = "namespace"
 const AppTagNamespaceParentQueue = "namespace.parentqueue"
 const AppTagImagePullSecrets = "imagePullSecrets"
 const DefaultAppNamespace = "default"
-const DefaultUserLabel = DomainYuniKorn + "username"
 const DefaultUser = "nobody"
 
 // Spark

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -318,7 +318,7 @@ func MergeMaps(first, second map[string]string) map[string]string {
 	return result
 }
 
-// GetUserFromPod find username from pod annotation or label
+// GetUserFromPod find username from pod annotation
 func GetUserFromPod(pod *v1.Pod) (string, []string) {
 	if pod.Annotations[userInfoKey] != "" {
 		userInfoJSON := pod.Annotations[userInfoKey]
@@ -339,28 +339,7 @@ func GetUserFromPod(pod *v1.Pod) (string, []string) {
 		return user, groups
 	}
 
-	// Label is processed for backwards compatibility
-	userLabelKey := conf.GetSchedulerConf().UserLabelKey
-	if userLabelKey != "" {
-		log.Log(log.Deprecation).Warn("'userLabelKey' config is deprecated, use 'user.info' annotation")
-	}
-	// UserLabelKey should not be empty
-	if userLabelKey == "" {
-		userLabelKey = constants.DefaultUserLabel
-	}
-	// Username to be defined in labels
-	if username := GetPodLabelValue(pod, userLabelKey); username != "" && len(username) > 0 {
-		log.Log(log.Deprecation).Warn("Found user name from pod label",
-			zap.String("userLabel", userLabelKey),
-			zap.String("user", username))
-		return username, nil
-	}
-	value := constants.DefaultUser
-
-	log.Log(log.ShimUtils).Debug("Unable to retrieve user name from pod labels. Empty user label",
-		zap.String("userLabel", userLabelKey))
-
-	return value, nil
+	return constants.DefaultUser, nil
 }
 
 // GetCoreSchedulerConfigFromConfigMap resolves a yunikorn configmap into a core scheduler config.

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -875,57 +875,6 @@ func TestMergeMaps(t *testing.T) {
 	}
 }
 
-func TestGetUserFromPodLabel(t *testing.T) {
-	userInLabel := "testuser"
-	userNotInLabel := constants.DefaultUser
-	customUserKeyLabel := "test"
-	testCases := []struct {
-		name         string
-		userLabelKey string
-		pod          *v1.Pod
-		expectedUser string
-	}{
-		{"User defined in label with default key", constants.DefaultUserLabel, &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{constants.DefaultUserLabel: userInLabel},
-			},
-		}, userInLabel},
-		{"The length of UserKeyLabel value is 0", constants.DefaultUserLabel, &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{customUserKeyLabel: ""},
-			},
-		}, userNotInLabel},
-		{"User not defined in label", constants.DefaultUserLabel, &v1.Pod{}, userNotInLabel},
-		{"UserKeyLabel is empty and the user definded in the pod labels with default key", "", &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{constants.DefaultUserLabel: userInLabel},
-			},
-		}, userInLabel},
-		{"UserKeyLabel is empty and the user isn't defined in the pod labels", "", &v1.Pod{}, userNotInLabel},
-		{"UserKeyLabel is changed and the user definded in the pod labels", customUserKeyLabel, &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{customUserKeyLabel: userInLabel},
-			},
-		}, userInLabel},
-		{"UserKeyLabel is changed and the user isn't defined in the pod labels", customUserKeyLabel, &v1.Pod{}, userNotInLabel},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			conf := conf.GetSchedulerConf()
-			// The default UserLabelKey could be set with the custom UserLabelKey.
-			if tc.userLabelKey != constants.DefaultUserLabel {
-				conf.UserLabelKey = tc.userLabelKey
-			}
-
-			userID, _ := GetUserFromPod(tc.pod)
-			assert.Equal(t, userID, tc.expectedUser)
-			// The order of test cases is allowed to impact other test case.
-			conf.UserLabelKey = constants.DefaultUserLabel
-		})
-	}
-}
-
 func TestGetUserFromPodAnnotation(t *testing.T) {
 	const userAndGroups = "{\"user\":\"test\",\"groups\":[\"devops\",\"test\"]}"
 	const emptyUserAndGroups = "{\"user\":\"\",\"groups\":[\"devops\",\"test\"]}"
@@ -954,6 +903,7 @@ func TestGetUserFromPodAnnotation(t *testing.T) {
 					userInfoKey: "xyzxyz"},
 			},
 		}, "nobody", nil},
+		{"No annotation", &v1.Pod{}, "nobody", nil},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -125,7 +125,6 @@ type SchedulerConf struct {
 	KubeBurst                int                `json:"kubeBurst"`
 	EnableConfigHotRefresh   bool               `json:"enableConfigHotRefresh"`
 	DisableGangScheduling    bool               `json:"disableGangScheduling"`
-	UserLabelKey             string             `json:"userLabelKey"`
 	PlaceHolderConfig        *PlaceHolderConfig `json:"placeHolderConfig"`
 	InstanceTypeNodeLabelKey string             `json:"instanceTypeNodeLabelKey"`
 	Namespace                string             `json:"namespace"`
@@ -159,7 +158,6 @@ func (conf *SchedulerConf) Clone() *SchedulerConf {
 		KubeBurst:                conf.KubeBurst,
 		EnableConfigHotRefresh:   conf.EnableConfigHotRefresh,
 		DisableGangScheduling:    conf.DisableGangScheduling,
-		UserLabelKey:             conf.UserLabelKey,
 		PlaceHolderConfig:        conf.PlaceHolderConfig,
 		InstanceTypeNodeLabelKey: conf.InstanceTypeNodeLabelKey,
 		Namespace:                conf.Namespace,
@@ -332,7 +330,6 @@ func CreateDefaultConfig() *SchedulerConf {
 		KubeBurst:                DefaultKubeBurst,
 		EnableConfigHotRefresh:   DefaultEnableConfigHotRefresh,
 		DisableGangScheduling:    DefaultDisableGangScheduling,
-		UserLabelKey:             constants.DefaultUserLabel,
 		InstanceTypeNodeLabelKey: constants.DefaultNodeInstanceTypeNodeLabelKey,
 		GenerateUniqueAppIds:     DefaultAMFilteringGenerateUniqueAppIds,
 		PlaceHolderConfig: &PlaceHolderConfig{

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -74,7 +74,6 @@ func assertDefaults(t *testing.T, conf *SchedulerConf) {
 	assert.Equal(t, conf.DispatchTimeout, DefaultDispatchTimeout)
 	assert.Equal(t, conf.KubeQPS, DefaultKubeQPS)
 	assert.Equal(t, conf.KubeBurst, DefaultKubeBurst)
-	assert.Equal(t, conf.UserLabelKey, constants.DefaultUserLabel)
 }
 
 func TestDecompress(t *testing.T) {


### PR DESCRIPTION
### Description
Remove deprecated user label processing code from the k8shim side:
- Remove `DefaultUserLabel` constant
- Remove `UserLabelKey` field from `SchedulerConf`
- Simplify `GetUserFromPod()` to only use the `user.info` annotation
- Remove `TestGetUserFromPodLabel` test

This is the cleanup follow-up to YUNIKORN-2634 which deprecated the label-based user resolution.

### Type of change

- [x] Refactoring

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3311

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling

- [x] The PR includes the phrase "Generated by GitHub Copilot", where <tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.