### PR TITLE
[YUNIKORN-3356] Split Kubernetes clients by concern (writes/informers/events)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	k8s.io/kube-scheduler v0.36.1
 	k8s.io/kubernetes v1.36.1
 	k8s.io/streaming v0.36.1
+	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
 )
 
 require (
@@ -121,7 +122,6 @@ require (
 	k8s.io/controller-manager v0.36.1 // indirect
 	k8s.io/csi-translation-lib v0.34.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect

--- a/pkg/admission/webhook_manager.go
+++ b/pkg/admission/webhook_manager.go
@@ -86,22 +86,11 @@ type webhookManagerImpl struct {
 
 // NewWebhookManager is used to create a new webhook manager
 func NewWebhookManager(conf *conf.AdmissionControllerConf) (WebhookManager, error) {
-	kubeconfig, err := client.CreateRestConfig(conf.GetKubeConfig())
-	if err != nil {
-		log.Log(log.AdmissionWebhook).Error("Unable to create kubernetes config", zap.Error(err))
-		return nil, err
-	}
-	// the webhook and secret writes must be attributed to the admission controller
-	kubeconfig.UserAgent = client.UserAgent(client.UserAgentAdmissionController)
-	// no client side rate limiting: leaving the QPS at 0 would mean the client-go defaults
-	// of 5 QPS / 10 burst
-	kubeconfig.QPS = -1
-	clientset, err := kubernetes.NewForConfig(kubeconfig)
-	if err != nil {
-		log.Log(log.AdmissionWebhook).Error("Unable to create kubernetes clientset", zap.Error(err))
-		return nil, err
-	}
-	return newWebhookManagerImpl(conf, clientset), nil
+	// the webhook and secret writes must be attributed to the admission controller; the
+	// admission controller never populates the scheduler configuration, so the client runs
+	// on the defaults: no client side rate limiting
+	kubeClient := client.NewKubeClientWithUserAgent(conf.GetKubeConfig(), client.UserAgentAdmissionController)
+	return newWebhookManagerImpl(conf, kubeClient.GetClientSet()), nil
 }
 
 func newWebhookManagerImpl(conf *conf.AdmissionControllerConf, clientset kubernetes.Interface) *webhookManagerImpl {

--- a/pkg/admission/webhook_manager.go
+++ b/pkg/admission/webhook_manager.go
@@ -91,6 +91,11 @@ func NewWebhookManager(conf *conf.AdmissionControllerConf) (WebhookManager, erro
 		log.Log(log.AdmissionWebhook).Error("Unable to create kubernetes config", zap.Error(err))
 		return nil, err
 	}
+	// the webhook and secret writes must be attributed to the admission controller
+	kubeconfig.UserAgent = client.UserAgent(client.UserAgentAdmissionController)
+	// no client side rate limiting: leaving the QPS at 0 would mean the client-go defaults
+	// of 5 QPS / 10 burst
+	kubeconfig.QPS = -1
 	clientset, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
 		log.Log(log.AdmissionWebhook).Error("Unable to create kubernetes clientset", zap.Error(err))

--- a/pkg/admission/webhook_manager.go
+++ b/pkg/admission/webhook_manager.go
@@ -85,12 +85,9 @@ type webhookManagerImpl struct {
 }
 
 // NewWebhookManager is used to create a new webhook manager
-func NewWebhookManager(conf *conf.AdmissionControllerConf) (WebhookManager, error) {
-	// the webhook and secret writes must be attributed to the admission controller; the
-	// admission controller never populates the scheduler configuration, so the client runs
-	// on the defaults: no client side rate limiting
-	kubeClient := client.NewKubeClientWithUserAgent(conf.GetKubeConfig(), client.UserAgentAdmissionController)
-	return newWebhookManagerImpl(conf, kubeClient.GetClientSet()), nil
+func NewWebhookManager(conf *conf.AdmissionControllerConf) WebhookManager {
+	kubeClient := client.NewAdmissionControllerKubeClient(conf.GetKubeConfig())
+	return newWebhookManagerImpl(conf, kubeClient.GetClientSet())
 }
 
 func newWebhookManagerImpl(conf *conf.AdmissionControllerConf, clientset kubernetes.Interface) *webhookManagerImpl {

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -220,7 +220,8 @@ func TestSetUnallocatedPodsToFailedWhenFailApplication(t *testing.T) {
 	mgr.Start()
 	defer mgr.Stop()
 
-	mockClient := mockedAPIProvider.GetAPIs().KubeClient
+	mockClient, ok := mockedAPIProvider.GetAPIs().KubeClient.(*client.KubeClientMock)
+	assert.Assert(t, ok, "expecting KubeClientMock")
 	context.apiProvider.GetAPIs().KubeClient = mockClient
 
 	ms := &mockSchedulerAPI{}
@@ -322,7 +323,8 @@ func TestSetUnallocatedPodsToFailedWhenRejectApplication(t *testing.T) {
 		return pod, nil
 	})
 
-	mockClient := mockedAPIProvider.GetAPIs().KubeClient
+	mockClient, ok := mockedAPIProvider.GetAPIs().KubeClient.(*client.KubeClientMock)
+	assert.Assert(t, ok, "expecting KubeClientMock")
 	context.apiProvider.GetAPIs().KubeClient = mockClient
 	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
 	mgr.Start()

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -1235,7 +1235,7 @@ func (ctx *Context) HandleContainerStateUpdate(request *si.UpdateContainerSchedu
 					Message: request.Reason,
 				}) {
 				events.GetRecorder().Eventf(task.GetTaskPod().DeepCopy(), nil,
-					v1.EventTypeNormal, "PodUnschedulable", "PodUnschedulable",
+					v1.EventTypeWarning, "PodUnschedulable", "PodUnschedulable",
 					"Task %s is skipped from scheduling because the queue quota has been exceed", task.alias)
 			}
 		case si.UpdateContainerSchedulingStateRequest_FAILED:
@@ -1249,7 +1249,7 @@ func (ctx *Context) HandleContainerStateUpdate(request *si.UpdateContainerSchedu
 					Message: request.Reason,
 				}) {
 				events.GetRecorder().Eventf(task.GetTaskPod().DeepCopy(), nil,
-					v1.EventTypeNormal, "PodUnschedulable", "PodUnschedulable",
+					v1.EventTypeWarning, "PodUnschedulable", "PodUnschedulable",
 					"Task %s is pending for the requested resources become available", task.alias)
 			}
 		default:

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -31,6 +31,7 @@ import (
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	k8sEvents "k8s.io/client-go/tools/events"
@@ -1849,6 +1850,70 @@ func TestCtxUpdatePodCondition(t *testing.T) {
 	condition.Status = v1.ConditionFalse
 	updated = context.updatePodCondition(task, &condition)
 	assert.Equal(t, true, updated)
+}
+
+// recordedEvent is the type and the reason of an event captured by the eventTypeRecorder
+type recordedEvent struct {
+	eventType string
+	reason    string
+}
+
+// eventTypeRecorder records the type and the reason of every event it receives
+type eventTypeRecorder struct {
+	recorded []recordedEvent
+}
+
+func (r *eventTypeRecorder) Eventf(_ runtime.Object, _ runtime.Object, eventtype, reason, _, _ string, _ ...interface{}) {
+	r.recorded = append(r.recorded, recordedEvent{eventType: eventtype, reason: reason})
+}
+
+// an unschedulable pod must be reported as a Warning: the type decides if the event survives the
+// kubernetes.eventLevel filter
+func TestHandleContainerStateUpdateEventType(t *testing.T) {
+	testCases := []struct {
+		name  string
+		state si.UpdateContainerSchedulingStateRequest_SchedulingState
+	}{
+		{"skipped", si.UpdateContainerSchedulingStateRequest_SKIPPED},
+		{"failed", si.UpdateContainerSchedulingStateRequest_FAILED},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := &eventTypeRecorder{}
+			events.SetRecorder(recorder)
+			defer events.SetRecorder(events.NewMockedRecorder())
+
+			context := initContextForTest()
+			context.AddApplication(&AddApplicationRequest{
+				Metadata: ApplicationMetadata{
+					ApplicationID: appID1,
+					QueueName:     queueNameA,
+					User:          testUser,
+				},
+			})
+			task := context.AddTask(&AddTaskRequest{
+				Metadata: TaskMetadata{
+					ApplicationID: appID1,
+					TaskID:        taskUID1,
+					Pod:           newPodHelper("pod-test-00001", namespace, taskUID1, "", appID1, v1.PodPending),
+				},
+			})
+			// the pod condition, and with it the event, is only updated while the task is scheduling
+			task.sm.SetState(TaskStates().Scheduling)
+
+			context.HandleContainerStateUpdate(&si.UpdateContainerSchedulingStateRequest{
+				ApplicationID: appID1,
+				AllocationKey: taskUID1,
+				State:         tc.state,
+				Reason:        "reason",
+			})
+
+			assert.Equal(t, 1, len(recorder.recorded), "one event expected")
+			assert.Equal(t, "PodUnschedulable", recorder.recorded[0].reason, "unexpected event reason")
+			assert.Equal(t, v1.EventTypeWarning, recorder.recorded[0].eventType, "unexpected event type")
+		})
+	}
 }
 
 func TestGetExistingAllocation(t *testing.T) {

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -434,7 +434,7 @@ func (task *Task) postTaskRejected() {
 // send different requests to scheduler-core, depending on current task state
 func (task *Task) beforeTaskFail() {
 	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
-		v1.EventTypeNormal, "TaskFailed", "TaskFailed",
+		v1.EventTypeWarning, "TaskFailed", "TaskFailed",
 		"Task %s is failed", task.alias)
 	task.releaseAllocation(false)
 }

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -606,6 +606,38 @@ func TestHandleSubmitTaskEvent(t *testing.T) {
 	assert.Assert(t, allocRequest.Allocations[0].PreemptionPolicy.AllowPreemptOther)
 }
 
+// a failed task must be reported as a Warning: the type decides if the event survives the
+// kubernetes.eventLevel filter
+func TestBeforeTaskFailEventType(t *testing.T) {
+	recorder := &eventTypeRecorder{}
+	events.SetRecorder(recorder)
+	defer events.SetRecorder(events.NewMockedRecorder())
+
+	mockedContext, mockedAPIProvider := initContextAndAPIProviderForTest()
+	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-test-00001",
+			UID:  "UID-00001",
+		},
+	}
+	app := NewApplication("app01", "root.default",
+		"bob", testGroups, map[string]string{}, mockedAPIProvider.GetAPIs().SchedulerAPI)
+	task := NewTask("task01", app, mockedContext, pod)
+	task.sm.SetState(TaskStates().Scheduling)
+
+	err := task.handle(NewFailTaskEvent(app.GetApplicationID(), task.GetTaskID(), "task failed"))
+	assert.NilError(t, err, "failed to handle FailTask event")
+	assert.Equal(t, task.GetTaskState(), TaskStates().Failed)
+
+	assert.Equal(t, 1, len(recorder.recorded), "one event expected")
+	assert.Equal(t, "TaskFailed", recorder.recorded[0].reason, "unexpected event reason")
+	assert.Equal(t, v1.EventTypeWarning, recorder.recorded[0].eventType, "unexpected event type")
+}
+
 func TestSimultaneousTaskCompleteAndAllocate(t *testing.T) {
 	const (
 		podUID    = "UID-00001"

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -23,7 +23,6 @@ import (
 
 	"go.uber.org/zap"
 	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -90,11 +89,17 @@ type APIFactory struct {
 	lock     *locking.RWMutex
 }
 
-// NewAPIFactory creates the clients shared by the shim. The clientset backing informerFactory
-// is passed in so that the namespaced factory created here shares it: both only run informers
-// so they need the same unlimited client and the same attribution.
-func NewAPIFactory(scheduler api.SchedulerAPI, informerClientSet kubernetes.Interface, informerFactory informers.SharedInformerFactory, configs *conf.SchedulerConf, testMode bool) (*APIFactory, error) {
+// NewAPIFactory creates the clients shared by the shim.
+func NewAPIFactory(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, testMode bool) (*APIFactory, error) {
 	kubeClient := NewKubeClient(configs.KubeConfig)
+
+	// all informers, cluster wide and namespaced, share one clientset: both only run
+	// informers so they need the same unlimited client and the same attribution.
+	// resync is disabled (period 0): the shim relies on the watch stream for updates; a
+	// periodic resync only replays the local cache into the handlers, which at scale is
+	// pure no-op churn
+	informerClientSet := NewInformerClientSet(configs.KubeConfig)
+	informerFactory := informers.NewSharedInformerFactory(informerClientSet, 0)
 	namespaceInformerFactory := informers.NewSharedInformerFactoryWithOptions(informerClientSet, 0, informers.WithNamespace(configs.Namespace))
 	// init informers
 	// volume informers are also used to get the Listers for the predicates

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -23,6 +23,7 @@ import (
 
 	"go.uber.org/zap"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -89,9 +90,12 @@ type APIFactory struct {
 	lock     *locking.RWMutex
 }
 
-func NewAPIFactory(scheduler api.SchedulerAPI, informerFactory informers.SharedInformerFactory, configs *conf.SchedulerConf, testMode bool) (*APIFactory, error) {
+// NewAPIFactory creates the clients shared by the shim. The clientset backing informerFactory
+// is passed in so that the namespaced factory created here shares it: both only run informers
+// so they need the same unlimited client and the same attribution.
+func NewAPIFactory(scheduler api.SchedulerAPI, informerClientSet kubernetes.Interface, informerFactory informers.SharedInformerFactory, configs *conf.SchedulerConf, testMode bool) (*APIFactory, error) {
 	kubeClient := NewKubeClient(configs.KubeConfig)
-	namespaceInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient.GetClientSet(), 0, informers.WithNamespace(configs.Namespace))
+	namespaceInformerFactory := informers.NewSharedInformerFactoryWithOptions(informerClientSet, 0, informers.WithNamespace(configs.Namespace))
 	// init informers
 	// volume informers are also used to get the Listers for the predicates
 	podInformer := informerFactory.Core().V1().Pods()

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -93,14 +93,11 @@ type APIFactory struct {
 func NewAPIFactory(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, testMode bool) (*APIFactory, error) {
 	kubeClient := NewKubeClient(configs.KubeConfig)
 
-	// all informers, cluster wide and namespaced, share one clientset: both only run
-	// informers so they need the same unlimited client and the same attribution.
 	// resync is disabled (period 0): the shim relies on the watch stream for updates; a
 	// periodic resync only replays the local cache into the handlers, which at scale is
 	// pure no-op churn
-	informerClientSet := NewInformerClientSet(configs.KubeConfig)
-	informerFactory := informers.NewSharedInformerFactory(informerClientSet, 0)
-	namespaceInformerFactory := informers.NewSharedInformerFactoryWithOptions(informerClientSet, 0, informers.WithNamespace(configs.Namespace))
+	informerFactory := informers.NewSharedInformerFactory(kubeClient.GetClientSet(), 0)
+	namespaceInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient.GetClientSet(), 0, informers.WithNamespace(configs.Namespace))
 	// init informers
 	// volume informers are also used to get the Listers for the predicates
 	podInformer := informerFactory.Core().V1().Pods()

--- a/pkg/client/bootstrap.go
+++ b/pkg/client/bootstrap.go
@@ -26,8 +26,10 @@ import (
 )
 
 func LoadBootstrapConfigMaps() ([]*v1.ConfigMap, error) {
-	// we need a bootstrap client so that we can read the initial version of the configmap
-	kubeClient := NewBootstrapKubeClient(conf.GetDefaultKubeConfigPath())
+	// we need a client so that we can read the initial version of the configmap, this runs
+	// before the configmaps are loaded so it always uses the configuration defaults. All
+	// binaries load their bootstrap configmaps this way, hence the separate user agent.
+	kubeClient := NewKubeClientWithUserAgent(conf.GetDefaultKubeConfigPath(), userAgentBootstrap)
 	namespace := conf.GetSchedulerNamespace()
 
 	defaults, err := kubeClient.GetConfigMap(namespace, constants.DefaultConfigMapName)

--- a/pkg/client/bootstrap.go
+++ b/pkg/client/bootstrap.go
@@ -27,9 +27,10 @@ import (
 
 func LoadBootstrapConfigMaps() ([]*v1.ConfigMap, error) {
 	// we need a client so that we can read the initial version of the configmap, this runs
-	// before the configmaps are loaded so it always uses the configuration defaults. All
-	// binaries load their bootstrap configmaps this way, hence the separate user agent.
-	kubeClient := NewKubeClientWithUserAgent(conf.GetDefaultKubeConfigPath(), userAgentBootstrap)
+	// before the configuration is loaded so the client runs on the client-go defaults. All
+	// binaries load their bootstrap configmaps this way, two GETs, hence the separate user
+	// agent.
+	kubeClient := newKubeClient(conf.GetDefaultKubeConfigPath(), 0, 0, userAgentBootstrap)
 	namespace := conf.GetSchedulerNamespace()
 
 	defaults, err := kubeClient.GetConfigMap(namespace, constants.DefaultConfigMapName)

--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -34,9 +34,18 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/api"
 )
 
-// clients encapsulates a set of useful client APIs
-// that can be shared by callers when talking to K8s api-server,
-// or the scheduler core.
+// Clients encapsulates the client APIs shared by callers when talking to the K8s api-server
+// or the scheduler core. Each Kubernetes client serves one concern with its own rate limit
+// policy and user agent, see kubeclient.go:
+//   - KubeClient carries the direct must-complete traffic: binds, pod create/delete, pod and
+//     status updates, the volume binder and the predicate handle, the configmap loads at
+//     registration, and the reads made in service of those writes (the get before a retried
+//     update). Its policy is the opt-in kubernetes.qps/burst cap.
+//   - the informers, cluster wide and namespaced, run on a separate clientset created in
+//     NewAPIFactory: list/watch traffic is never rate limited on the client side and is
+//     attributed separately.
+//   - events do not pass through any of these: the broadcaster writes through the shedding
+//     event sink, see NewEventSink.
 type Clients struct {
 	// client apis
 	KubeClient   KubeClient

--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -35,17 +35,14 @@ import (
 )
 
 // Clients encapsulates the client APIs shared by callers when talking to the K8s api-server
-// or the scheduler core. Each Kubernetes client serves one concern with its own rate limit
-// policy and user agent, see kubeclient.go:
-//   - KubeClient carries the direct must-complete traffic: binds, pod create/delete, pod and
-//     status updates, the volume binder and the predicate handle, the configmap loads at
+// or the scheduler core:
+//   - KubeClient carries the must-complete traffic: binds, pod create/delete, pod and status
+//     updates, the volume binder and the predicate handle, the configmap loads at
 //     registration, and the reads made in service of those writes (the get before a retried
-//     update). Its policy is the opt-in kubernetes.qps/burst cap.
-//   - the informers, cluster wide and namespaced, run on a separate clientset created in
-//     NewAPIFactory: list/watch traffic is never rate limited on the client side and is
-//     attributed separately.
-//   - events do not pass through any of these: the broadcaster writes through the shedding
-//     event sink, see NewEventSink.
+//     update). It also backs the informer factories. Its policy is the opt-in
+//     kubernetes.qps/burst cap.
+//   - events do not pass through it: the broadcaster writes through the shedding event sink
+//     on its own client, see NewEventSink.
 type Clients struct {
 	// client apis
 	KubeClient   KubeClient

--- a/pkg/client/eventsink.go
+++ b/pkg/client/eventsink.go
@@ -1,0 +1,228 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	eventsv1 "k8s.io/api/events/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/clock"
+
+	"github.com/apache/yunikorn-k8shim/pkg/conf"
+	"github.com/apache/yunikorn-k8shim/pkg/log"
+)
+
+const (
+	// the shortest time between two logs of the number of shed events
+	eventShedLogInterval = 30 * time.Second
+	// the longest the events are muted after the server asked us to back off
+	maxEventMute = 60 * time.Second
+	// the mute used when the server throttles without saying for how long
+	defaultEventMute = time.Second
+)
+
+// rateLimitedEventSink sheds events which exceed the configured rate instead of sending them.
+// The broadcaster writes every event from its own goroutine, so a rate limiter on the events
+// client would only pace those writes: the goroutines pile up for as long as a storm lasts.
+// Events are discardable, dropping them here bounds a storm instead of delaying it.
+// The events are also muted for as long as the server asks us to back off: priority and
+// fairness rejects with a 429 which carries the time to wait for.
+type rateLimitedEventSink struct {
+	inner     events.EventSink
+	limiter   flowcontrol.RateLimiter
+	rateLimit string
+	clock     clock.PassiveClock
+	// the delay advertised by the server, recorded by the transport which removes the header
+	hints *muteHintHolder
+
+	// number of events shed since they were last logged
+	shed atomic.Int64
+	// time the shed events were last logged, as unix nanoseconds
+	lastLogged atomic.Int64
+	// time the mute was last logged, as unix nanoseconds
+	lastMuteLogged atomic.Int64
+	// time until which no event is sent, as unix nanoseconds
+	muteUntil atomic.Int64
+}
+
+// NewRateLimitedEventSink wraps an event sink and sheds the events which exceed the given
+// rate. A qps <= 0 disables shedding, every event is passed on to the wrapped sink.
+func NewRateLimitedEventSink(inner events.EventSink, qps, burst int) events.EventSink {
+	return newRateLimitedEventSink(inner, qps, burst, clock.RealClock{}, nil)
+}
+
+// newRateLimitedEventSink allows the clock and the delays recorded by the transport to be
+// passed in for testing
+func newRateLimitedEventSink(inner events.EventSink, qps, burst int, clk clock.PassiveClock, hints *muteHintHolder) *rateLimitedEventSink {
+	limitQPS, limitBurst, rateLimit := rateLimitPolicy(userAgentEvents, qps, burst)
+
+	sink := &rateLimitedEventSink{
+		inner:     inner,
+		rateLimit: rateLimit,
+		clock:     clk,
+		hints:     hints,
+	}
+	shedPolicy := rateLimit
+	if limitQPS > 0 {
+		sink.limiter = flowcontrol.NewTokenBucketRateLimiter(limitQPS, limitBurst)
+		shedPolicy = "shed above " + rateLimit
+	}
+
+	log.Log(log.ShimClient).Info("creating event sink",
+		zap.String("concern", userAgentEvents),
+		zap.String("shedPolicy", shedPolicy))
+	return sink
+}
+
+// NewEventSink creates the sink for the event broadcaster: events are written by the events
+// client and shed above the configured event rate.
+// The client and the sink share the delays advertised by the server: the client fails fast on
+// a rejection instead of retrying it, the sink mutes the events until the advertised deadline.
+func NewEventSink(kc string) events.EventSink {
+	schedulerConf := conf.GetSchedulerConf()
+
+	clk := clock.RealClock{}
+	hints := &muteHintHolder{}
+	sink := &events.EventSinkImpl{Interface: newEventsClientSet(kc, hints, clk).EventsV1()}
+	return newRateLimitedEventSink(sink, schedulerConf.KubeEventQPS, schedulerConf.KubeEventBurst, clk, hints)
+}
+
+func (s *rateLimitedEventSink) Create(ctx context.Context, event *eventsv1.Event) (*eventsv1.Event, error) {
+	if s.shedEvent() {
+		return event, nil
+	}
+	result, err := s.inner.Create(ctx, event)
+	s.checkThrottled(err)
+	return result, err
+}
+
+func (s *rateLimitedEventSink) Update(ctx context.Context, event *eventsv1.Event) (*eventsv1.Event, error) {
+	if s.shedEvent() {
+		return event, nil
+	}
+	result, err := s.inner.Update(ctx, event)
+	s.checkThrottled(err)
+	return result, err
+}
+
+func (s *rateLimitedEventSink) Patch(ctx context.Context, oldEvent *eventsv1.Event, data []byte) (*eventsv1.Event, error) {
+	if s.shedEvent() {
+		return oldEvent, nil
+	}
+	result, err := s.inner.Patch(ctx, oldEvent, data)
+	s.checkThrottled(err)
+	return result, err
+}
+
+// checkThrottled mutes the events for as long as the server asked us to back off. Priority
+// and fairness rejects with a 429 and advertises a delay which grows while it keeps dropping
+// requests, following it is cheaper than having every event rejected.
+func (s *rateLimitedEventSink) checkThrottled(err error) {
+	if err == nil || !errors.IsTooManyRequests(err) {
+		return
+	}
+	delay, source := s.muteDelay(err)
+	if delay > maxEventMute {
+		delay = maxEventMute
+	}
+
+	muteUntil := s.clock.Now().Add(delay).UnixNano()
+	for {
+		current := s.muteUntil.Load()
+		// a mute is only ever extended, a later response must not shorten it
+		if muteUntil <= current {
+			return
+		}
+		if s.muteUntil.CompareAndSwap(current, muteUntil) {
+			break
+		}
+	}
+
+	if s.claimLogInterval(&s.lastMuteLogged) {
+		log.Log(log.ShimClient).Warn("muting events, the server asked to back off",
+			zap.Duration("delay", delay),
+			zap.String("delaySource", source),
+			zap.String("rateLimit", s.rateLimit))
+	}
+}
+
+// muteDelay returns how long the events must be muted and where that delay came from. The
+// delay is normally recorded by the transport, which removes the header from the response to
+// stop the REST client from retrying: the error the sink sees no longer carries it. It is
+// still read from the error first, for the rejections which do not pass our transport.
+func (s *rateLimitedEventSink) muteDelay(err error) (time.Duration, string) {
+	if seconds, ok := errors.SuggestsClientDelay(err); ok && seconds > 0 {
+		return time.Duration(seconds) * time.Second, "header"
+	}
+	if s.hints != nil {
+		if seconds, ok := s.hints.get(s.clock.Now()); ok && seconds > 0 {
+			return time.Duration(seconds) * time.Second, "transport"
+		}
+	}
+	return defaultEventMute, "default"
+}
+
+// shedEvent returns true if the event must be dropped instead of being passed on. Dropping is
+// reported to the broadcaster as a successful write: it does not retry and does not hold on
+// to the goroutine which is recording the event.
+// The mute is checked before the limiter: while the server is throttling us there is no point
+// in spending a token on an event which it would reject.
+func (s *rateLimitedEventSink) shedEvent() bool {
+	muted := s.muted()
+	if !muted && (s.limiter == nil || s.limiter.TryAccept()) {
+		return false
+	}
+	s.shed.Add(1)
+	s.logShedEvents(muted)
+	return true
+}
+
+// muted returns true while the server asked us to stop sending events
+func (s *rateLimitedEventSink) muted() bool {
+	return s.clock.Now().UnixNano() < s.muteUntil.Load()
+}
+
+// logShedEvents logs the number of events shed since the last time they were logged, at most
+// once every eventShedLogInterval. The first drop is always logged.
+func (s *rateLimitedEventSink) logShedEvents(muted bool) {
+	if !s.claimLogInterval(&s.lastLogged) {
+		return
+	}
+	log.Log(log.ShimClient).Warn("events shed",
+		zap.Int64("shedEvents", s.shed.Swap(0)),
+		zap.Bool("muted", muted),
+		zap.String("rateLimit", s.rateLimit))
+}
+
+// claimLogInterval returns true for the caller which claims the current logging interval, the
+// callers racing with it just skip their log. The first call always claims the interval.
+func (s *rateLimitedEventSink) claimLogInterval(last *atomic.Int64) bool {
+	now := s.clock.Now().UnixNano()
+	previous := last.Load()
+	if now-previous < int64(eventShedLogInterval) {
+		return false
+	}
+	return last.CompareAndSwap(previous, now)
+}

--- a/pkg/client/eventsink.go
+++ b/pkg/client/eventsink.go
@@ -20,10 +20,12 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/events"
@@ -43,12 +45,15 @@ const (
 	defaultEventMute = time.Second
 )
 
-// rateLimitedEventSink sheds events which exceed the configured rate instead of sending them.
+// rateLimitedEventSink sheds the Normal events which exceed the configured rate instead of
+// sending them. Warning events are always sent: they explain why a pod is not running and
+// there are few of them. The Normal events are the volume, three per scheduled pod
+// (Scheduling, Scheduled and PodBindSuccessful) plus the informational records from the core.
 // The broadcaster writes every event from its own goroutine, so a rate limiter on the events
 // client would only pace those writes: the goroutines pile up for as long as a storm lasts.
 // Events are discardable, dropping them here bounds a storm instead of delaying it.
-// The events are also muted for as long as the server asks us to back off: priority and
-// fairness rejects with a 429 which carries the time to wait for.
+// All events are muted for as long as the server asks us to back off: priority and fairness
+// rejects with a 429 which carries the time to wait for.
 type rateLimitedEventSink struct {
 	inner     events.EventSink
 	limiter   flowcontrol.RateLimiter
@@ -67,8 +72,8 @@ type rateLimitedEventSink struct {
 	muteUntil atomic.Int64
 }
 
-// NewRateLimitedEventSink wraps an event sink and sheds the events which exceed the given
-// rate. A qps <= 0 disables shedding, every event is passed on to the wrapped sink.
+// NewRateLimitedEventSink wraps an event sink and sheds the Normal events which exceed the
+// given rate. A qps <= 0 disables shedding, every event is passed on to the wrapped sink.
 func NewRateLimitedEventSink(inner events.EventSink, qps, burst int) events.EventSink {
 	return newRateLimitedEventSink(inner, qps, burst, clock.RealClock{}, nil)
 }
@@ -76,18 +81,21 @@ func NewRateLimitedEventSink(inner events.EventSink, qps, burst int) events.Even
 // newRateLimitedEventSink allows the clock and the delays recorded by the transport to be
 // passed in for testing
 func newRateLimitedEventSink(inner events.EventSink, qps, burst int, clk clock.PassiveClock, hints *muteHintHolder) *rateLimitedEventSink {
-	limitQPS, limitBurst, rateLimit := rateLimitPolicy(userAgentEvents, qps, burst)
-
 	sink := &rateLimitedEventSink{
 		inner:     inner,
-		rateLimit: rateLimit,
+		rateLimit: "unlimited",
 		clock:     clk,
 		hints:     hints,
 	}
-	shedPolicy := rateLimit
-	if limitQPS > 0 {
-		sink.limiter = flowcontrol.NewTokenBucketRateLimiter(limitQPS, limitBurst)
-		shedPolicy = "shed above " + rateLimit
+	shedPolicy := sink.rateLimit
+	// a qps <= 0 sheds nothing, a burst which is not set defaults to the qps
+	if qps > 0 {
+		if burst <= 0 {
+			burst = qps
+		}
+		sink.rateLimit = fmt.Sprintf("%d qps / %d burst", qps, burst)
+		sink.limiter = flowcontrol.NewTokenBucketRateLimiter(float32(qps), burst)
+		shedPolicy = "shed above " + sink.rateLimit
 	}
 
 	log.Log(log.ShimClient).Info("creating event sink",
@@ -110,7 +118,7 @@ func NewEventSink(kc string) events.EventSink {
 }
 
 func (s *rateLimitedEventSink) Create(ctx context.Context, event *eventsv1.Event) (*eventsv1.Event, error) {
-	if s.shedEvent() {
+	if s.shedEvent(event.Type) {
 		return event, nil
 	}
 	result, err := s.inner.Create(ctx, event)
@@ -119,7 +127,7 @@ func (s *rateLimitedEventSink) Create(ctx context.Context, event *eventsv1.Event
 }
 
 func (s *rateLimitedEventSink) Update(ctx context.Context, event *eventsv1.Event) (*eventsv1.Event, error) {
-	if s.shedEvent() {
+	if s.shedEvent(event.Type) {
 		return event, nil
 	}
 	result, err := s.inner.Update(ctx, event)
@@ -128,7 +136,7 @@ func (s *rateLimitedEventSink) Update(ctx context.Context, event *eventsv1.Event
 }
 
 func (s *rateLimitedEventSink) Patch(ctx context.Context, oldEvent *eventsv1.Event, data []byte) (*eventsv1.Event, error) {
-	if s.shedEvent() {
+	if s.shedEvent(oldEvent.Type) {
 		return oldEvent, nil
 	}
 	result, err := s.inner.Patch(ctx, oldEvent, data)
@@ -187,11 +195,12 @@ func (s *rateLimitedEventSink) muteDelay(err error) (time.Duration, string) {
 // shedEvent returns true if the event must be dropped instead of being passed on. Dropping is
 // reported to the broadcaster as a successful write: it does not retry and does not hold on
 // to the goroutine which is recording the event.
-// The mute is checked before the limiter: while the server is throttling us there is no point
-// in spending a token on an event which it would reject.
-func (s *rateLimitedEventSink) shedEvent() bool {
+// A Warning event is never shed by the bucket and spends no token on it. The mute is checked
+// first and applies to every type: while the server is throttling us the event is rejected
+// anyway, sending it changes nothing.
+func (s *rateLimitedEventSink) shedEvent(eventType string) bool {
 	muted := s.muted()
-	if !muted && (s.limiter == nil || s.limiter.TryAccept()) {
+	if !muted && (eventType == v1.EventTypeWarning || s.limiter == nil || s.limiter.TryAccept()) {
 		return false
 	}
 	s.shed.Add(1)

--- a/pkg/client/eventsink_test.go
+++ b/pkg/client/eventsink_test.go
@@ -1,0 +1,257 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+// fakeEventSink counts the calls which reach it, it is the sink which would write to the
+// API server
+type fakeEventSink struct {
+	creates int
+	updates int
+	patches int
+	err     error
+}
+
+func (f *fakeEventSink) Create(_ context.Context, event *eventsv1.Event) (*eventsv1.Event, error) {
+	f.creates++
+	return event, f.err
+}
+
+func (f *fakeEventSink) Update(_ context.Context, event *eventsv1.Event) (*eventsv1.Event, error) {
+	f.updates++
+	return event, f.err
+}
+
+func (f *fakeEventSink) Patch(_ context.Context, event *eventsv1.Event, _ []byte) (*eventsv1.Event, error) {
+	f.patches++
+	return event, f.err
+}
+
+func newEvent(name string) *eventsv1.Event {
+	return &eventsv1.Event{
+		ObjectMeta: apis.ObjectMeta{Namespace: "default", Name: name},
+	}
+}
+
+// step advances the fake clock, a passive clock can only have its time set
+func step(clk *clocktesting.FakePassiveClock, d time.Duration) {
+	clk.SetTime(clk.Now().Add(d))
+}
+
+// an exhausted bucket must shed the event: the wrapped sink is not called and the event is
+// reported as written so that the broadcaster does not retry it
+func TestEventSinkShedding(t *testing.T) {
+	inner := &fakeEventSink{}
+	// a burst of 1 leaves the bucket empty after the first event
+	sink := NewRateLimitedEventSink(inner, 1, 1)
+
+	event := newEvent("first")
+	result, err := sink.Create(context.Background(), event)
+	assert.NilError(t, err, "create failed")
+	assert.Equal(t, event, result, "event not returned")
+	assert.Equal(t, 1, inner.creates, "event not forwarded")
+
+	for i := 0; i < 10; i++ {
+		shedEvent := newEvent("shed")
+		result, err = sink.Create(context.Background(), shedEvent)
+		assert.NilError(t, err, "shed event must not fail the write")
+		assert.Equal(t, shedEvent, result, "shed event not returned")
+	}
+	assert.Equal(t, 1, inner.creates, "shed events were forwarded")
+
+	limited, ok := sink.(*rateLimitedEventSink)
+	assert.Assert(t, ok, "unexpected sink type")
+	// the first drop is logged which resets the counter, the remaining 9 are still counted
+	assert.Equal(t, int64(9), limited.shed.Load(), "shed events not counted")
+}
+
+// all three sink operations must be shed, not just the creates
+func TestEventSinkShedsAllOperations(t *testing.T) {
+	inner := &fakeEventSink{}
+	// a qps of 1 with a burst of 1: the single token is taken by the create
+	sink := NewRateLimitedEventSink(inner, 1, 1)
+
+	_, err := sink.Create(context.Background(), newEvent("first"))
+	assert.NilError(t, err, "create failed")
+
+	_, err = sink.Update(context.Background(), newEvent("update"))
+	assert.NilError(t, err, "update failed")
+	_, err = sink.Patch(context.Background(), newEvent("patch"), []byte("{}"))
+	assert.NilError(t, err, "patch failed")
+
+	assert.Equal(t, 1, inner.creates, "unexpected creates")
+	assert.Equal(t, 0, inner.updates, "update not shed")
+	assert.Equal(t, 0, inner.patches, "patch not shed")
+}
+
+// a qps <= 0 disables shedding, the sink must pass everything through
+func TestEventSinkPassThrough(t *testing.T) {
+	testCases := []struct {
+		name  string
+		qps   int
+		burst int
+	}{
+		{"zero qps", 0, 0},
+		{"negative qps", -1, 100},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inner := &fakeEventSink{}
+			sink := NewRateLimitedEventSink(inner, tc.qps, tc.burst)
+			limited, ok := sink.(*rateLimitedEventSink)
+			assert.Assert(t, ok, "unexpected sink type")
+			assert.Assert(t, limited.limiter == nil, "limiter must not be set")
+
+			for i := 0; i < 100; i++ {
+				_, err := sink.Create(context.Background(), newEvent("event"))
+				assert.NilError(t, err, "create failed")
+			}
+			assert.Equal(t, 100, inner.creates, "events were shed")
+			assert.Equal(t, int64(0), limited.shed.Load(), "events were counted as shed")
+		})
+	}
+}
+
+// an error from the wrapped sink must be passed back so that the broadcaster can retry
+func TestEventSinkForwardsError(t *testing.T) {
+	expected := errors.New("sink failed")
+	inner := &fakeEventSink{err: expected}
+	sink := NewRateLimitedEventSink(inner, 0, 0)
+
+	_, err := sink.Create(context.Background(), newEvent("event"))
+	assert.Equal(t, expected, err, "error not returned")
+}
+
+// a 429 mutes the events for the time the server asked for: nothing is sent until it passes
+func TestEventSinkMuteOnThrottle(t *testing.T) {
+	clk := clocktesting.NewFakePassiveClock(time.Now())
+	inner := &fakeEventSink{err: apierrors.NewTooManyRequests("slow down", 5)}
+	// no client side limit, only the mute can shed here
+	sink := newRateLimitedEventSink(inner, 0, 0, clk, nil)
+
+	_, err := sink.Create(context.Background(), newEvent("throttled"))
+	assert.Assert(t, err != nil, "the 429 must be returned to the broadcaster")
+	assert.Equal(t, 1, inner.creates, "event not forwarded")
+
+	// the sink is muted for the next 5 seconds, the wrapped sink must not be called
+	inner.err = nil
+	for i := 0; i < 4; i++ {
+		step(clk, time.Second)
+		event := newEvent("muted")
+		result, muteErr := sink.Create(context.Background(), event)
+		assert.NilError(t, muteErr, "muted event must not fail the write")
+		assert.Equal(t, event, result, "muted event not returned")
+	}
+	assert.Equal(t, 1, inner.creates, "events sent while muted")
+	// the first drop is logged which resets the counter, the remaining 3 are still counted
+	assert.Equal(t, int64(3), sink.shed.Load(), "shed events not counted")
+
+	// once the deadline is reached the events are sent again
+	step(clk, time.Second)
+	_, err = sink.Create(context.Background(), newEvent("after mute"))
+	assert.NilError(t, err, "create failed")
+	assert.Equal(t, 2, inner.creates, "event not forwarded after the mute expired")
+}
+
+// only a 429 mutes the events, any other failure is left to the broadcaster
+func TestEventSinkMuteIgnoresOtherErrors(t *testing.T) {
+	clk := clocktesting.NewFakePassiveClock(time.Now())
+
+	testCases := []struct {
+		name string
+		err  error
+	}{
+		{"plain error", errors.New("sink failed")},
+		{"not found", apierrors.NewNotFound(eventsv1.Resource("events"), "event")},
+		{"server timeout", apierrors.NewInternalError(errors.New("boom"))},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inner := &fakeEventSink{err: tc.err}
+			sink := newRateLimitedEventSink(inner, 0, 0, clk, nil)
+
+			_, err := sink.Create(context.Background(), newEvent("failed"))
+			assert.Assert(t, err != nil, "error not returned")
+			assert.Equal(t, int64(0), sink.muteUntil.Load(), "events muted by a non 429 error")
+
+			_, err = sink.Create(context.Background(), newEvent("next"))
+			assert.Assert(t, err != nil, "error not returned")
+			assert.Equal(t, 2, inner.creates, "event was shed")
+		})
+	}
+}
+
+// a mute is extended by a longer delay but never shortened by a shorter one
+func TestEventSinkMuteOnlyExtends(t *testing.T) {
+	clk := clocktesting.NewFakePassiveClock(time.Now())
+	inner := &fakeEventSink{err: apierrors.NewTooManyRequests("slow down", 30)}
+	sink := newRateLimitedEventSink(inner, 0, 0, clk, nil)
+
+	_, err := sink.Create(context.Background(), newEvent("throttled"))
+	assert.Assert(t, err != nil, "error not returned")
+	muted := sink.muteUntil.Load()
+	assert.Equal(t, clk.Now().Add(30*time.Second).UnixNano(), muted, "unexpected mute deadline")
+
+	// a shorter delay must not bring the deadline forward: step past the mute so that the
+	// event is forwarded again, the new deadline is still earlier than the current one
+	step(clk, time.Second)
+	inner.err = apierrors.NewTooManyRequests("slow down", 1)
+	sink.checkThrottled(inner.err)
+	assert.Equal(t, muted, sink.muteUntil.Load(), "mute deadline was shortened")
+
+	// a longer delay extends it
+	sink.checkThrottled(apierrors.NewTooManyRequests("slow down", 60))
+	assert.Equal(t, clk.Now().Add(60*time.Second).UnixNano(), sink.muteUntil.Load(), "mute not extended")
+}
+
+// a 429 without a delay must still mute, and an excessive delay must be capped
+func TestEventSinkMuteBounds(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected time.Duration
+	}{
+		{"no delay advertised", apierrors.NewTooManyRequestsError("slow down"), defaultEventMute},
+		{"delay capped", apierrors.NewTooManyRequests("slow down", 600), maxEventMute},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clk := clocktesting.NewFakePassiveClock(time.Now())
+			sink := newRateLimitedEventSink(&fakeEventSink{}, 0, 0, clk, nil)
+
+			sink.checkThrottled(tc.err)
+			assert.Equal(t, clk.Now().Add(tc.expected).UnixNano(), sink.muteUntil.Load(), "unexpected mute deadline")
+		})
+	}
+}

--- a/pkg/client/eventsink_test.go
+++ b/pkg/client/eventsink_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,9 +56,15 @@ func (f *fakeEventSink) Patch(_ context.Context, event *eventsv1.Event, _ []byte
 	return event, f.err
 }
 
+// newEvent creates a Normal event, the type which the sink is allowed to shed
 func newEvent(name string) *eventsv1.Event {
+	return newTypedEvent(name, v1.EventTypeNormal)
+}
+
+func newTypedEvent(name, eventType string) *eventsv1.Event {
 	return &eventsv1.Event{
 		ObjectMeta: apis.ObjectMeta{Namespace: "default", Name: name},
+		Type:       eventType,
 	}
 }
 
@@ -110,6 +117,51 @@ func TestEventSinkShedsAllOperations(t *testing.T) {
 	assert.Equal(t, 1, inner.creates, "unexpected creates")
 	assert.Equal(t, 0, inner.updates, "update not shed")
 	assert.Equal(t, 0, inner.patches, "patch not shed")
+}
+
+// a Warning event is never shed by the bucket and spends no token on it: it is the event a
+// user reads to find out why a pod is not running
+func TestEventSinkWarningNotShed(t *testing.T) {
+	inner := &fakeEventSink{}
+	// a burst of 1 leaves the bucket empty after the first event
+	sink := NewRateLimitedEventSink(inner, 1, 1)
+
+	_, err := sink.Create(context.Background(), newEvent("first"))
+	assert.NilError(t, err, "create failed")
+	assert.Equal(t, 1, inner.creates, "event not forwarded")
+
+	for i := 0; i < 10; i++ {
+		warning := newTypedEvent("warning", v1.EventTypeWarning)
+		result, warnErr := sink.Create(context.Background(), warning)
+		assert.NilError(t, warnErr, "create failed")
+		assert.Equal(t, warning, result, "event not returned")
+	}
+	assert.Equal(t, 11, inner.creates, "warning events were shed")
+
+	// no token was spent on the warnings, the next normal event is still shed
+	_, err = sink.Create(context.Background(), newEvent("shed"))
+	assert.NilError(t, err, "shed event must not fail the write")
+	assert.Equal(t, 11, inner.creates, "normal event was forwarded")
+}
+
+// while the server is throttling us a warning is shed as well: it would only be rejected
+func TestEventSinkShedsWarningWhileMuted(t *testing.T) {
+	clk := clocktesting.NewFakePassiveClock(time.Now())
+	inner := &fakeEventSink{err: apierrors.NewTooManyRequests("slow down", 5)}
+	// no client side limit, only the mute can shed here
+	sink := newRateLimitedEventSink(inner, 0, 0, clk, nil)
+
+	_, err := sink.Create(context.Background(), newTypedEvent("throttled", v1.EventTypeWarning))
+	assert.Assert(t, err != nil, "the 429 must be returned to the broadcaster")
+	assert.Equal(t, 1, inner.creates, "event not forwarded")
+
+	inner.err = nil
+	step(clk, time.Second)
+	warning := newTypedEvent("muted", v1.EventTypeWarning)
+	result, muteErr := sink.Create(context.Background(), warning)
+	assert.NilError(t, muteErr, "muted event must not fail the write")
+	assert.Equal(t, warning, result, "muted event not returned")
+	assert.Equal(t, 1, inner.creates, "warning event sent while muted")
 }
 
 // a qps <= 0 disables shedding, the sink must pass everything through

--- a/pkg/client/eventstransport.go
+++ b/pkg/client/eventstransport.go
@@ -1,0 +1,115 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package client
+
+import (
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/clock"
+)
+
+const (
+	// the header priority and fairness uses to advertise how long to wait
+	retryAfterHeader = "Retry-After"
+	// the longest a delay recorded by the transport is used by the sink
+	muteHintValidity = 10 * time.Second
+)
+
+// muteHint is the delay the server advertised on a rejected request, handed from the
+// transport to the sink which mutes the events
+type muteHint struct {
+	seconds    int
+	recordedAt time.Time
+}
+
+// muteHintHolder holds the most recent delay advertised by the server
+type muteHintHolder struct {
+	hint atomic.Pointer[muteHint]
+}
+
+func (h *muteHintHolder) record(seconds int, now time.Time) {
+	h.hint.Store(&muteHint{seconds: seconds, recordedAt: now})
+}
+
+// get returns the recorded delay if it was recorded recently enough to still describe the
+// state of the server
+func (h *muteHintHolder) get(now time.Time) (int, bool) {
+	hint := h.hint.Load()
+	if hint == nil || now.Sub(hint.recordedAt) > muteHintValidity {
+		return 0, false
+	}
+	return hint.seconds, true
+}
+
+// eventsThrottleTransport records the delay advertised on a 429 and removes the Retry-After
+// header from the response.
+// Removing the header stops the REST client from retrying the request itself: it only retries
+// a 429 which tells it how long to wait for (see checkWait in client-go rest/with_retry.go).
+// Those retries sleep in the calling goroutine, which for events means the broadcaster
+// goroutines pile up in the client for the whole time the server is throttling us, and the
+// rejection never reaches the sink. Failing the request instead lets the sink mute the events
+// for the window the server asked for, which is what the delay is for.
+type eventsThrottleTransport struct {
+	base  http.RoundTripper
+	hints *muteHintHolder
+	clock clock.PassiveClock
+}
+
+func (t *eventsThrottleTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+		return resp, err
+	}
+
+	if seconds, ok := retryAfterSeconds(resp); ok {
+		t.hints.record(seconds, t.clock.Now())
+	}
+	resp.Header.Del(retryAfterHeader)
+	return resp, nil
+}
+
+// retryAfterSeconds returns the advertised delay in seconds, or false if the header is
+// missing or does not hold a number
+func retryAfterSeconds(resp *http.Response) (int, bool) {
+	header := resp.Header.Get(retryAfterHeader)
+	if header == "" {
+		return 0, false
+	}
+	seconds, err := strconv.Atoi(header)
+	if err != nil {
+		return 0, false
+	}
+	return seconds, true
+}
+
+// newEventsClientSet creates the events client. When hints are passed in the client fails
+// fast on a 429 instead of retrying it internally, see eventsThrottleTransport.
+func newEventsClientSet(kc string, hints *muteHintHolder, clk clock.PassiveClock) kubernetes.Interface {
+	config := newRestConfig(kc, -1, 0, userAgentEvents)
+	if hints != nil {
+		config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+			return &eventsThrottleTransport{base: rt, hints: hints, clock: clk}
+		})
+	}
+	return newClientSetOrDie(config)
+}

--- a/pkg/client/eventstransport_test.go
+++ b/pkg/client/eventstransport_test.go
@@ -1,0 +1,211 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+// the REST client only retries a rejection which tells it how long to wait for, so it must
+// not see the header: the retries sleep in the calling goroutine and never reach the sink
+const noRetryBudget = time.Second
+
+// newThrottlingServer returns a server which rejects every request with the given status and
+// headers, and counts the requests it served
+func newThrottlingServer(t *testing.T, status int, headers map[string]string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		for name, value := range headers {
+			w.Header().Set(name, value)
+		}
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(server.Close)
+	return server, &requests
+}
+
+// newTestEventsClient builds the events client used against the test server, with the
+// throttle transport attached when hints are passed in
+func newTestEventsClient(t *testing.T, server *httptest.Server, hints *muteHintHolder, clk *clocktesting.FakePassiveClock) kubernetes.Interface {
+	t.Helper()
+	config := &rest.Config{Host: server.URL}
+	config.QPS = -1
+	if hints != nil {
+		config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+			return &eventsThrottleTransport{base: rt, hints: hints, clock: clk}
+		})
+	}
+	clientSet, err := kubernetes.NewForConfig(config)
+	assert.NilError(t, err, "could not create clientset")
+	return clientSet
+}
+
+func createEvent(clientSet kubernetes.Interface) error {
+	event := &eventsv1.Event{ObjectMeta: apis.ObjectMeta{Namespace: "default", Name: "event"}}
+	_, err := clientSet.EventsV1().Events("default").Create(context.Background(), event, apis.CreateOptions{})
+	return err
+}
+
+// a 429 which advertises a delay must fail fast, the delay must be recorded and the header
+// removed so that the REST client does not retry the request itself
+func TestThrottleTransportRecordsAndStrips(t *testing.T) {
+	clk := clocktesting.NewFakePassiveClock(time.Now())
+	hints := &muteHintHolder{}
+	server, requests := newThrottlingServer(t, http.StatusTooManyRequests, map[string]string{retryAfterHeader: "7"})
+	clientSet := newTestEventsClient(t, server, hints, clk)
+
+	start := time.Now()
+	err := createEvent(clientSet)
+	elapsed := time.Since(start)
+
+	assert.Assert(t, err != nil, "the rejection must be returned")
+	assert.Assert(t, apierrors.IsTooManyRequests(err), "unexpected error: %v", err)
+	assert.Assert(t, elapsed < noRetryBudget, "the request was retried internally, it took %s", elapsed)
+	assert.Equal(t, int64(1), requests.Load(), "the request was sent more than once")
+
+	seconds, ok := hints.get(clk.Now())
+	assert.Assert(t, ok, "delay not recorded")
+	assert.Equal(t, 7, seconds, "unexpected delay recorded")
+
+	// the header is gone from the error, the sink has to fall back to the recorded delay
+	_, hasDelay := apierrors.SuggestsClientDelay(err)
+	assert.Assert(t, !hasDelay, "the Retry-After header was not removed")
+}
+
+// a 429 without a delay must fail fast as well, there is nothing to record
+func TestThrottleTransportWithoutHeader(t *testing.T) {
+	clk := clocktesting.NewFakePassiveClock(time.Now())
+	hints := &muteHintHolder{}
+	server, requests := newThrottlingServer(t, http.StatusTooManyRequests, nil)
+	clientSet := newTestEventsClient(t, server, hints, clk)
+
+	start := time.Now()
+	err := createEvent(clientSet)
+	elapsed := time.Since(start)
+
+	assert.Assert(t, apierrors.IsTooManyRequests(err), "unexpected error: %v", err)
+	assert.Assert(t, elapsed < noRetryBudget, "the request was retried internally, it took %s", elapsed)
+	assert.Equal(t, int64(1), requests.Load(), "the request was sent more than once")
+
+	_, ok := hints.get(clk.Now())
+	assert.Assert(t, !ok, "a delay was recorded")
+}
+
+// every response which is not a 429 must be passed through untouched
+func TestThrottleTransportPassesThrough(t *testing.T) {
+	testCases := []struct {
+		name   string
+		status int
+	}{
+		{"created", http.StatusOK},
+		{"not found", http.StatusNotFound},
+		{"server error", http.StatusInternalServerError},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clk := clocktesting.NewFakePassiveClock(time.Now())
+			hints := &muteHintHolder{}
+			server, _ := newThrottlingServer(t, tc.status, map[string]string{retryAfterHeader: "7"})
+
+			// call the transport directly, the typed client would retry a 500 for a while
+			base := &eventsThrottleTransport{base: http.DefaultTransport, hints: hints, clock: clk}
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			assert.NilError(t, err, "could not create request")
+			resp, err := base.RoundTrip(req)
+			assert.NilError(t, err, "round trip failed")
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+
+			assert.Equal(t, tc.status, resp.StatusCode, "unexpected status")
+			assert.Equal(t, "7", resp.Header.Get(retryAfterHeader), "the header was removed")
+			_, ok := hints.get(clk.Now())
+			assert.Assert(t, !ok, "a delay was recorded")
+		})
+	}
+}
+
+// the recorded delay describes the server right now, it must not be used indefinitely
+func TestMuteHintExpires(t *testing.T) {
+	now := time.Now()
+	hints := &muteHintHolder{}
+
+	_, ok := hints.get(now)
+	assert.Assert(t, !ok, "an empty holder returned a delay")
+
+	hints.record(7, now)
+	seconds, ok := hints.get(now.Add(muteHintValidity))
+	assert.Assert(t, ok, "delay expired too early")
+	assert.Equal(t, 7, seconds, "unexpected delay")
+
+	_, ok = hints.get(now.Add(muteHintValidity + time.Second))
+	assert.Assert(t, !ok, "stale delay returned")
+}
+
+// the sink mutes for the delay recorded by the transport when the error no longer carries it
+func TestEventSinkMuteFromTransport(t *testing.T) {
+	clk := clocktesting.NewFakePassiveClock(time.Now())
+	hints := &muteHintHolder{}
+	hints.record(7, clk.Now())
+	// the error carries no delay, exactly what the transport leaves behind
+	inner := &fakeEventSink{err: apierrors.NewTooManyRequestsError("slow down")}
+	sink := newRateLimitedEventSink(inner, 0, 0, clk, hints)
+
+	_, err := sink.Create(context.Background(), newEvent("throttled"))
+	assert.Assert(t, err != nil, "error not returned")
+
+	delay, source := sink.muteDelay(err)
+	assert.Equal(t, 7*time.Second, delay, "unexpected delay")
+	assert.Equal(t, "transport", source, "unexpected delay source")
+	assert.Equal(t, clk.Now().Add(7*time.Second).UnixNano(), sink.muteUntil.Load(), "unexpected mute deadline")
+
+	// a stale delay is ignored, the sink falls back to the default
+	step(clk, muteHintValidity+time.Second)
+	delay, source = sink.muteDelay(inner.err)
+	assert.Equal(t, defaultEventMute, delay, "stale delay used")
+	assert.Equal(t, "default", source, "unexpected delay source")
+}
+
+// the delay on the error wins, it is the one the server sent for this request
+func TestEventSinkMuteSourcePriority(t *testing.T) {
+	clk := clocktesting.NewFakePassiveClock(time.Now())
+	hints := &muteHintHolder{}
+	hints.record(7, clk.Now())
+	sink := newRateLimitedEventSink(&fakeEventSink{}, 0, 0, clk, hints)
+
+	delay, source := sink.muteDelay(apierrors.NewTooManyRequests("slow down", 30))
+	assert.Equal(t, 30*time.Second, delay, "unexpected delay")
+	assert.Equal(t, "header", source, "unexpected delay source")
+}

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -52,9 +52,13 @@ type KubeClient interface {
 }
 
 func NewKubeClient(kc string) KubeClient {
-	return newSchedulerKubeClient(kc)
+	return NewKubeClientWithUserAgent(kc, userAgentWrites)
 }
 
-func NewBootstrapKubeClient(kc string) KubeClient {
-	return newBootstrapSchedulerKubeClient(kc)
+// NewKubeClientWithUserAgent creates a KubeClient which identifies itself with the given
+// user agent concern, the build version is appended to it. The client uses the
+// kubernetes.qps and kubernetes.burst policy from the scheduler configuration, which is
+// unlimited by default.
+func NewKubeClientWithUserAgent(kc string, userAgent string) KubeClient {
+	return newSchedulerKubeClient(kc, userAgent)
 }

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -21,7 +21,6 @@ package client
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 type KubeClient interface {
@@ -40,13 +39,8 @@ type KubeClient interface {
 	// Update the status of a pod
 	UpdateStatus(pod *v1.Pod) (*v1.Pod, error)
 
-	// Get a pod
-	Get(podNamespace string, podName string) (*v1.Pod, error)
-
 	// minimal expose this, only informers factory needs it
 	GetClientSet() kubernetes.Interface
-
-	GetConfigs() *rest.Config
 
 	GetConfigMap(namespace string, name string) (*v1.ConfigMap, error)
 }

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -21,6 +21,8 @@ package client
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/apache/yunikorn-k8shim/pkg/conf"
 )
 
 type KubeClient interface {
@@ -45,14 +47,17 @@ type KubeClient interface {
 	GetConfigMap(namespace string, name string) (*v1.ConfigMap, error)
 }
 
+// NewKubeClient creates the scheduler client: it carries the scheduling actions and backs
+// the informers. The kubernetes.qps and kubernetes.burst policy from the scheduler
+// configuration applies, so the client must be created after the configmaps are loaded.
 func NewKubeClient(kc string) KubeClient {
-	return NewKubeClientWithUserAgent(kc, userAgentWrites)
+	schedulerConf := conf.GetSchedulerConf()
+	return newKubeClient(kc, schedulerConf.KubeQPS, schedulerConf.KubeBurst, userAgentScheduler)
 }
 
-// NewKubeClientWithUserAgent creates a KubeClient which identifies itself with the given
-// user agent concern, the build version is appended to it. The client uses the
-// kubernetes.qps and kubernetes.burst policy from the scheduler configuration, which is
-// unlimited by default.
-func NewKubeClientWithUserAgent(kc string, userAgent string) KubeClient {
-	return newSchedulerKubeClient(kc, userAgent)
+// NewAdmissionControllerKubeClient creates the admission controller client. It runs on the
+// client-go defaults: its traffic is three small informers and the occasional webhook or
+// secret write.
+func NewAdmissionControllerKubeClient(kc string) KubeClient {
+	return newKubeClient(kc, 0, 0, userAgentAdmissionController)
 }

--- a/pkg/client/kubeclient.go
+++ b/pkg/client/kubeclient.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/clock"
 
 	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
@@ -40,32 +41,116 @@ type SchedulerKubeClient struct {
 	configs   *rest.Config
 }
 
-func newBootstrapSchedulerKubeClient(kc string) SchedulerKubeClient {
+// Every client identifies the concern it serves in its user agent so that traffic can be
+// attributed on the API server side. The concern comes first to allow prefix matching, the
+// build version is appended by UserAgent().
+const (
+	UserAgentAdmissionController = "yunikorn-admission-controller"
+
+	userAgentBootstrap = "yunikorn-bootstrap"
+	userAgentWrites    = "yunikorn-scheduler/writes"
+	userAgentInformers = "yunikorn-scheduler/informers"
+	userAgentEvents    = "yunikorn-scheduler/events"
+)
+
+// UserAgent appends the build version to the concern, e.g. "yunikorn-scheduler/writes
+// (1.7.0)". The version is only set in release builds, it is left out when empty.
+func UserAgent(concern string) string {
+	return userAgentWithVersion(concern, conf.GetBuildInfoMap()["buildVersion"])
+}
+
+func userAgentWithVersion(concern, version string) string {
+	if version == "" {
+		return concern
+	}
+	return fmt.Sprintf("%s (%s)", concern, version)
+}
+
+// rateLimitPolicy turns the configured qps and burst into the values to set on a REST config
+// and a description of the resulting limit for logging.
+// A qps <= 0 disables client side rate limiting: this is expressed as a negative QPS, which
+// client-go treats as "create no rate limiter", while a QPS of 0 silently falls back to its
+// own defaults of 5 QPS / 10 burst (see RESTClientFor and NewForConfigAndClient in
+// client-go). A QPS set without a burst is rejected by client-go, so the burst defaults to
+// the configured qps.
+func rateLimitPolicy(concern string, qps, burst int) (effectiveQPS float32, effectiveBurst int, description string) {
+	if qps <= 0 {
+		if burst > 0 {
+			log.Log(log.ShimClient).Warn("ignoring configured burst, client side rate limiting is disabled unless qps is set to a positive value",
+				zap.String("concern", concern),
+				zap.Int("qps", qps),
+				zap.Int("burst", burst))
+		}
+		return -1, 0, "unlimited"
+	}
+	if burst <= 0 {
+		log.Log(log.ShimClient).Warn("no burst configured, defaulting burst to the configured qps",
+			zap.String("concern", concern),
+			zap.Int("qps", qps))
+		burst = qps
+	}
+	return float32(qps), burst, fmt.Sprintf("%d qps / %d burst", qps, burst)
+}
+
+// newRestConfig creates a REST config for a single purpose client, see rateLimitPolicy for
+// the way the configured qps and burst are applied.
+func newRestConfig(kc string, qps, burst int, concern string) *rest.Config {
 	config := CreateRestConfigOrDie(kc)
+	config.UserAgent = UserAgent(concern)
+
+	var rateLimit string
+	config.QPS, config.Burst, rateLimit = rateLimitPolicy(concern, qps, burst)
+
+	log.Log(log.ShimClient).Info("creating Kubernetes client",
+		zap.String("concern", concern),
+		zap.String("rateLimit", rateLimit),
+		zap.String("userAgent", config.UserAgent))
+	return config
+}
+
+func newClientSetOrDie(config *rest.Config) *kubernetes.Clientset {
 	configuredClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		log.Log(log.ShimClient).Fatal("failed to get Clientset", zap.Error(err))
 	}
+	return configuredClient
+}
+
+// newSchedulerKubeClient creates the client used for all writes to the API server. Beside
+// the pod writes it also backs the volume binder and the predicate framework handle, so the
+// configured QPS and burst are an opt-in policy cap on those paths as well.
+// The QPS and burst are read from the configuration singleton, like all other configuration
+// access. In the shim this means the client must be created after UpdateConfigMaps has run
+// for the values set by the operator to take effect. The admission controller never
+// populates the scheduler configuration, so its clients always run on the defaults: that is
+// intended, its traffic is low volume and it previously ran on a 1000/1000 limiter which was
+// never engaged either.
+func newSchedulerKubeClient(kc string, concern string) SchedulerKubeClient {
+	schedulerConf := conf.GetSchedulerConf()
+
+	config := newRestConfig(kc, schedulerConf.KubeQPS, schedulerConf.KubeBurst, concern)
 	return SchedulerKubeClient{
-		clientSet: configuredClient,
+		clientSet: newClientSetOrDie(config),
 		configs:   config,
 	}
 }
 
-func newSchedulerKubeClient(kc string) SchedulerKubeClient {
-	schedulerConf := conf.GetSchedulerConf()
+// NewInformerClientSet creates the client backing the informer factories. Informer traffic
+// is never rate limited on the client side: watches are long lived and a relist must not be
+// throttled behind the write path.
+func NewInformerClientSet(kc string) kubernetes.Interface {
+	return newClientSetOrDie(newRestConfig(kc, 0, 0, userAgentInformers))
+}
 
-	config := CreateRestConfigOrDie(kc)
-	config.QPS = float32(schedulerConf.KubeQPS)
-	config.Burst = schedulerConf.KubeBurst
-	configuredClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		log.Log(log.ShimClient).Fatal("failed to get Clientset", zap.Error(err))
-	}
-	return SchedulerKubeClient{
-		clientSet: configuredClient,
-		configs:   config,
-	}
+// NewEventsClientSet creates the client backing the event broadcaster sink. It is never rate
+// limited: the configured event rate is enforced by the sink, which sheds the events above
+// it, see NewRateLimitedEventSink. A limiter here as well would delay the events which are
+// kept for as long as a storm lasts.
+// This client retries a server side rejection like every other client. Only the client built
+// by NewEventSink fails fast on it, that behaviour only makes sense paired with the sink
+// which mutes the events for the window the server asked for.
+func NewEventsClientSet(kc string) kubernetes.Interface {
+	return newEventsClientSet(kc, nil, clock.RealClock{})
 }
 
 func CreateRestConfigOrDie(kc string) *rest.Config {

--- a/pkg/client/kubeclient.go
+++ b/pkg/client/kubeclient.go
@@ -38,7 +38,6 @@ import (
 
 type SchedulerKubeClient struct {
 	clientSet *kubernetes.Clientset
-	configs   *rest.Config
 }
 
 // Every client identifies the concern it serves in its user agent so that traffic can be
@@ -131,7 +130,6 @@ func newSchedulerKubeClient(kc string, concern string) SchedulerKubeClient {
 	config := newRestConfig(kc, schedulerConf.KubeQPS, schedulerConf.KubeBurst, concern)
 	return SchedulerKubeClient{
 		clientSet: newClientSetOrDie(config),
-		configs:   config,
 	}
 }
 
@@ -189,10 +187,6 @@ func (nc SchedulerKubeClient) GetClientSet() kubernetes.Interface {
 	return nc.clientSet
 }
 
-func (nc SchedulerKubeClient) GetConfigs() *rest.Config {
-	return nc.configs
-}
-
 func (nc SchedulerKubeClient) Bind(pod *v1.Pod, hostID string) error {
 	log.Log(log.ShimClient).Info("bind pod to node",
 		zap.String("podName", pod.Name),
@@ -243,18 +237,6 @@ func (nc SchedulerKubeClient) GetConfigMap(namespace string, name string) (*v1.C
 		return nil, err
 	}
 	return configmap, nil
-}
-
-func (nc SchedulerKubeClient) Get(podNamespace string, podName string) (*v1.Pod, error) {
-	pod, err := nc.clientSet.CoreV1().Pods(podNamespace).Get(context.Background(), podName, apis.GetOptions{})
-	if err != nil {
-		log.Log(log.ShimClient).Warn("failed to get pod",
-			zap.String("namespace", pod.Namespace),
-			zap.String("podName", pod.Name),
-			zap.Error(err))
-		return nil, err
-	}
-	return pod, nil
 }
 
 func (nc SchedulerKubeClient) UpdatePod(pod *v1.Pod, podMutator func(pod *v1.Pod)) (*v1.Pod, error) {

--- a/pkg/client/kubeclient.go
+++ b/pkg/client/kubeclient.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/clock"
 
 	"github.com/apache/yunikorn-k8shim/pkg/conf"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
@@ -40,70 +39,37 @@ type SchedulerKubeClient struct {
 	clientSet *kubernetes.Clientset
 }
 
-// Every client identifies the concern it serves in its user agent so that traffic can be
-// attributed on the API server side. The concern comes first to allow prefix matching, the
-// build version is appended by UserAgent().
+// Every client identifies the concern it serves in its user agent so that the traffic can be
+// attributed on the API server side. That is all the concern is used for.
 const (
-	UserAgentAdmissionController = "yunikorn-admission-controller"
-
-	userAgentBootstrap = "yunikorn-bootstrap"
-	userAgentWrites    = "yunikorn-scheduler/writes"
-	userAgentInformers = "yunikorn-scheduler/informers"
-	userAgentEvents    = "yunikorn-scheduler/events"
+	userAgentScheduler           = "yunikorn-scheduler"
+	userAgentEvents              = "yunikorn-scheduler/events"
+	userAgentBootstrap           = "yunikorn-bootstrap"
+	userAgentAdmissionController = "yunikorn-admission-controller"
 )
 
-// UserAgent appends the build version to the concern, e.g. "yunikorn-scheduler/writes
-// (1.7.0)". The version is only set in release builds, it is left out when empty.
-func UserAgent(concern string) string {
-	return userAgentWithVersion(concern, conf.GetBuildInfoMap()["buildVersion"])
-}
-
-func userAgentWithVersion(concern, version string) string {
-	if version == "" {
-		return concern
-	}
-	return fmt.Sprintf("%s (%s)", concern, version)
-}
-
-// rateLimitPolicy turns the configured qps and burst into the values to set on a REST config
-// and a description of the resulting limit for logging.
-// A qps <= 0 disables client side rate limiting: this is expressed as a negative QPS, which
-// client-go treats as "create no rate limiter", while a QPS of 0 silently falls back to its
-// own defaults of 5 QPS / 10 burst (see RESTClientFor and NewForConfigAndClient in
-// client-go). A QPS set without a burst is rejected by client-go, so the burst defaults to
-// the configured qps.
-func rateLimitPolicy(concern string, qps, burst int) (effectiveQPS float32, effectiveBurst int, description string) {
-	if qps <= 0 {
-		if burst > 0 {
-			log.Log(log.ShimClient).Warn("ignoring configured burst, client side rate limiting is disabled unless qps is set to a positive value",
-				zap.String("concern", concern),
-				zap.Int("qps", qps),
-				zap.Int("burst", burst))
-		}
-		return -1, 0, "unlimited"
-	}
+// clientRateLimit normalises the configured qps and burst into the values set on the REST
+// config. A negative qps creates no client side limiter, a qps of 0 leaves client-go on its
+// defaults (5 QPS / 10 burst). For a positive qps client-go requires a positive burst, so an
+// unset burst defaults to the qps.
+func clientRateLimit(qps, burst int) (float32, int) {
 	if burst <= 0 {
-		log.Log(log.ShimClient).Warn("no burst configured, defaulting burst to the configured qps",
-			zap.String("concern", concern),
-			zap.Int("qps", qps))
-		burst = qps
+		burst = max(0, qps)
 	}
-	return float32(qps), burst, fmt.Sprintf("%d qps / %d burst", qps, burst)
+	return float32(max(-1, qps)), burst
 }
 
-// newRestConfig creates a REST config for a single purpose client, see rateLimitPolicy for
+// newRestConfig creates a REST config for a single purpose client, see clientRateLimit for
 // the way the configured qps and burst are applied.
 func newRestConfig(kc string, qps, burst int, concern string) *rest.Config {
 	config := CreateRestConfigOrDie(kc)
-	config.UserAgent = UserAgent(concern)
-
-	var rateLimit string
-	config.QPS, config.Burst, rateLimit = rateLimitPolicy(concern, qps, burst)
+	config.UserAgent = concern
+	config.QPS, config.Burst = clientRateLimit(qps, burst)
 
 	log.Log(log.ShimClient).Info("creating Kubernetes client",
 		zap.String("concern", concern),
-		zap.String("rateLimit", rateLimit),
-		zap.String("userAgent", config.UserAgent))
+		zap.Float32("qps", config.QPS),
+		zap.Int("burst", config.Burst))
 	return config
 }
 
@@ -115,40 +81,15 @@ func newClientSetOrDie(config *rest.Config) *kubernetes.Clientset {
 	return configuredClient
 }
 
-// newSchedulerKubeClient creates the client used for all writes to the API server. Beside
-// the pod writes it also backs the volume binder and the predicate framework handle, so the
-// configured QPS and burst are an opt-in policy cap on those paths as well.
-// The QPS and burst are read from the configuration singleton, like all other configuration
-// access. In the shim this means the client must be created after UpdateConfigMaps has run
-// for the values set by the operator to take effect. The admission controller never
-// populates the scheduler configuration, so its clients always run on the defaults: that is
-// intended, its traffic is low volume and it previously ran on a 1000/1000 limiter which was
-// never engaged either.
-func newSchedulerKubeClient(kc string, concern string) SchedulerKubeClient {
-	schedulerConf := conf.GetSchedulerConf()
-
-	config := newRestConfig(kc, schedulerConf.KubeQPS, schedulerConf.KubeBurst, concern)
+// newKubeClient creates a client for a single concern. Beside the pod writes the scheduler
+// client also backs the volume binder and the predicate framework handle, so the configured
+// QPS and burst are an opt-in policy cap on those paths as well.
+// The QPS and burst are passed in by the caller: the values from the configuration singleton
+// can only be read after UpdateConfigMaps has run.
+func newKubeClient(kc string, qps, burst int, concern string) SchedulerKubeClient {
 	return SchedulerKubeClient{
-		clientSet: newClientSetOrDie(config),
+		clientSet: newClientSetOrDie(newRestConfig(kc, qps, burst, concern)),
 	}
-}
-
-// NewInformerClientSet creates the client backing the informer factories. Informer traffic
-// is never rate limited on the client side: watches are long lived and a relist must not be
-// throttled behind the write path.
-func NewInformerClientSet(kc string) kubernetes.Interface {
-	return newClientSetOrDie(newRestConfig(kc, 0, 0, userAgentInformers))
-}
-
-// NewEventsClientSet creates the client backing the event broadcaster sink. It is never rate
-// limited: the configured event rate is enforced by the sink, which sheds the events above
-// it, see NewRateLimitedEventSink. A limiter here as well would delay the events which are
-// kept for as long as a storm lasts.
-// This client retries a server side rejection like every other client. Only the client built
-// by NewEventSink fails fast on it, that behaviour only makes sense paired with the sink
-// which mutes the events for the window the server asked for.
-func NewEventsClientSet(kc string) kubernetes.Interface {
-	return newEventsClientSet(kc, nil, clock.RealClock{})
 }
 
 func CreateRestConfigOrDie(kc string) *rest.Config {

--- a/pkg/client/kubeclient_mock.go
+++ b/pkg/client/kubeclient_mock.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
 
 	"github.com/apache/yunikorn-k8shim/pkg/locking"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
@@ -180,6 +179,7 @@ func (c *KubeClientMock) UpdateStatus(pod *v1.Pod) (*v1.Pod, error) {
 	return c.updateStatusFn(pod)
 }
 
+// Get returns a pod tracked by the mock, it is a test only helper and not part of KubeClient
 func (c *KubeClientMock) Get(podNamespace string, podName string) (*v1.Pod, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
@@ -202,12 +202,6 @@ func (c *KubeClientMock) GetClientSet() kubernetes.Interface {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.clientSet
-}
-
-func (c *KubeClientMock) GetConfigs() *rest.Config {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	return nil
 }
 
 func (c *KubeClientMock) GetConfigMap(namespace string, name string) (*v1.ConfigMap, error) {

--- a/pkg/client/kubeclient_test.go
+++ b/pkg/client/kubeclient_test.go
@@ -1,0 +1,150 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"k8s.io/client-go/kubernetes"
+)
+
+const testKubeConfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://localhost:6443
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user: {}
+`
+
+func TestUserAgentWithVersion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		concern  string
+		version  string
+		expected string
+	}{
+		{"no version", userAgentWrites, "", "yunikorn-scheduler/writes"},
+		{"version appended", userAgentWrites, "1.7.0", "yunikorn-scheduler/writes (1.7.0)"},
+		{"admission controller", UserAgentAdmissionController, "1.7.0", "yunikorn-admission-controller (1.7.0)"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, userAgentWithVersion(tc.concern, tc.version), "unexpected user agent")
+		})
+	}
+}
+
+func TestRateLimitPolicy(t *testing.T) {
+	testCases := []struct {
+		name          string
+		concern       string
+		qps           int
+		burst         int
+		expectedQPS   float32
+		expectedBurst int
+		expectedLimit string
+	}{
+		{"unlimited", userAgentInformers, 0, 0, -1, 0, "unlimited"},
+		{"negative is unlimited", userAgentWrites, -1, -1, -1, 0, "unlimited"},
+		{"burst without qps is ignored", userAgentBootstrap, 0, 100, -1, 0, "unlimited"},
+		{"limited", userAgentEvents, 100, 200, 100, 200, "100 qps / 200 burst"},
+		{"burst defaults to qps", UserAgentAdmissionController, 100, 0, 100, 100, "100 qps / 100 burst"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			qps, burst, rateLimit := rateLimitPolicy(tc.concern, tc.qps, tc.burst)
+			assert.Equal(t, tc.expectedQPS, qps, "unexpected QPS")
+			assert.Equal(t, tc.expectedBurst, burst, "unexpected burst")
+			assert.Equal(t, tc.expectedLimit, rateLimit, "unexpected rate limit description")
+		})
+	}
+}
+
+func TestNewRestConfig(t *testing.T) {
+	kc := writeKubeConfig(t)
+
+	testCases := []struct {
+		name    string
+		concern string
+		qps     int
+		burst   int
+	}{
+		{"unlimited", userAgentInformers, 0, 0},
+		{"limited", userAgentEvents, 100, 200},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedQPS, expectedBurst, _ := rateLimitPolicy(tc.concern, tc.qps, tc.burst)
+			config := newRestConfig(kc, tc.qps, tc.burst, tc.concern)
+			assert.Equal(t, UserAgent(tc.concern), config.UserAgent, "user agent not set")
+			// creating the limiter is always left to client-go: a negative QPS makes it
+			// create none, a QPS of 0 would silently fall back to the client-go defaults
+			assert.Assert(t, config.RateLimiter == nil, "rate limiter must be left to client-go")
+			assert.Equal(t, expectedQPS, config.QPS, "QPS not taken from the rate limit policy")
+			assert.Equal(t, expectedBurst, config.Burst, "burst not taken from the rate limit policy")
+		})
+	}
+}
+
+// client-go must accept every configuration we generate, it rejects a QPS which is set
+// without a burst and a rejected configuration is fatal at startup
+func TestNewClientSetAcceptsRestConfig(t *testing.T) {
+	kc := writeKubeConfig(t)
+
+	testCases := []struct {
+		name  string
+		qps   int
+		burst int
+	}{
+		{"unlimited", 0, 0},
+		{"qps without burst", 100, 0},
+		{"qps and burst", 100, 200},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := kubernetes.NewForConfig(newRestConfig(kc, tc.qps, tc.burst, userAgentWrites))
+			assert.NilError(t, err, "clientset creation failed")
+		})
+	}
+}
+
+// writeKubeConfig creates a kubeconfig file for a non existing cluster and returns its path
+func writeKubeConfig(t *testing.T) string {
+	t.Helper()
+	kc := filepath.Join(t.TempDir(), "kubeconfig")
+	err := os.WriteFile(kc, []byte(testKubeConfig), 0600)
+	assert.NilError(t, err, "could not write kubeconfig")
+	return kc
+}

--- a/pkg/client/kubeclient_test.go
+++ b/pkg/client/kubeclient_test.go
@@ -44,48 +44,28 @@ users:
   user: {}
 `
 
-func TestUserAgentWithVersion(t *testing.T) {
-	testCases := []struct {
-		name     string
-		concern  string
-		version  string
-		expected string
-	}{
-		{"no version", userAgentWrites, "", "yunikorn-scheduler/writes"},
-		{"version appended", userAgentWrites, "1.7.0", "yunikorn-scheduler/writes (1.7.0)"},
-		{"admission controller", UserAgentAdmissionController, "1.7.0", "yunikorn-admission-controller (1.7.0)"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, userAgentWithVersion(tc.concern, tc.version), "unexpected user agent")
-		})
-	}
-}
-
-func TestRateLimitPolicy(t *testing.T) {
+func TestClientRateLimit(t *testing.T) {
 	testCases := []struct {
 		name          string
-		concern       string
 		qps           int
 		burst         int
 		expectedQPS   float32
 		expectedBurst int
-		expectedLimit string
 	}{
-		{"unlimited", userAgentInformers, 0, 0, -1, 0, "unlimited"},
-		{"negative is unlimited", userAgentWrites, -1, -1, -1, 0, "unlimited"},
-		{"burst without qps is ignored", userAgentBootstrap, 0, 100, -1, 0, "unlimited"},
-		{"limited", userAgentEvents, 100, 200, 100, 200, "100 qps / 200 burst"},
-		{"burst defaults to qps", UserAgentAdmissionController, 100, 0, 100, 100, "100 qps / 100 burst"},
+		{"unset is no limiter", -1, -1, -1, 0},
+		{"zero leaves the client-go defaults", 0, 0, 0, 0},
+		{"burst defaults to qps", 100, 0, 100, 100},
+		{"negative burst defaults to qps", 100, -1, 100, 100},
+		{"qps and burst", 100, 50, 100, 50},
+		{"burst is kept without a qps", -1, 50, -1, 50},
+		{"burst is kept on the client-go defaults", 0, 50, 0, 50},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			qps, burst, rateLimit := rateLimitPolicy(tc.concern, tc.qps, tc.burst)
+			qps, burst := clientRateLimit(tc.qps, tc.burst)
 			assert.Equal(t, tc.expectedQPS, qps, "unexpected QPS")
 			assert.Equal(t, tc.expectedBurst, burst, "unexpected burst")
-			assert.Equal(t, tc.expectedLimit, rateLimit, "unexpected rate limit description")
 		})
 	}
 }
@@ -99,20 +79,21 @@ func TestNewRestConfig(t *testing.T) {
 		qps     int
 		burst   int
 	}{
-		{"unlimited", userAgentInformers, 0, 0},
+		{"unset", userAgentScheduler, -1, -1},
+		{"client-go defaults", userAgentBootstrap, 0, 0},
 		{"limited", userAgentEvents, 100, 200},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			expectedQPS, expectedBurst, _ := rateLimitPolicy(tc.concern, tc.qps, tc.burst)
+			expectedQPS, expectedBurst := clientRateLimit(tc.qps, tc.burst)
 			config := newRestConfig(kc, tc.qps, tc.burst, tc.concern)
-			assert.Equal(t, UserAgent(tc.concern), config.UserAgent, "user agent not set")
+			assert.Equal(t, tc.concern, config.UserAgent, "user agent not set to the concern")
 			// creating the limiter is always left to client-go: a negative QPS makes it
-			// create none, a QPS of 0 would silently fall back to the client-go defaults
+			// create none, a QPS of 0 falls back to the client-go defaults
 			assert.Assert(t, config.RateLimiter == nil, "rate limiter must be left to client-go")
-			assert.Equal(t, expectedQPS, config.QPS, "QPS not taken from the rate limit policy")
-			assert.Equal(t, expectedBurst, config.Burst, "burst not taken from the rate limit policy")
+			assert.Equal(t, expectedQPS, config.QPS, "QPS not normalised")
+			assert.Equal(t, expectedBurst, config.Burst, "burst not normalised")
 		})
 	}
 }
@@ -134,7 +115,7 @@ func TestNewClientSetAcceptsRestConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := kubernetes.NewForConfig(newRestConfig(kc, tc.qps, tc.burst, userAgentWrites))
+			_, err := kubernetes.NewForConfig(newRestConfig(kc, tc.qps, tc.burst, userAgentScheduler))
 			assert.NilError(t, err, "clientset creation failed")
 		})
 	}

--- a/pkg/cmd/admissioncontroller/main.go
+++ b/pkg/cmd/admissioncontroller/main.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	amConf := conf.NewAdmissionControllerConf(configMaps)
-	kubeClient := client.NewKubeClient(amConf.GetKubeConfig())
+	kubeClient := client.NewKubeClientWithUserAgent(amConf.GetKubeConfig(), client.UserAgentAdmissionController)
 
 	informers := admission.NewInformers(kubeClient, amConf.GetNamespace())
 

--- a/pkg/cmd/admissioncontroller/main.go
+++ b/pkg/cmd/admissioncontroller/main.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	amConf := conf.NewAdmissionControllerConf(configMaps)
-	kubeClient := client.NewKubeClientWithUserAgent(amConf.GetKubeConfig(), client.UserAgentAdmissionController)
+	kubeClient := client.NewAdmissionControllerKubeClient(amConf.GetKubeConfig())
 
 	informers := admission.NewInformers(kubeClient, amConf.GetNamespace())
 
@@ -80,10 +80,7 @@ func main() {
 	}
 	informers.Start()
 
-	wm, err := admission.NewWebhookManager(amConf)
-	if err != nil {
-		log.Log(log.Admission).Fatal("Failed to initialize webhook manager", zap.Error(err))
-	}
+	wm := admission.NewWebhookManager(amConf)
 
 	ac := admission.InitAdmissionController(amConf, pcCache, nsCache)
 

--- a/pkg/common/events/recorder.go
+++ b/pkg/common/events/recorder.go
@@ -57,13 +57,8 @@ func NewLevelFilteredRecorder(inner events.EventRecorder) events.EventRecorder {
 
 // Eventf reads the level on every call: the setting is hot-reloadable
 func (r *levelFilteredRecorder) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
-	switch conf.GetSchedulerConf().KubeEventLevel {
-	case conf.EventLevelNone:
+	if conf.GetSchedulerConf().KubeEventLevel == conf.EventLevelWarning && eventtype != v1.EventTypeWarning {
 		return
-	case conf.EventLevelWarning:
-		if eventtype != v1.EventTypeWarning {
-			return
-		}
 	}
 	r.inner.Eventf(regarding, related, eventtype, reason, action, note, args...)
 }

--- a/pkg/common/events/recorder.go
+++ b/pkg/common/events/recorder.go
@@ -21,7 +21,11 @@ package events
 import (
 	"sync/atomic"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
+
+	"github.com/apache/yunikorn-k8shim/pkg/conf"
 )
 
 var eventRecorder atomic.Pointer[events.EventRecorder]
@@ -37,4 +41,29 @@ func GetRecorder() events.EventRecorder {
 
 func SetRecorder(recorder events.EventRecorder) {
 	eventRecorder.Store(&recorder)
+}
+
+// levelFilteredRecorder drops the events below the configured event level
+type levelFilteredRecorder struct {
+	inner events.EventRecorder
+}
+
+// NewLevelFilteredRecorder wraps a recorder and drops the events below the configured
+// kubernetes.eventLevel before they reach the broadcaster: nothing is copied, cached or
+// written for a suppressed event.
+func NewLevelFilteredRecorder(inner events.EventRecorder) events.EventRecorder {
+	return &levelFilteredRecorder{inner: inner}
+}
+
+// Eventf reads the level on every call: the setting is hot-reloadable
+func (r *levelFilteredRecorder) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+	switch conf.GetSchedulerConf().KubeEventLevel {
+	case conf.EventLevelNone:
+		return
+	case conf.EventLevelWarning:
+		if eventtype != v1.EventTypeWarning {
+			return
+		}
+	}
+	r.inner.Eventf(regarding, related, eventtype, reason, action, note, args...)
 }

--- a/pkg/common/events/recorder_test.go
+++ b/pkg/common/events/recorder_test.go
@@ -23,10 +23,53 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/apache/yunikorn-k8shim/pkg/conf"
 )
 
 func TestInit(t *testing.T) {
 	// simply test the get won't fail
 	recorder := GetRecorder()
 	assert.Equal(t, reflect.TypeOf(recorder).String(), "*events.MockedRecorder")
+}
+
+// recordingRecorder collects the type of every event which reaches it
+type recordingRecorder struct {
+	recorded []string
+}
+
+func (r *recordingRecorder) Eventf(_ runtime.Object, _ runtime.Object, eventtype, _, _, _ string, _ ...interface{}) {
+	r.recorded = append(r.recorded, eventtype)
+}
+
+// the level filter drops the events below the configured level before they are recorded
+func TestLevelFilteredRecorder(t *testing.T) {
+	testCases := []struct {
+		level    string
+		expected []string
+	}{
+		{conf.EventLevelNormal, []string{v1.EventTypeNormal, v1.EventTypeWarning}},
+		{conf.EventLevelWarning, []string{v1.EventTypeWarning}},
+		{conf.EventLevelNone, nil},
+	}
+
+	original := conf.GetSchedulerConf()
+	defer conf.SetSchedulerConf(original)
+
+	for _, tc := range testCases {
+		t.Run(tc.level, func(t *testing.T) {
+			levelConf := conf.CreateDefaultConfig()
+			levelConf.KubeEventLevel = tc.level
+			conf.SetSchedulerConf(levelConf)
+
+			inner := &recordingRecorder{}
+			recorder := NewLevelFilteredRecorder(inner)
+			recorder.Eventf(nil, nil, v1.EventTypeNormal, "reason", "action", "note")
+			recorder.Eventf(nil, nil, v1.EventTypeWarning, "reason", "action", "note")
+
+			assert.DeepEqual(t, tc.expected, inner.recorded)
+		})
+	}
 }

--- a/pkg/common/events/recorder_test.go
+++ b/pkg/common/events/recorder_test.go
@@ -52,7 +52,6 @@ func TestLevelFilteredRecorder(t *testing.T) {
 	}{
 		{conf.EventLevelNormal, []string{v1.EventTypeNormal, v1.EventTypeWarning}},
 		{conf.EventLevelWarning, []string{v1.EventTypeWarning}},
-		{conf.EventLevelNone, nil},
 	}
 
 	original := conf.GetSchedulerConf()

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -73,8 +73,10 @@ const (
 	CMSvcNodeInstanceTypeNodeLabelKey = PrefixService + "nodeInstanceTypeNodeLabelKey"
 
 	// kubernetes
-	CMKubeQPS   = PrefixKubernetes + "qps"
-	CMKubeBurst = PrefixKubernetes + "burst"
+	CMKubeQPS        = PrefixKubernetes + "qps"
+	CMKubeBurst      = PrefixKubernetes + "burst"
+	CMKubeEventQPS   = PrefixKubernetes + "eventQPS"
+	CMKubeEventBurst = PrefixKubernetes + "eventBurst"
 
 	// admissioncontroller
 	PrefixAMFiltering               = PrefixAdmissionController + "filtering."
@@ -91,8 +93,10 @@ const (
 	DefaultOperatorPlugins                 = "general"
 	DefaultDisableGangScheduling           = false
 	DefaultEnableConfigHotRefresh          = true
-	DefaultKubeQPS                         = 1000
-	DefaultKubeBurst                       = 1000
+	DefaultKubeQPS                         = 0 // client side write limiting is opt-in: <= 0 means no limiter
+	DefaultKubeBurst                       = 0
+	DefaultKubeEventQPS                    = 200 // events are discardable and limited by default: <= 0 means no limiter
+	DefaultKubeEventBurst                  = 400
 	DefaultAMFilteringGenerateUniqueAppIds = false
 )
 
@@ -123,6 +127,8 @@ type SchedulerConf struct {
 	DispatchTimeout          time.Duration      `json:"dispatchTimeout"`
 	KubeQPS                  int                `json:"kubeQPS"`
 	KubeBurst                int                `json:"kubeBurst"`
+	KubeEventQPS             int                `json:"kubeEventQPS"`
+	KubeEventBurst           int                `json:"kubeEventBurst"`
 	EnableConfigHotRefresh   bool               `json:"enableConfigHotRefresh"`
 	DisableGangScheduling    bool               `json:"disableGangScheduling"`
 	PlaceHolderConfig        *PlaceHolderConfig `json:"placeHolderConfig"`
@@ -156,6 +162,8 @@ func (conf *SchedulerConf) Clone() *SchedulerConf {
 		DispatchTimeout:          conf.DispatchTimeout,
 		KubeQPS:                  conf.KubeQPS,
 		KubeBurst:                conf.KubeBurst,
+		KubeEventQPS:             conf.KubeEventQPS,
+		KubeEventBurst:           conf.KubeEventBurst,
 		EnableConfigHotRefresh:   conf.EnableConfigHotRefresh,
 		DisableGangScheduling:    conf.DisableGangScheduling,
 		PlaceHolderConfig:        conf.PlaceHolderConfig,
@@ -215,6 +223,8 @@ func handleNonReloadableConfig(old *SchedulerConf, new *SchedulerConf) {
 	checkNonReloadableDuration(CMSvcDispatchTimeout, &old.DispatchTimeout, &new.DispatchTimeout)
 	checkNonReloadableInt(CMKubeQPS, &old.KubeQPS, &new.KubeQPS)
 	checkNonReloadableInt(CMKubeBurst, &old.KubeBurst, &new.KubeBurst)
+	checkNonReloadableInt(CMKubeEventQPS, &old.KubeEventQPS, &new.KubeEventQPS)
+	checkNonReloadableInt(CMKubeEventBurst, &old.KubeEventBurst, &new.KubeEventBurst)
 	checkNonReloadableBool(CMSvcDisableGangScheduling, &old.DisableGangScheduling, &new.DisableGangScheduling)
 	checkNonReloadableString(CMSvcNodeInstanceTypeNodeLabelKey, &old.InstanceTypeNodeLabelKey, &new.InstanceTypeNodeLabelKey)
 	checkNonReloadableBool(AMFilteringGenerateUniqueAppIds, &old.GenerateUniqueAppIds, &new.GenerateUniqueAppIds)
@@ -328,6 +338,8 @@ func CreateDefaultConfig() *SchedulerConf {
 		DispatchTimeout:          DefaultDispatchTimeout,
 		KubeQPS:                  DefaultKubeQPS,
 		KubeBurst:                DefaultKubeBurst,
+		KubeEventQPS:             DefaultKubeEventQPS,
+		KubeEventBurst:           DefaultKubeEventBurst,
 		EnableConfigHotRefresh:   DefaultEnableConfigHotRefresh,
 		DisableGangScheduling:    DefaultDisableGangScheduling,
 		InstanceTypeNodeLabelKey: constants.DefaultNodeInstanceTypeNodeLabelKey,
@@ -367,6 +379,8 @@ func parseConfig(config map[string]string, prev *SchedulerConf) (*SchedulerConf,
 	// kubernetes
 	parser.intVar(&conf.KubeQPS, CMKubeQPS)
 	parser.intVar(&conf.KubeBurst, CMKubeBurst)
+	parser.intVar(&conf.KubeEventQPS, CMKubeEventQPS)
+	parser.intVar(&conf.KubeEventBurst, CMKubeEventBurst)
 
 	// admission controller
 	parser.boolVar(&conf.GenerateUniqueAppIds, AMFilteringGenerateUniqueAppIds)

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -93,8 +93,8 @@ const (
 	DefaultOperatorPlugins                 = "general"
 	DefaultDisableGangScheduling           = false
 	DefaultEnableConfigHotRefresh          = true
-	DefaultKubeQPS                         = 0 // client side write limiting is opt-in: <= 0 means no limiter
-	DefaultKubeBurst                       = 0
+	DefaultKubeQPS                         = -1 // client side write limiting is opt-in: <= 0 means no limiter
+	DefaultKubeBurst                       = -1
 	DefaultKubeEventQPS                    = 200 // events are discardable and limited by default: <= 0 means no limiter
 	DefaultKubeEventBurst                  = 400
 	DefaultAMFilteringGenerateUniqueAppIds = false

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -77,6 +77,7 @@ const (
 	CMKubeBurst      = PrefixKubernetes + "burst"
 	CMKubeEventQPS   = PrefixKubernetes + "eventQPS"
 	CMKubeEventBurst = PrefixKubernetes + "eventBurst"
+	CMKubeEventLevel = PrefixKubernetes + "eventLevel"
 
 	// admissioncontroller
 	PrefixAMFiltering               = PrefixAdmissionController + "filtering."
@@ -97,7 +98,14 @@ const (
 	DefaultKubeBurst                       = -1
 	DefaultKubeEventQPS                    = 200 // events are discardable and limited by default: <= 0 means no limiter
 	DefaultKubeEventBurst                  = 400
+	DefaultKubeEventLevel                  = EventLevelNormal
 	DefaultAMFilteringGenerateUniqueAppIds = false
+
+	// event levels, the value of CMKubeEventLevel: all events, the Warning events only, or
+	// no events at all
+	EventLevelNormal  = "normal"
+	EventLevelWarning = "warning"
+	EventLevelNone    = "none"
 )
 
 var (
@@ -129,6 +137,7 @@ type SchedulerConf struct {
 	KubeBurst                int                `json:"kubeBurst"`
 	KubeEventQPS             int                `json:"kubeEventQPS"`
 	KubeEventBurst           int                `json:"kubeEventBurst"`
+	KubeEventLevel           string             `json:"kubeEventLevel"`
 	EnableConfigHotRefresh   bool               `json:"enableConfigHotRefresh"`
 	DisableGangScheduling    bool               `json:"disableGangScheduling"`
 	PlaceHolderConfig        *PlaceHolderConfig `json:"placeHolderConfig"`
@@ -164,6 +173,7 @@ func (conf *SchedulerConf) Clone() *SchedulerConf {
 		KubeBurst:                conf.KubeBurst,
 		KubeEventQPS:             conf.KubeEventQPS,
 		KubeEventBurst:           conf.KubeEventBurst,
+		KubeEventLevel:           conf.KubeEventLevel,
 		EnableConfigHotRefresh:   conf.EnableConfigHotRefresh,
 		DisableGangScheduling:    conf.DisableGangScheduling,
 		PlaceHolderConfig:        conf.PlaceHolderConfig,
@@ -340,6 +350,7 @@ func CreateDefaultConfig() *SchedulerConf {
 		KubeBurst:                DefaultKubeBurst,
 		KubeEventQPS:             DefaultKubeEventQPS,
 		KubeEventBurst:           DefaultKubeEventBurst,
+		KubeEventLevel:           DefaultKubeEventLevel,
 		EnableConfigHotRefresh:   DefaultEnableConfigHotRefresh,
 		DisableGangScheduling:    DefaultDisableGangScheduling,
 		InstanceTypeNodeLabelKey: constants.DefaultNodeInstanceTypeNodeLabelKey,
@@ -381,9 +392,21 @@ func parseConfig(config map[string]string, prev *SchedulerConf) (*SchedulerConf,
 	parser.intVar(&conf.KubeBurst, CMKubeBurst)
 	parser.intVar(&conf.KubeEventQPS, CMKubeEventQPS)
 	parser.intVar(&conf.KubeEventBurst, CMKubeEventBurst)
+	parser.stringVar(&conf.KubeEventLevel, CMKubeEventLevel)
 
 	// admission controller
 	parser.boolVar(&conf.GenerateUniqueAppIds, AMFilteringGenerateUniqueAppIds)
+
+	// an unknown event level falls back to the default, it must not fail the configuration
+	switch conf.KubeEventLevel {
+	case EventLevelNormal, EventLevelWarning, EventLevelNone:
+	default:
+		log.Log(log.ShimConfig).Warn("unknown event level, using the default",
+			zap.String("key", CMKubeEventLevel),
+			zap.String("value", conf.KubeEventLevel),
+			zap.String("default", DefaultKubeEventLevel))
+		conf.KubeEventLevel = DefaultKubeEventLevel
+	}
 
 	if len(parser.errors) > 0 {
 		return nil, parser.errors

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -101,11 +101,10 @@ const (
 	DefaultKubeEventLevel                  = EventLevelNormal
 	DefaultAMFilteringGenerateUniqueAppIds = false
 
-	// event levels, the value of CMKubeEventLevel: all events, the Warning events only, or
-	// no events at all
+	// event levels, the value of CMKubeEventLevel: all events, or the Warning events only.
+	// They mirror the Kubernetes event types Normal and Warning.
 	EventLevelNormal  = "normal"
 	EventLevelWarning = "warning"
-	EventLevelNone    = "none"
 )
 
 var (
@@ -399,7 +398,7 @@ func parseConfig(config map[string]string, prev *SchedulerConf) (*SchedulerConf,
 
 	// an unknown event level falls back to the default, it must not fail the configuration
 	switch conf.KubeEventLevel {
-	case EventLevelNormal, EventLevelWarning, EventLevelNone:
+	case EventLevelNormal, EventLevelWarning:
 	default:
 		log.Log(log.ShimConfig).Warn("unknown event level, using the default",
 			zap.String("key", CMKubeEventLevel),

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -74,6 +74,16 @@ func assertDefaults(t *testing.T, conf *SchedulerConf) {
 	assert.Equal(t, conf.DispatchTimeout, DefaultDispatchTimeout)
 	assert.Equal(t, conf.KubeQPS, DefaultKubeQPS)
 	assert.Equal(t, conf.KubeBurst, DefaultKubeBurst)
+	assert.Equal(t, conf.KubeEventQPS, DefaultKubeEventQPS)
+	assert.Equal(t, conf.KubeEventBurst, DefaultKubeEventBurst)
+}
+
+// the write path is unlimited by default, events are limited: a value <= 0 means no limiter
+func TestKubeRateLimitDefaults(t *testing.T) {
+	assert.Equal(t, 0, DefaultKubeQPS)
+	assert.Equal(t, 0, DefaultKubeBurst)
+	assert.Equal(t, 200, DefaultKubeEventQPS)
+	assert.Equal(t, 400, DefaultKubeEventBurst)
 }
 
 func TestDecompress(t *testing.T) {
@@ -145,6 +155,8 @@ func TestParseConfigMap(t *testing.T) {
 		{CMSvcNodeInstanceTypeNodeLabelKey, "InstanceTypeNodeLabelKey", "node.kubernetes.io/instance-type"},
 		{CMKubeQPS, "KubeQPS", 2345},
 		{CMKubeBurst, "KubeBurst", 3456},
+		{CMKubeEventQPS, "KubeEventQPS", 4567},
+		{CMKubeEventBurst, "KubeEventBurst", 5678},
 	}
 
 	for _, tc := range testCases {
@@ -179,6 +191,8 @@ func TestUpdateConfigMapNonReloadable(t *testing.T) {
 		{CMSvcPlaceholderFSGroup, "PlaceHolderConfig.FSGroup", int64(1003), false},
 		{CMKubeQPS, "KubeQPS", 2345, false},
 		{CMKubeBurst, "KubeBurst", 3456, false},
+		{CMKubeEventQPS, "KubeEventQPS", 4567, false},
+		{CMKubeEventBurst, "KubeEventBurst", 5678, false},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -80,8 +80,8 @@ func assertDefaults(t *testing.T, conf *SchedulerConf) {
 
 // the write path is unlimited by default, events are limited: a value <= 0 means no limiter
 func TestKubeRateLimitDefaults(t *testing.T) {
-	assert.Equal(t, 0, DefaultKubeQPS)
-	assert.Equal(t, 0, DefaultKubeBurst)
+	assert.Equal(t, -1, DefaultKubeQPS)
+	assert.Equal(t, -1, DefaultKubeBurst)
 	assert.Equal(t, 200, DefaultKubeEventQPS)
 	assert.Equal(t, 400, DefaultKubeEventBurst)
 }

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -76,6 +76,7 @@ func assertDefaults(t *testing.T, conf *SchedulerConf) {
 	assert.Equal(t, conf.KubeBurst, DefaultKubeBurst)
 	assert.Equal(t, conf.KubeEventQPS, DefaultKubeEventQPS)
 	assert.Equal(t, conf.KubeEventBurst, DefaultKubeEventBurst)
+	assert.Equal(t, conf.KubeEventLevel, DefaultKubeEventLevel)
 }
 
 // the write path is unlimited by default, events are limited: a value <= 0 means no limiter
@@ -157,6 +158,7 @@ func TestParseConfigMap(t *testing.T) {
 		{CMKubeBurst, "KubeBurst", 3456},
 		{CMKubeEventQPS, "KubeEventQPS", 4567},
 		{CMKubeEventBurst, "KubeEventBurst", 5678},
+		{CMKubeEventLevel, "KubeEventLevel", EventLevelWarning},
 	}
 
 	for _, tc := range testCases {
@@ -193,6 +195,7 @@ func TestUpdateConfigMapNonReloadable(t *testing.T) {
 		{CMKubeBurst, "KubeBurst", 3456, false},
 		{CMKubeEventQPS, "KubeEventQPS", 4567, false},
 		{CMKubeEventBurst, "KubeEventBurst", 5678, false},
+		{CMKubeEventLevel, "KubeEventLevel", EventLevelWarning, true},
 	}
 
 	for _, tc := range testCases {
@@ -214,6 +217,30 @@ func TestUpdateConfigMapNonReloadable(t *testing.T) {
 			} else {
 				assert.Equal(t, getConfValue(t, oldConf, tc.field), getConfValue(t, newConf, tc.field), "non-reloadable field updated")
 			}
+		})
+	}
+}
+
+// an unknown event level must not fail the configuration, it falls back to the default
+func TestParseEventLevel(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"normal", EventLevelNormal, EventLevelNormal},
+		{"warning", EventLevelWarning, EventLevelWarning},
+		{"none", EventLevelNone, EventLevelNone},
+		{"unknown", "verbose", DefaultKubeEventLevel},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := CreateDefaultConfig()
+			conf, errs := parseConfig(map[string]string{CMKubeEventLevel: tc.value}, prev)
+			assert.Assert(t, conf != nil, "conf was nil")
+			assert.Assert(t, errs == nil, errs)
+			assert.Equal(t, tc.expected, conf.KubeEventLevel, "unexpected event level")
 		})
 	}
 }

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -230,7 +230,7 @@ func TestParseEventLevel(t *testing.T) {
 	}{
 		{"normal", EventLevelNormal, EventLevelNormal},
 		{"warning", EventLevelWarning, EventLevelWarning},
-		{"none", EventLevelNone, EventLevelNone},
+		{"none", "none", DefaultKubeEventLevel},
 		{"unknown", "verbose", DefaultKubeEventLevel},
 	}
 

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -64,12 +64,12 @@ var (
 )
 
 func NewShimScheduler(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, bootstrapConfigMaps []*v1.ConfigMap) *KubernetesShim {
-	kubeClient := client.NewKubeClient(configs.KubeConfig)
-
+	// all informers, cluster wide and namespaced, share one client
+	informerClientSet := client.NewInformerClientSet(configs.KubeConfig)
 	// we have disabled re-sync to keep ourselves up-to-date
-	informerFactory := informers.NewSharedInformerFactory(kubeClient.GetClientSet(), 0)
+	informerFactory := informers.NewSharedInformerFactory(informerClientSet, 0)
 
-	apiFactory, err := client.NewAPIFactory(scheduler, informerFactory, configs, false)
+	apiFactory, err := client.NewAPIFactory(scheduler, informerClientSet, informerFactory, configs, false)
 	if err != nil {
 		log.Log(log.Shim).Fatal("problem in creating the api factory")
 		return nil
@@ -81,8 +81,8 @@ func NewShimScheduler(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, b
 	}
 	rmCallback := cache.NewAsyncRMCallback(context)
 
-	eventBroadcaster := k8events.NewBroadcaster(&k8events.EventSinkImpl{
-		Interface: kubeClient.GetClientSet().EventsV1()})
+	// the sink sheds the events above the configured event rate
+	eventBroadcaster := k8events.NewBroadcaster(client.NewEventSink(configs.KubeConfig))
 	err = eventBroadcaster.StartRecordingToSinkWithContext(ctx.Background())
 	if err != nil {
 		log.Log(log.Shim).Error("Could not create event broadcaster",

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/scheme"
 	k8events "k8s.io/client-go/tools/events"
 
@@ -64,12 +63,7 @@ var (
 )
 
 func NewShimScheduler(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, bootstrapConfigMaps []*v1.ConfigMap) *KubernetesShim {
-	// all informers, cluster wide and namespaced, share one client
-	informerClientSet := client.NewInformerClientSet(configs.KubeConfig)
-	// we have disabled re-sync to keep ourselves up-to-date
-	informerFactory := informers.NewSharedInformerFactory(informerClientSet, 0)
-
-	apiFactory, err := client.NewAPIFactory(scheduler, informerClientSet, informerFactory, configs, false)
+	apiFactory, err := client.NewAPIFactory(scheduler, configs, false)
 	if err != nil {
 		log.Log(log.Shim).Fatal("problem in creating the api factory")
 		return nil

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -83,7 +83,7 @@ func NewShimScheduler(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, b
 			zap.Error(err))
 	} else {
 		eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, constants.SchedulerName)
-		events.SetRecorder(eventRecorder)
+		events.SetRecorder(events.NewLevelFilteredRecorder(eventRecorder))
 	}
 
 	return newShimSchedulerInternal(context, apiFactory, rmCallback)


### PR DESCRIPTION
### What is this PR for?

Implements [YUNIKORN-3356](https://issues.apache.org/jira/browse/YUNIKORN-3356): separates the shim's event traffic from its scheduling traffic, gives every client its own rate-limit policy and a distinct User-Agent, and bounds event traffic under a storm. Previously `kubernetes.qps` applied to each of two general-purpose clientsets independently (effective ceiling 2× the configured value), an event burst shared a token bucket with informer relists, events could not be limited without limiting binds, and no client was identifiable server-side.

This PR has a follow up that provides a suggested APF configuration for the YuniKorn helm chart.

| Client | User-Agent | Serves | Client-side limiter |
|---|---|---|---|
| scheduler | `yunikorn-scheduler` | Bind, Create/Delete, status updates, configmap loads, volume binder, predicate handle, and both informer factories | none by default; `kubernetes.qps`/`kubernetes.burst` as opt-in cap (`< 0` = no limiter, `0` = client-go's 5/10) |
| events | `yunikorn-scheduler/events` | events/v1 broadcaster sink | Normal events shed above `kubernetes.eventQPS`/`kubernetes.eventBurst` (new keys, default 200/400); Warning events always sent; server-informed mute on 429 for all events |
| bootstrap | `yunikorn-bootstrap` | two startup ConfigMap GETs (both binaries) | client-go defaults (5/10) |
| admission controller | `yunikorn-admission-controller` | AC informers, webhook and secret writes | client-go defaults (5/10) |

### Design rationale

Server-side API Priority & Fairness (APF) governs every request on every supported Kubernetes version (default-on since 1.20, GA 1.29) and, unlike a client rate limit/token bucket, is fair across tenants and work-aware. We take advantage of that by:

1. **Having server side APF arbitrate everything that is sent.** Client-side limiting is retained only where it does something APF cannot.
2. **Not throttling must-complete traffic (binds, status) on the client side by default.** We should not try and guess the state of the server — we take heed of the 429 metadata dynamically suggesting a slowdown period. Informers share the scheduler client: WATCH bypasses the client-go limiter anyway and relists are rare, so they do not need a client of their own.
3. **Using client-side limiting only to avoid sending discardable traffic.** Events are the sole discardable class, and within them only the Normal ones: three per successfully scheduled pod (`Scheduling`, `Scheduled`, `PodBindSuccessful`) plus the core's informational records, spiking exactly with throughput. Dropping those is the one action YuniKorn can take to lower API server load that does not compromise on core scheduling functionality.

### How events are shed

A standard token bucket "delay on limit" implementation for the events clientset is not the right fit here - the events/v1 broadcaster spawns a goroutine per event, so delaying traffic converts traffic backlogs into unbounded goroutine growth with nothing ever dropped. Instead we configure a qps/burst bucket to manage event traffic, but we drop events rather than delay them if the event client is over budget.

Shedding is type-aware. **Warning events — the ones that explain why a pod is not running (`FailedScheduling`, `PodUnschedulable`, `TaskRejected`, `NodeRejected`, `ApplicationFailed`, the gang scheduling failures) — are never shed by the bucket and consume no token.** `PodUnschedulable` is retyped from Normal to Warning to match (kube-scheduler's `FailedScheduling` is a Warning). Only Normal events are shed above `eventQPS`.

`kubernetes.eventLevel` (`normal` | `warning`, default `normal`) mirrors the two Kubernetes event types and is applied at the recorder, so a suppressed event is never copied, cached or written. It is hot-reloadable like the log level.

Once APF is configured separately for events, rather than relying on a statically configured rate limit, we can rely on the server itself to tell us to back off (by sending 429 status codes with a suggested slow down period). In this case we mute all events for the nominated cool down period rather than delay them: client-go drops a server-rejected event itself after its Retry-After retries (`recordEvent`: "Server rejected event (will not retry!)"), so the mute only saves the round trips and the parked goroutines.

The event dropping is implemented inside the event sink object. The 429 status detection and removal is done via an http round-tripper added to the events clientset. Only the event path gets this treatment. For must-complete traffic, client-go's Retry-After retransmission behaviour is left in place and remains untouched.

### Behaviour changes

- `kubernetes.qps`/`kubernetes.burst` now apply to the scheduler client (scheduling actions and informers) as a single bucket; defaults change **1000/1000 → no limiter (`-1`)**. Deployments relying on the implicit 1000 cap should set it explicitly.
- Upgrade corner cases — what happens to a config already deployed under the old semantics:

  | Existing config | Old behaviour | New behaviour |
  |---|---|---|
  | `burst` set, `qps` unset | qps silently defaulted to 1000, so the burst value applied | no limiter; burst ignored¹ — set `kubernetes.qps` to restore one (burst then defaults to the same value) |
  | `qps: "0"` explicitly | client-go's 5/10 defaults | unchanged: client-go's 5/10 defaults |
  | `qps` set, `burst` unset | effective qps/1000 | qps/qps — same sustained rate, less bursty |
  | `qps` set, `burst: 0` | crashed client construction (startup crash-loop) | burst defaults to qps |

  ¹ burst is a bucket *size*, qps its *refill rate* — without a positive refill rate there is no limiter for the burst value to shape.

  For the new event keys the same convention applies to the rate: `eventQPS <= 0` disables shedding, while an unset `eventBurst` falls back to its own default (400) rather than to `eventQPS`.
- **`PodUnschedulable` and `TaskFailed` events are now type Warning** (were Normal); every other event site was cross-checked against the Kubernetes Normal/Warning semantics.
- **New key `kubernetes.eventLevel`** (`normal` | `warning`), hot-reloadable.
- **Admission controller**: both of its clients run on client-go's defaults (5/10) with the `yunikorn-admission-controller` user agent. Previously its informer client ran on the scheduler configuration defaults (1000/1000, the scheduler ConfigMap keys never actually applied to it) and its webhook client on client-go's 5/10.
- **All clients send distinct User-Agents** (`yunikorn-scheduler`, `yunikorn-scheduler/events`, `yunikorn-bootstrap`, `yunikorn-admission-controller`) for apiserver-side attribution.

### Type of change

- Improvement

### Jira issue

Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3356

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### How was this patch tested?

- `make test` (18 packages) and `make lint` clean; both binaries build.
- Unit: qps/burst normalisation table; `newRestConfig` plumbing; sink shed/pass-through/mute paths with a fake clock, including Warning events bypassing the bucket and being muted; recorder level filter over both levels × both types; `PodUnschedulable` and `TaskFailed` asserted as Warning; `eventLevel` parsing with fallback; transport strip/record (httptest, asserting a single request in ~10ms vs 11 in 10s); integration-level crash-loop regression through `kubernetes.NewForConfig`.
- Live on kind (K8s v1.36.1) + KWOK (500 nodes), taken on the previous revision of this PR (four-client layout; the event path and the scheduler write path are unchanged in mechanism since):
  - defaults: 3,000-pod bind burst at ~1,900 binds/s;
  - `qps: 100` without burst: boots with a working 100/100 limiter (crash-looped before the fix); cap enforces ~134 binds/s;
  - event storm: 9,805 events shed with one throttled warning; steady-state delivery lossless;
  - APF squeeze (2,394 rejections served): server escalated Retry-After to 31–32s, mute engaged (`delaySource: transport`), 869 events shed in one window, no goroutine accumulation (vs ~360 parked pre-transport).

Generated by Author with assistance from Claude Code.

### Questions:

- [x] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [x] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

