### PR TITLE
[YUNIKORN-3347] Map new checksum, checksumMatch in admission controller config validation

### DIFF
--- a/pkg/admission/admission_controller.go
+++ b/pkg/admission/admission_controller.go
@@ -71,8 +71,10 @@ type AdmissionController struct {
 }
 
 type ValidateConfResponse struct {
-	Allowed bool   `json:"allowed"`
-	Reason  string `json:"reason"`
+	Allowed       bool   `json:"allowed"`
+	Reason        string `json:"reason"`
+	Checksum      string `json:"checksum"`
+	ChecksumMatch bool   `json:"checksumMatch"`
 }
 
 func InitAdmissionController(conf *conf.AdmissionControllerConf, pcCache *PriorityClassCache, nsCache *NamespaceCache) *AdmissionController {
@@ -594,7 +596,8 @@ func (c *AdmissionController) validateConfigMap(namespace string, cm *v1.ConfigM
 		return err
 	}
 
-	log.Log(log.Admission).Info("Successfully validated YuniKorn configuration")
+	log.Log(log.Admission).Info("Successfully validated YuniKorn configuration",
+		zap.String("checksum", responseData.Checksum), zap.Bool("checksumMatch", responseData.ChecksumMatch))
 	return nil
 }
 

--- a/pkg/admission/admission_controller_test.go
+++ b/pkg/admission/admission_controller_test.go
@@ -335,6 +335,46 @@ func TestValidateConfigMapServerError(t *testing.T) {
 	assert.NilError(t, err, "No error expected")
 }
 
+// Test for the case to check if validateConfigMap accepts a valid config response with checksum
+func TestValidateConfigMapValidConfigWithChecksum(t *testing.T) {
+	configmap := prepareConfigMap(ConfigData)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		resp := `{"allowed": true, "reason": "", "checksum": "ABC123", "checksumMatch": false}`
+		w.Write([]byte(resp)) //nolint:errcheck
+	}))
+	defer srv.Close()
+	// both server and url pattern contains http://, so we need to delete one
+	controller := prepareController(t, strings.Replace(srv.URL, "http://", "", 1), "", "", "", "", false, true)
+	err := controller.validateConfigMap("yunikorn", configmap)
+	assert.NilError(t, err, "No error expected with checksum fields in response")
+}
+
+// Test for the checksum fields returned by the scheduler validate-conf response
+func TestValidateConfResponseChecksum(t *testing.T) {
+	tests := []struct {
+		name         string
+		response     string
+		wantAllowed  bool
+		wantChecksum string
+		wantChkMatch bool
+	}{
+		{"checksum present and matching", `{"allowed": true, "reason": "", "checksum": "ABC123", "checksumMatch": true}`, true, "ABC123", true},
+		{"checksum present not matching", `{"allowed": true, "reason": "", "checksum": "ABC123", "checksumMatch": false}`, true, "ABC123", false},
+		{"checksum fields omitted", `{"allowed": true, "reason": ""}`, true, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var data ValidateConfResponse
+			err := json.Unmarshal([]byte(tt.response), &data)
+			assert.NilError(t, err, "unexpected error unmarshalling validate-conf response")
+			assert.Equal(t, data.Allowed, tt.wantAllowed, "allowed flag not parsed as expected")
+			assert.Equal(t, data.Checksum, tt.wantChecksum, "checksum not parsed as expected")
+			assert.Equal(t, data.ChecksumMatch, tt.wantChkMatch, "checksumMatch flag not parsed as expected")
+		})
+	}
+}
+
 func prepareConfigMap(data string) *v1.ConfigMap {
 	configmap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### Description
Maps the new checksum and checksumMatch fields from the scheduler validate-conf response and log them after a successful config validation.


### Type of change
Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : [YUNIKORN-3347](https://issues.apache.org/jira/browse/YUNIKORN-3347)

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [x] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [x] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
