### PR TITLE
[YUNIKORN-3357] Add goroutine leak detection to tests via goleak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/onsi/gomega v1.40.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/sasha-s/go-deadlock v0.3.9
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	go.yaml.in/yaml/v3 v3.0.5
 	gotest.tools/v3 v3.5.2

--- a/pkg/admission/conf/main_test.go
+++ b/pkg/admission/conf/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package conf
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/admission/main_test.go
+++ b/pkg/admission/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package admission
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/admission/metadata/main_test.go
+++ b/pkg/admission/metadata/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/admission/pki/main_test.go
+++ b/pkg/admission/pki/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pki
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -1886,6 +1886,7 @@ func TestGetExistingAllocation(t *testing.T) {
 func TestInitializeState(t *testing.T) {
 	context, apiProvider := initContextAndAPIProviderForTest()
 	apiProvider.RunEventHandler()
+	defer apiProvider.Stop()
 	pcLister, ok := apiProvider.GetAPIs().PriorityClassInformer.Lister().(*test.MockPriorityClassLister)
 	assert.Assert(t, ok, "unable to get mock priority class lister")
 	nodeLister, ok := apiProvider.GetAPIs().NodeInformer.Lister().(*test.NodeListerMock)
@@ -2012,6 +2013,7 @@ func TestInitializeState(t *testing.T) {
 func TestInitializeStateDoesNotEnableCordonedNodes(t *testing.T) {
 	context, apiProvider := initContextAndAPIProviderForTest()
 	apiProvider.RunEventHandler()
+	defer apiProvider.Stop()
 	nodeLister, ok := apiProvider.GetAPIs().NodeInformer.Lister().(*test.NodeListerMock)
 	assert.Assert(t, ok, "unable to get mock node lister")
 

--- a/pkg/cache/external/main_test.go
+++ b/pkg/cache/external/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package external
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/cache/main_test.go
+++ b/pkg/cache/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/client/main_test.go
+++ b/pkg/client/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/common/events/main_test.go
+++ b/pkg/common/events/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package events
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/common/leakcheck/leakcheck.go
+++ b/pkg/common/leakcheck/leakcheck.go
@@ -42,13 +42,12 @@
 // Three properties of goleak v1.3.0 are worth knowing before trusting a green
 // run:
 //
-//   - The leak check only runs when m.Run() returns 0. A package with a failing
-//     test is never checked for leaks, so a leak introduced together with a test
-//     failure only shows up on the CI round trip after the failure is fixed.
-//   - goleak polls for up to about 430ms (20 retries, backing off from 1µs to a
-//     100ms cap) waiting for goroutines to finish before it reports them. A
-//     teardown that is slower than that on a loaded CI machine is reported as a
-//     leak, which is the most likely source of a flake here.
+//   - The leak check only runs when m.Run() returns 0, so a leak introduced
+//     together with a test failure only shows up on the CI round trip after the
+//     failure is fixed.
+//   - goleak polls for up to about 430ms waiting for goroutines to finish before
+//     it reports them, so a teardown that is slower than that on a loaded CI
+//     machine is reported as a leak.
 //   - VerifyTestMain calls os.Exit itself. See the warning on VerifyTestMain
 //     before passing goleak.Cleanup as an extra option.
 package leakcheck
@@ -62,82 +61,53 @@ import (
 
 // options returns the goleak exemptions shared by every instrumented package.
 //
-// What this list does and does not buy us, precisely:
+// goleak already filters out the goroutines that the testing, runtime and
+// tracing packages run themselves, so every entry below is a goroutine that
+// really does outlive the test binary today. IgnoreTopFunction matches on the
+// top stack frame only, IgnoreAnyFunction on any frame below the creator.
+// Neither is bounded by count, so the list stops new KINDS of leak from being
+// added, it is not a proof that the exempted counts stay put.
 //
-//   - goleak already filters out the goroutines that the testing, runtime and
-//     tracing packages run themselves, so every entry below is a goroutine that
-//     really does outlive the test binary today.
-//   - IgnoreTopFunction matches on the top stack frame only, IgnoreAnyFunction on
-//     any frame below the creator. Neither is bounded by count, so the baseline
-//     stops new KINDS of leak from being added but does not stop new instances
-//     of the shapes already listed. It is a ratchet against regression, not a
-//     proof that the exempted counts stay put.
-//   - Matching also assumes the goroutine is parked in its select when goleak
-//     takes the stack snapshot, which holds for the default tick intervals used
-//     in tests. A test that shortens an interval enough to catch one of these
-//     mid-body would see a different top frame and a spurious failure.
+// Two matching caveats: the entries that key on compiler-assigned closure names
+// (".func1", ".func2") are positional, so inserting an earlier closure in the
+// same enclosing function silently breaks the match (goleak v1.3.0 cannot match
+// the creator frame); and a test that catches one of these goroutines mid-body,
+// rather than parked in its select, sees a different top frame and can fail
+// spuriously.
 //
-// Exemptions are split two ways. By lifetime: section A, ecosystemOptions, is for
-// Kubernetes goroutines that never stop by design and is permanent, while
-// section B is the baseline of YuniKorn-owned leaks that was present when
-// detection was switched on and is meant to be burned down, not extended. And by
-// blast radius: only shapes that more than one package leaks live in this shared
-// list, because an entry here switches the ratchet off everywhere. Everything
-// else belongs in a per-package group like ShimSchedulerOptions.
-//
-// Each section B entry names the goroutine, what starts it, and what has to
-// change before the entry can be deleted.
-//
-// Several entries key on compiler-assigned closure names (".func1", ".func2").
-// Those names are positional: adding another closure earlier in the same
-// enclosing function renumbers them and the exemption silently stops matching,
-// turning the affected package red. goleak v1.3.0 cannot match on the creator
-// frame, so there is no more robust spelling available. For the shim-owned
-// entries the durable fix is to hoist the goroutine bodies into named methods,
-// which is a production change and belongs in the follow-up that fixes the leaks
-// themselves. For the borrowed ones a yunikorn-core or Kubernetes bump can
-// renumber them at any time.
+// Exemptions are split two ways. By lifetime: ecosystemOptions is for Kubernetes
+// goroutines that never stop by design and is permanent, while the rest are the
+// baseline of YuniKorn-owned leaks that was present when detection was switched
+// on and is meant to be burned down, not extended. And by blast radius: only
+// shapes that more than one package leaks live in this shared list, because an
+// entry here switches the ratchet off everywhere. Everything else belongs in a
+// per-package group like ShimSchedulerOptions. Each burn-down entry names its
+// goroutine and the JIRA that tracks removing it.
 func options() []goleak.Option {
 	return slices.Concat(ecosystemOptions(), sharedOptions())
 }
 
-// ecosystemOptions returns section A: Kubernetes ecosystem goroutines that never
-// stop by design.
+// ecosystemOptions returns the permanent exemptions: Kubernetes ecosystem
+// goroutines that never stop by design.
 //
 // Empty, and that is a result rather than an oversight. The shim's unit tests
-// drive fake clientsets and never call SharedInformerFactory.Start, so no
-// reflector, workqueue or watch goroutine is ever created, and klog is reached
-// through klog.NewKlogr() without its flush daemon. Every leak the baseline run
-// found is YuniKorn-owned, so nothing is exempt permanently.
-//
-// Add an entry here only for a goroutine that a Kubernetes library starts and
-// offers no way to stop. Keep it as specific as the observed top frame allows,
-// and keep it out of section B, which is a burn-down list.
+// drive fake clientsets and never call SharedInformerFactory.Start, so every
+// leak the baseline run found is YuniKorn-owned. Add an entry here only for a
+// goroutine that a Kubernetes library starts and offers no way to stop, and keep
+// it as specific as the observed top frame allows.
 func ecosystemOptions() []goleak.Option {
 	return nil
 }
 
-// sharedOptions returns the section B entries that more than one package leaks.
+// sharedOptions returns the burn-down entries that more than one package leaks.
 func sharedOptions() []goleak.Option {
 	return []goleak.Option{
-		// DRA resource slice tracker sync monitor, started by
-		// tracker.StartTracker. Leaked by pkg/cache, pkg/plugin/predicates,
-		// pkg/plugin/support and pkg/shim, which all reach it through
-		// cache.NewContext or support.SharedDRAManager. Both call StartTracker
-		// with an uncancellable context, so the monitor's only two exits are
-		// unreachable: the context is never cancelled, and the informers it
-		// waits on are never started so they never sync. Tracker.Stop() would
-		// cancel it, but neither caller keeps a handle that a shutdown path can
-		// reach. Harmless in production, where a Context is built once and lives
-		// as long as the process, but a test that builds a Context leaks one of
-		// these per tracker for good. Delete this entry once the tracker is
-		// created with a cancellable context, or once Context grows a shutdown
-		// that calls Tracker.Stop().
+		// DRA resource-slice tracker sync monitor (tracker.StartTracker). See YUNIKORN-3371.
 		goleak.IgnoreTopFunction("k8s.io/dynamic-resource-allocation/resourceslice/tracker.(*Tracker).initInformers.func1"),
 	}
 }
 
-// ShimSchedulerOptions returns the section B entries that only pkg/shim leaks,
+// ShimSchedulerOptions returns the burn-down entries that only pkg/shim leaks,
 // because only it runs a whole mock cluster: a real KubernetesShim driving a
 // real yunikorn-core ServiceContext. Pass them from pkg/shim's TestMain rather
 // than adding them to the shared list, which would switch these shapes off for
@@ -149,135 +119,71 @@ func ShimSchedulerOptions() []goleak.Option {
 // shimOwnedOptions returns the pkg/shim entries whose cause is in shim code.
 func shimOwnedOptions() []goleak.Option {
 	return []goleak.Option{
-		// Placeholder manager cleanup loop and dispatcher event loop, started by
-		// KubernetesShim.Run through PlaceholderManager.Start and
-		// dispatcher.Start. Suspected production defect rather than a test
-		// problem: KubernetesShim.Stop() only stops them from inside the
-		// "case ss.stopChan <- struct{}{}" arm of a select that has a default
-		// branch. When Run() fails before doScheduling() nothing receives on
-		// stopChan yet, so Stop() takes the default branch, logs "scheduler is
-		// already stopped" and returns having stopped neither component. Run()
-		// calls Stop() itself when registration or state initialization fails,
-		// so the shim leaks both goroutines on every failed startup.
-		// TestSchedulerRegistrationFailed reproduces it; in a full package run
-		// the dispatcher goroutine is masked because it is a package singleton
-		// that a later test stops, but it leaks whenever that test runs alone.
-		// Delete both entries once Stop() releases what it owns regardless of
-		// how far Run() got.
+		// Placeholder-manager cleanup loop (leaked by Stop()-after-failed-Run). See YUNIKORN-3368.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-k8shim/pkg/cache.(*PlaceholderManager).Start.func1"),
+
+		// Dispatcher event loop (leaked by Stop()-after-failed-Run). See YUNIKORN-3368.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-k8shim/pkg/dispatcher.Start.func1"),
 
-		// A shim scheduling loop, started by KubernetesShim.doScheduling as one
-		// of two wait.Until goroutines that share ss.stopChan. Suspected
-		// production defect: stopChan is unbuffered and KubernetesShim.Stop()
-		// sends a single value to it instead of closing it, so exactly one of
-		// the two loops wakes up and returns. The other keeps running for the
-		// lifetime of the process, scheduling applications on a shim that has
-		// been told to stop. Which of schedule and checkOutstandingApps survives
-		// is a race, and both park in the same Kubernetes backoff frame, so the
-		// exemption cannot tell them apart.
-		//
-		// Two warnings for whoever triages this next. It is the broadest entry
-		// anywhere in this file: the top frame belongs to k8s.io/apimachinery,
-		// so within pkg/shim it exempts every wait.Until, wait.Forever and
-		// wait.JitterUntil loop, including ones nobody has written yet. And the
-		// frame name is an apimachinery implementation detail that has already
-		// moved once, from BackoffUntil to BackoffUntilWithContext when the
-		// context-aware variants were introduced; a dependency bump can rename
-		// it again, at which point this entry silently stops matching and
-		// pkg/shim turns red. Delete it once Stop() closes stopChan instead of
-		// sending to it, which stops both loops.
+		// A shim doScheduling loop (BackoffUntilWithContext). See YUNIKORN-3367.
+		// Broadest entry here: matches every wait.Until/Forever/JitterUntil in
+		// pkg/shim, and this apimachinery frame name has moved before
+		// (BackoffUntil -> BackoffUntilWithContext), so a dep bump can silently
+		// break the match.
 		goleak.IgnoreTopFunction("k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext"),
 
-		// The core RM proxy event loop, wedged inside the shim's own callback.
-		// AsyncRMCallback.UpdateAllocation retries AssumePod through
-		// retry.OnError with a 30 step backoff, and it runs on the
-		// RMProxy.handleRMEvents goroutine. Suspected production defect: the
-		// retry has no stop channel and no context, so a pod that cannot be
-		// assumed blocks all RM event handling for the length of the backoff and
-		// cannot be interrupted by shutdown, because nothing the shim or the
-		// core can stop reaches the loop. TestAssumePodError reproduces it.
-		// Keyed on the callback frame rather than the top frame, which is
-		// time.Sleep and far too broad to exempt. Delete this entry once the
-		// retry aborts on shutdown.
+		// AssumePod retry on the RM proxy loop. See YUNIKORN-3369. Keyed on the
+		// callback frame, not the top frame (time.Sleep), which is too broad.
 		goleak.IgnoreAnyFunction("github.com/apache/yunikorn-k8shim/pkg/cache.(*AsyncRMCallback).UpdateAllocation"),
 	}
 }
 
-// coreServiceOptions returns the pkg/shim entries that come from yunikorn-core.
-// Every one of them is a service that entrypoint.StartAllServices() starts,
-// leaked for a single reason: MockScheduler.stop() stops the shim and the mocked
-// API provider but never calls coreContext.StopAll(), so the core half of the
-// mock cluster keeps running after every test that builds one.
-// The obvious fix does not work yet, so do not re-apply it without
-// re-measuring. Adding StopAll() to MockScheduler.stop() does clear fifteen of
-// these seventeen entries, but it also makes TestAssumePodError fail
-// intermittently: 3 failures in 12 executions at -count=3 and 3 in 10 at
-// -count=5, against 0 in 35 without it, all on the same machine. It only shows
-// up when the package runs more than once per binary, which is why -count=1
-// looks clean. The cause is that core's services are not restartable in-process:
-// the event system singleton below is the clearest example, and StopAll() also
-// tears down process-wide config callbacks and the user/group cache singleton
-// that the next StartAllServices() then reuses. Delete this whole group once
-// core can be stopped and restarted in one process, at which point
-// MockScheduler.stop() can call StopAll().
-//
-// Two of these leak in yunikorn-core's own suite as well, for causes a StopAll()
-// here would not address: notifyRMNewAllocation parks on an unbuffered reply
-// channel when shutdown races the allocation path, and the user/group cache is a
-// singleton that outlives its ClusterContext.
+// coreServiceOptions returns the pkg/shim entries that come from yunikorn-core:
+// service goroutines the shim starts in-process and cannot stop in tests; they
+// burn down once the core is restartable and the shim calls StopAll
+// (YUNIKORN-3370). A few map to specific core defects, noted per entry.
 func coreServiceOptions() []goleak.Option {
 	return []goleak.Option{
-		// Scheduler event handlers, started by Scheduler.StartService.
+		// Scheduler event handlers (Scheduler.StartService). See YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).handleAllocEvent"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).handleNodeEvent"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).handleInfraEvent"),
 
-		// Scheduler background loops, started by Scheduler.StartService.
+		// Scheduler background loops (Scheduler.StartService). See YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).internalSchedule"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).internalInspectOutstandingRequests"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).internalQuotaPreemption"),
 
-		// The internalSchedule goroutine again, caught a few frames deeper while
-		// it waits for an RM proxy reply that shutdown never delivers.
+		// internalSchedule wedged on an RM reply shutdown never delivers. See YUNIKORN-3365.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*ClusterContext).notifyRMNewAllocation"),
 
-		// Node resource usage monitor and health checker, started by
-		// Scheduler.StartService alongside the loops above.
+		// Node usage monitor and health checker (Scheduler.StartService). See YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*nodesResourceUsageMonitor).start.func1"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*HealthChecker).startInternal.func2"),
 
-		// Partition cleaners, started by partitionManager.Run when the mock
-		// cluster's configuration adds a partition.
+		// Partition cleaners (partitionManager.Run). See YUNIKORN-3366.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*partitionManager).cleanRoot"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*partitionManager).cleanExpiredApps"),
 
-		// User/group cache cleaner, started once by security.GetUserGroupCache
-		// when a partition resolves users.
+		// User/group cache cleaner. See YUNIKORN-3366.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/common/security.(*UserGroupCache).run"),
 
-		// RM proxy event loop, started by RMProxy.StartService.
+		// RM proxy event loop (RMProxy.StartService). See YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/rmproxy.(*RMProxy).handleRMEvents"),
 
-		// Event system handler and publisher, started by
-		// EventSystemImpl.StartService. The handler is also the clearest
-		// evidence that core is not restartable in-process:
-		// StartServiceWithPublisher starts a handler goroutine unconditionally
-		// without clearing the stopped flag or recreating the channel that
-		// Stop() nils out, and Stop() returns early once that flag is set, so
-		// after one stop every later start leaks a handler that nothing can
-		// reach.
+		// Event system handler and publisher; the handler is the clearest
+		// evidence core is not restartable in-process. See YUNIKORN-3363 and
+		// YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/events.(*EventSystemImpl).StartServiceWithPublisher.func2"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/events.(*EventPublisher).StartService.func1"),
 
-		// Internal metrics collector, started by ServiceContext when the history
-		// size is non-zero.
+		// Internal metrics collector (ServiceContext). See YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/metrics.(*internalMetricsCollector).StartService.func1"),
 
-		// Web service accept loop, started by WebService.StartWebApp. Keyed on
-		// the yunikorn-core frame rather than the top frame, which is
-		// internal/poll.runtime_pollWait and would exempt every goroutine in the
-		// binary that is blocked on network I/O.
+		// Web service accept loop (WebService.StartWebApp). See YUNIKORN-3370.
+		// Keyed on the yunikorn-core frame, not the top frame
+		// (runtime_pollWait), which would exempt every network-blocked
+		// goroutine.
 		goleak.IgnoreAnyFunction("github.com/apache/yunikorn-core/pkg/webservice.(*WebService).StartWebApp.func1"),
 	}
 }

--- a/pkg/common/leakcheck/leakcheck.go
+++ b/pkg/common/leakcheck/leakcheck.go
@@ -1,0 +1,295 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package leakcheck wraps uber-go/goleak so that goroutine leak detection can be
+// switched on for a package by adding a main_test.go with:
+//
+//	func TestMain(m *testing.M) {
+//		leakcheck.VerifyTestMain(m)
+//	}
+//
+// A package that leaks something nobody else leaks passes its own exemptions as
+// extra options, so the shared list stays as small as the evidence allows:
+//
+//	func TestMain(m *testing.M) {
+//		leakcheck.VerifyTestMain(m, leakcheck.ShimSchedulerOptions()...)
+//	}
+//
+// Those per-package groups are defined here rather than inlined into the
+// main_test.go files, so that every exemption in the repository is documented in
+// this one file.
+//
+// Every test package under pkg is instrumented. The suites under test/e2e are
+// not: they are ginkgo suites that run against a live cluster rather than as
+// part of "make test", and they leave client-go informers running on purpose, so
+// a check there would need exemptions for goroutines that are meant to be alive.
+//
+// Three properties of goleak v1.3.0 are worth knowing before trusting a green
+// run:
+//
+//   - The leak check only runs when m.Run() returns 0. A package with a failing
+//     test is never checked for leaks, so a leak introduced together with a test
+//     failure only shows up on the CI round trip after the failure is fixed.
+//   - goleak polls for up to about 430ms (20 retries, backing off from 1µs to a
+//     100ms cap) waiting for goroutines to finish before it reports them. A
+//     teardown that is slower than that on a loaded CI machine is reported as a
+//     leak, which is the most likely source of a flake here.
+//   - VerifyTestMain calls os.Exit itself. See the warning on VerifyTestMain
+//     before passing goleak.Cleanup as an extra option.
+package leakcheck
+
+import (
+	"slices"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// options returns the goleak exemptions shared by every instrumented package.
+//
+// What this list does and does not buy us, precisely:
+//
+//   - goleak already filters out the goroutines that the testing, runtime and
+//     tracing packages run themselves, so every entry below is a goroutine that
+//     really does outlive the test binary today.
+//   - IgnoreTopFunction matches on the top stack frame only, IgnoreAnyFunction on
+//     any frame below the creator. Neither is bounded by count, so the baseline
+//     stops new KINDS of leak from being added but does not stop new instances
+//     of the shapes already listed. It is a ratchet against regression, not a
+//     proof that the exempted counts stay put.
+//   - Matching also assumes the goroutine is parked in its select when goleak
+//     takes the stack snapshot, which holds for the default tick intervals used
+//     in tests. A test that shortens an interval enough to catch one of these
+//     mid-body would see a different top frame and a spurious failure.
+//
+// Exemptions are split two ways. By lifetime: section A, ecosystemOptions, is for
+// Kubernetes goroutines that never stop by design and is permanent, while
+// section B is the baseline of YuniKorn-owned leaks that was present when
+// detection was switched on and is meant to be burned down, not extended. And by
+// blast radius: only shapes that more than one package leaks live in this shared
+// list, because an entry here switches the ratchet off everywhere. Everything
+// else belongs in a per-package group like ShimSchedulerOptions.
+//
+// Each section B entry names the goroutine, what starts it, and what has to
+// change before the entry can be deleted.
+//
+// Several entries key on compiler-assigned closure names (".func1", ".func2").
+// Those names are positional: adding another closure earlier in the same
+// enclosing function renumbers them and the exemption silently stops matching,
+// turning the affected package red. goleak v1.3.0 cannot match on the creator
+// frame, so there is no more robust spelling available. For the shim-owned
+// entries the durable fix is to hoist the goroutine bodies into named methods,
+// which is a production change and belongs in the follow-up that fixes the leaks
+// themselves. For the borrowed ones a yunikorn-core or Kubernetes bump can
+// renumber them at any time.
+func options() []goleak.Option {
+	return slices.Concat(ecosystemOptions(), sharedOptions())
+}
+
+// ecosystemOptions returns section A: Kubernetes ecosystem goroutines that never
+// stop by design.
+//
+// Empty, and that is a result rather than an oversight. The shim's unit tests
+// drive fake clientsets and never call SharedInformerFactory.Start, so no
+// reflector, workqueue or watch goroutine is ever created, and klog is reached
+// through klog.NewKlogr() without its flush daemon. Every leak the baseline run
+// found is YuniKorn-owned, so nothing is exempt permanently.
+//
+// Add an entry here only for a goroutine that a Kubernetes library starts and
+// offers no way to stop. Keep it as specific as the observed top frame allows,
+// and keep it out of section B, which is a burn-down list.
+func ecosystemOptions() []goleak.Option {
+	return nil
+}
+
+// sharedOptions returns the section B entries that more than one package leaks.
+func sharedOptions() []goleak.Option {
+	return []goleak.Option{
+		// DRA resource slice tracker sync monitor, started by
+		// tracker.StartTracker. Leaked by pkg/cache, pkg/plugin/predicates,
+		// pkg/plugin/support and pkg/shim, which all reach it through
+		// cache.NewContext or support.SharedDRAManager. Both call StartTracker
+		// with an uncancellable context, so the monitor's only two exits are
+		// unreachable: the context is never cancelled, and the informers it
+		// waits on are never started so they never sync. Tracker.Stop() would
+		// cancel it, but neither caller keeps a handle that a shutdown path can
+		// reach. Harmless in production, where a Context is built once and lives
+		// as long as the process, but a test that builds a Context leaks one of
+		// these per tracker for good. Delete this entry once the tracker is
+		// created with a cancellable context, or once Context grows a shutdown
+		// that calls Tracker.Stop().
+		goleak.IgnoreTopFunction("k8s.io/dynamic-resource-allocation/resourceslice/tracker.(*Tracker).initInformers.func1"),
+	}
+}
+
+// ShimSchedulerOptions returns the section B entries that only pkg/shim leaks,
+// because only it runs a whole mock cluster: a real KubernetesShim driving a
+// real yunikorn-core ServiceContext. Pass them from pkg/shim's TestMain rather
+// than adding them to the shared list, which would switch these shapes off for
+// the other seventeen packages as well.
+func ShimSchedulerOptions() []goleak.Option {
+	return slices.Concat(shimOwnedOptions(), coreServiceOptions())
+}
+
+// shimOwnedOptions returns the pkg/shim entries whose cause is in shim code.
+func shimOwnedOptions() []goleak.Option {
+	return []goleak.Option{
+		// Placeholder manager cleanup loop and dispatcher event loop, started by
+		// KubernetesShim.Run through PlaceholderManager.Start and
+		// dispatcher.Start. Suspected production defect rather than a test
+		// problem: KubernetesShim.Stop() only stops them from inside the
+		// "case ss.stopChan <- struct{}{}" arm of a select that has a default
+		// branch. When Run() fails before doScheduling() nothing receives on
+		// stopChan yet, so Stop() takes the default branch, logs "scheduler is
+		// already stopped" and returns having stopped neither component. Run()
+		// calls Stop() itself when registration or state initialization fails,
+		// so the shim leaks both goroutines on every failed startup.
+		// TestSchedulerRegistrationFailed reproduces it; in a full package run
+		// the dispatcher goroutine is masked because it is a package singleton
+		// that a later test stops, but it leaks whenever that test runs alone.
+		// Delete both entries once Stop() releases what it owns regardless of
+		// how far Run() got.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-k8shim/pkg/cache.(*PlaceholderManager).Start.func1"),
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-k8shim/pkg/dispatcher.Start.func1"),
+
+		// A shim scheduling loop, started by KubernetesShim.doScheduling as one
+		// of two wait.Until goroutines that share ss.stopChan. Suspected
+		// production defect: stopChan is unbuffered and KubernetesShim.Stop()
+		// sends a single value to it instead of closing it, so exactly one of
+		// the two loops wakes up and returns. The other keeps running for the
+		// lifetime of the process, scheduling applications on a shim that has
+		// been told to stop. Which of schedule and checkOutstandingApps survives
+		// is a race, and both park in the same Kubernetes backoff frame, so the
+		// exemption cannot tell them apart.
+		//
+		// Two warnings for whoever triages this next. It is the broadest entry
+		// anywhere in this file: the top frame belongs to k8s.io/apimachinery,
+		// so within pkg/shim it exempts every wait.Until, wait.Forever and
+		// wait.JitterUntil loop, including ones nobody has written yet. And the
+		// frame name is an apimachinery implementation detail that has already
+		// moved once, from BackoffUntil to BackoffUntilWithContext when the
+		// context-aware variants were introduced; a dependency bump can rename
+		// it again, at which point this entry silently stops matching and
+		// pkg/shim turns red. Delete it once Stop() closes stopChan instead of
+		// sending to it, which stops both loops.
+		goleak.IgnoreTopFunction("k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext"),
+
+		// The core RM proxy event loop, wedged inside the shim's own callback.
+		// AsyncRMCallback.UpdateAllocation retries AssumePod through
+		// retry.OnError with a 30 step backoff, and it runs on the
+		// RMProxy.handleRMEvents goroutine. Suspected production defect: the
+		// retry has no stop channel and no context, so a pod that cannot be
+		// assumed blocks all RM event handling for the length of the backoff and
+		// cannot be interrupted by shutdown, because nothing the shim or the
+		// core can stop reaches the loop. TestAssumePodError reproduces it.
+		// Keyed on the callback frame rather than the top frame, which is
+		// time.Sleep and far too broad to exempt. Delete this entry once the
+		// retry aborts on shutdown.
+		goleak.IgnoreAnyFunction("github.com/apache/yunikorn-k8shim/pkg/cache.(*AsyncRMCallback).UpdateAllocation"),
+	}
+}
+
+// coreServiceOptions returns the pkg/shim entries that come from yunikorn-core.
+// Every one of them is a service that entrypoint.StartAllServices() starts,
+// leaked for a single reason: MockScheduler.stop() stops the shim and the mocked
+// API provider but never calls coreContext.StopAll(), so the core half of the
+// mock cluster keeps running after every test that builds one.
+// The obvious fix does not work yet, so do not re-apply it without
+// re-measuring. Adding StopAll() to MockScheduler.stop() does clear fifteen of
+// these seventeen entries, but it also makes TestAssumePodError fail
+// intermittently: 3 failures in 12 executions at -count=3 and 3 in 10 at
+// -count=5, against 0 in 35 without it, all on the same machine. It only shows
+// up when the package runs more than once per binary, which is why -count=1
+// looks clean. The cause is that core's services are not restartable in-process:
+// the event system singleton below is the clearest example, and StopAll() also
+// tears down process-wide config callbacks and the user/group cache singleton
+// that the next StartAllServices() then reuses. Delete this whole group once
+// core can be stopped and restarted in one process, at which point
+// MockScheduler.stop() can call StopAll().
+//
+// Two of these leak in yunikorn-core's own suite as well, for causes a StopAll()
+// here would not address: notifyRMNewAllocation parks on an unbuffered reply
+// channel when shutdown races the allocation path, and the user/group cache is a
+// singleton that outlives its ClusterContext.
+func coreServiceOptions() []goleak.Option {
+	return []goleak.Option{
+		// Scheduler event handlers, started by Scheduler.StartService.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).handleAllocEvent"),
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).handleNodeEvent"),
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).handleInfraEvent"),
+
+		// Scheduler background loops, started by Scheduler.StartService.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).internalSchedule"),
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).internalInspectOutstandingRequests"),
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).internalQuotaPreemption"),
+
+		// The internalSchedule goroutine again, caught a few frames deeper while
+		// it waits for an RM proxy reply that shutdown never delivers.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*ClusterContext).notifyRMNewAllocation"),
+
+		// Node resource usage monitor and health checker, started by
+		// Scheduler.StartService alongside the loops above.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*nodesResourceUsageMonitor).start.func1"),
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*HealthChecker).startInternal.func2"),
+
+		// Partition cleaners, started by partitionManager.Run when the mock
+		// cluster's configuration adds a partition.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*partitionManager).cleanRoot"),
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*partitionManager).cleanExpiredApps"),
+
+		// User/group cache cleaner, started once by security.GetUserGroupCache
+		// when a partition resolves users.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/common/security.(*UserGroupCache).run"),
+
+		// RM proxy event loop, started by RMProxy.StartService.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/rmproxy.(*RMProxy).handleRMEvents"),
+
+		// Event system handler and publisher, started by
+		// EventSystemImpl.StartService. The handler is also the clearest
+		// evidence that core is not restartable in-process:
+		// StartServiceWithPublisher starts a handler goroutine unconditionally
+		// without clearing the stopped flag or recreating the channel that
+		// Stop() nils out, and Stop() returns early once that flag is set, so
+		// after one stop every later start leaks a handler that nothing can
+		// reach.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/events.(*EventSystemImpl).StartServiceWithPublisher.func2"),
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/events.(*EventPublisher).StartService.func1"),
+
+		// Internal metrics collector, started by ServiceContext when the history
+		// size is non-zero.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/metrics.(*internalMetricsCollector).StartService.func1"),
+
+		// Web service accept loop, started by WebService.StartWebApp. Keyed on
+		// the yunikorn-core frame rather than the top frame, which is
+		// internal/poll.runtime_pollWait and would exempt every goroutine in the
+		// binary that is blocked on network I/O.
+		goleak.IgnoreAnyFunction("github.com/apache/yunikorn-core/pkg/webservice.(*WebService).StartWebApp.func1"),
+	}
+}
+
+// VerifyTestMain runs m and fails the test binary if goroutines leaked. Any
+// extra options are applied on top of the shared exemptions, so a package can
+// carry an exemption of its own without widening the list for everyone.
+//
+// It calls os.Exit, so it must be the last statement of TestMain. Do not pass
+// goleak.Cleanup as an extra option: goleak calls it instead of os.Exit, so a
+// cleanup function that does not exit itself turns a leak failure into a silent
+// pass.
+func VerifyTestMain(m *testing.M, extra ...goleak.Option) {
+	goleak.VerifyTestMain(m, slices.Concat(options(), extra)...)
+}

--- a/pkg/common/leakcheck/leakcheck.go
+++ b/pkg/common/leakcheck/leakcheck.go
@@ -120,14 +120,15 @@ func ShimSchedulerOptions() []goleak.Option {
 }
 
 // shimOwnedOptions returns the pkg/shim entries whose cause is in shim code.
-// One is left: YUNIKORN-3367 fixed the shim shutdown path that leaked the
-// other three.
+//
+// Empty: the burn-down is done. This group started at four entries and both
+// causes have since been fixed on master. YUNIKORN-3367 closed the shim stop
+// channel and always releases the dispatcher and placeholder manager, which
+// removed three; YUNIKORN-3369 aborted the AssumePod retry loop on shutdown,
+// which removed the last one. Nothing the shim leaks is exempt any more, so a
+// new shim-owned leak fails the build rather than being carved out.
 func shimOwnedOptions() []goleak.Option {
-	return []goleak.Option{
-		// AssumePod retry on the RM proxy loop. See YUNIKORN-3369. Keyed on the
-		// callback frame, not the top frame (time.Sleep), which is too broad.
-		goleak.IgnoreAnyFunction("github.com/apache/yunikorn-k8shim/pkg/cache.(*AsyncRMCallback).UpdateAllocation"),
-	}
+	return nil
 }
 
 // coreServiceOptions returns the pkg/shim entries that come from yunikorn-core:
@@ -146,7 +147,11 @@ func coreServiceOptions() []goleak.Option {
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).internalInspectOutstandingRequests"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*Scheduler).internalQuotaPreemption"),
 
-		// internalSchedule wedged on an RM reply shutdown never delivers. See YUNIKORN-3365.
+		// internalSchedule wedged on an RM reply shutdown never delivers. See
+		// YUNIKORN-3365. The only intermittent entry: the wedge is a shutdown
+		// race, and it did not reproduce in five consecutive runs against core
+		// 2577453c1aed. Kept because 3365 is still open and a leak that shows up
+		// once in CI is worse than an entry that costs nothing.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*ClusterContext).notifyRMNewAllocation"),
 
 		// Node usage monitor and health checker (Scheduler.StartService). See YUNIKORN-3370.

--- a/pkg/common/leakcheck/leakcheck.go
+++ b/pkg/common/leakcheck/leakcheck.go
@@ -68,12 +68,15 @@ import (
 // Neither is bounded by count, so the list stops new KINDS of leak from being
 // added, it is not a proof that the exempted counts stay put.
 //
-// Two matching caveats: the entries that key on compiler-assigned closure names
-// (".func1", ".func2") are positional, so inserting an earlier closure in the
-// same enclosing function silently breaks the match (goleak v1.3.0 cannot match
-// the creator frame); and a test that catches one of these goroutines mid-body,
-// rather than parked in its select, sees a different top frame and can fail
-// spuriously.
+// Three matching caveats. The entries that key on compiler-assigned closure
+// names (".func1", ".func2") are positional, so inserting an earlier closure in
+// the same enclosing function silently breaks the match (goleak v1.3.0 cannot
+// match the creator frame). A test that catches one of these goroutines
+// mid-body, rather than parked in its select, sees a different top frame and can
+// fail spuriously. And a frame name is a dependency's private detail: bumping
+// yunikorn-core or apimachinery can rename or unexport one, which turns the
+// exemption into a no-op and the next run red. That is not hypothetical; both
+// events entries below had to be realigned after a core bump.
 //
 // Exemptions are split two ways. By lifetime: ecosystemOptions is for Kubernetes
 // goroutines that never stop by design and is permanent, while the rest are the
@@ -117,21 +120,10 @@ func ShimSchedulerOptions() []goleak.Option {
 }
 
 // shimOwnedOptions returns the pkg/shim entries whose cause is in shim code.
+// One is left: YUNIKORN-3367 fixed the shim shutdown path that leaked the
+// other three.
 func shimOwnedOptions() []goleak.Option {
 	return []goleak.Option{
-		// Placeholder-manager cleanup loop (leaked by Stop()-after-failed-Run). See YUNIKORN-3368.
-		goleak.IgnoreTopFunction("github.com/apache/yunikorn-k8shim/pkg/cache.(*PlaceholderManager).Start.func1"),
-
-		// Dispatcher event loop (leaked by Stop()-after-failed-Run). See YUNIKORN-3368.
-		goleak.IgnoreTopFunction("github.com/apache/yunikorn-k8shim/pkg/dispatcher.Start.func1"),
-
-		// A shim doScheduling loop (BackoffUntilWithContext). See YUNIKORN-3367.
-		// Broadest entry here: matches every wait.Until/Forever/JitterUntil in
-		// pkg/shim, and this apimachinery frame name has moved before
-		// (BackoffUntil -> BackoffUntilWithContext), so a dep bump can silently
-		// break the match.
-		goleak.IgnoreTopFunction("k8s.io/apimachinery/pkg/util/wait.BackoffUntilWithContext"),
-
 		// AssumePod retry on the RM proxy loop. See YUNIKORN-3369. Keyed on the
 		// callback frame, not the top frame (time.Sleep), which is too broad.
 		goleak.IgnoreAnyFunction("github.com/apache/yunikorn-k8shim/pkg/cache.(*AsyncRMCallback).UpdateAllocation"),
@@ -141,7 +133,7 @@ func shimOwnedOptions() []goleak.Option {
 // coreServiceOptions returns the pkg/shim entries that come from yunikorn-core:
 // service goroutines the shim starts in-process and cannot stop in tests; they
 // burn down once the core is restartable and the shim calls StopAll
-// (YUNIKORN-3370). A few map to specific core defects, noted per entry.
+// (YUNIKORN-3370). One maps to a specific core defect, noted at that entry.
 func coreServiceOptions() []goleak.Option {
 	return []goleak.Option{
 		// Scheduler event handlers (Scheduler.StartService). See YUNIKORN-3370.
@@ -161,21 +153,20 @@ func coreServiceOptions() []goleak.Option {
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*nodesResourceUsageMonitor).start.func1"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*HealthChecker).startInternal.func2"),
 
-		// Partition cleaners (partitionManager.Run). See YUNIKORN-3366.
+		// Partition cleaners (partitionManager.Run). See YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*partitionManager).cleanRoot"),
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/scheduler.(*partitionManager).cleanExpiredApps"),
 
-		// User/group cache cleaner. See YUNIKORN-3366.
+		// User/group cache cleaner. See YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/common/security.(*UserGroupCache).run"),
 
 		// RM proxy event loop (RMProxy.StartService). See YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/rmproxy.(*RMProxy).handleRMEvents"),
 
 		// Event system handler and publisher; the handler is the clearest
-		// evidence core is not restartable in-process. See YUNIKORN-3363 and
-		// YUNIKORN-3370.
-		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/events.(*EventSystemImpl).StartServiceWithPublisher.func2"),
-		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/events.(*EventPublisher).StartService.func1"),
+		// evidence core is not restartable in-process. See YUNIKORN-3370.
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/events.(*EventSystemImpl).StartServiceWithPublisher.func1"),
+		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/events.(*eventPublisher).start.func1"),
 
 		// Internal metrics collector (ServiceContext). See YUNIKORN-3370.
 		goleak.IgnoreTopFunction("github.com/apache/yunikorn-core/pkg/metrics.(*internalMetricsCollector).StartService.func1"),

--- a/pkg/common/main_test.go
+++ b/pkg/common/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/common/utils/main_test.go
+++ b/pkg/common/utils/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/conf/main_test.go
+++ b/pkg/conf/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package conf
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/dispatcher/main_test.go
+++ b/pkg/dispatcher/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package dispatcher
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/locking/main_test.go
+++ b/pkg/locking/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package locking
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/log/main_test.go
+++ b/pkg/log/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package log
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/plugin/predicates/main_test.go
+++ b/pkg/plugin/predicates/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/plugin/support/main_test.go
+++ b/pkg/plugin/support/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package support
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}

--- a/pkg/shim/main_test.go
+++ b/pkg/shim/main_test.go
@@ -1,0 +1,31 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package shim
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine. The extra exemptions
+// cover the mock cluster this package runs; they are documented in leakcheck.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m, leakcheck.ShimSchedulerOptions()...)
+}

--- a/pkg/webtest/main_test.go
+++ b/pkg/webtest/main_test.go
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package webtest
+
+import (
+	"testing"
+
+	"github.com/apache/yunikorn-k8shim/pkg/common/leakcheck"
+)
+
+// TestMain fails the package if a test leaks a goroutine.
+func TestMain(m *testing.M) {
+	leakcheck.VerifyTestMain(m)
+}


### PR DESCRIPTION
### What is this PR for?

Shim half of YUNIKORN-3357 (core PR: apache/yunikorn-core#1124). Adds goroutine leak detection via [uber-go/goleak](https://github.com/uber-go/goleak) to all 18 test packages under `pkg/`, through a shared `pkg/common/leakcheck` helper mirroring the core design.

- **Scoped exemptions**: only the genuinely multi-package entry (DRA resource-slice tracker) is shared; the 17 `pkg/shim`-specific entries are passed only from that package's `TestMain` via `leakcheck.ShimSchedulerOptions()`, so the other 17 packages run with a 1-entry list and the check binds tightly there
- **No shim-owned exemptions remain.** All 17 `pkg/shim` entries are inherited from yunikorn-core; nothing this repo leaks is carved out
- **Two-line test fix included**: `defer apiProvider.Stop()` at two `pkg/cache` call sites, which deletes the exemption those tests caused
- `test/e2e` ginkgo suites deliberately not instrumented (live-cluster suites that leave informers running by design; documented in the package doc)
- No production code modified; goleak was already a transitive dependency (`go.sum` unchanged) and becomes a direct test-only one

### Findings surfaced (separate JIRAs)

Suspected production defects, all reproduced and documented in the exemption comments. **The burn-down is complete on the shim side**: all four shim-owned exemptions this PR opened with are now gone, because the defects they documented were fixed.

1. ~~`KubernetesShim.Stop()` stops only one of the two `doScheduling` loops~~ — **fixed on master** by YUNIKORN-3367 (#1074); exemption removed
2. ~~`Stop()` after a failed `Run()` is a no-op~~ — **fixed on master** by the same change (YUNIKORN-3368, duplicate of 3367); exemption removed
3. ~~`AsyncRMCallback.UpdateAllocation`'s AssumePod retry (30-step backoff) runs on the RM proxy event loop with no context/stop channel~~ — **fixed on master** by YUNIKORN-3369 (#1078); exemption removed in this PR
4. yunikorn-core services are not restartable in-process (`EventSystemImpl.Stop()` is one-way), so `MockScheduler.stop()` cannot call `coreContext.StopAll()` without introducing an intermittent failure at `-count>1`. The 17 inherited core-service exemptions burn down after a core-side fix (YUNIKORN-3370)

One of those 17, the YUNIKORN-3365 shutdown wedge, is the only intermittent entry: it did not reproduce in five consecutive runs against the current core pin. It is kept, and now says so in the comment, because 3365 is open and a leak that surfaces once in CI costs more than an entry that costs nothing.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-3357

### How should this be tested?

Rebased onto master (`fa7b6add`) and re-verified.

**CI on this PR is red for a reason that is not this PR: master itself does not compile.** The YUNIKORN-3435 SI bump (`a2222d65`) added `PreFilterPredicates` to `api.ResourceManagerCallback` before #1043 implements it in the shim, so `pkg/cache` fails to build on master too — see master's own run [33974617433](https://github.com/apache/yunikorn-k8shim/actions/runs/33974617433). The results below were produced with a local throwaway stub of that one method (not committed, and not part of the diff), mirroring core's own mock callback:

- `go test ./pkg/... -race -tags deadlock -count=1`: all 18 instrumented packages ok, no data races
- `go test ./pkg/shim/ -tags deadlock -count=3`: ok (the racy package)
- `golangci-lint run`, `make license-check`, `go vet`, `gofmt`, `go mod tidy`: clean
- Every exemption re-probed against the current core pin by deleting it and confirming the result: the YUNIKORN-3369 entry now passes without it (hence its removal), and every remaining entry still fires except the intermittent 3365 one noted above
- Ground truth cross-checked by stripping the whole list and reading goleak's report: no core frame was renamed by the dependency bump this time

Generated by the Author with assistance from Claude Code
