### PR TITLE
[YUNIKORN-3359] Run e2e tests with deadlock detection enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -590,7 +590,7 @@ test:
 	@echo "running unit tests"
 	@mkdir -p "$(OUTPUT)"
 	"$(GO)" clean -testcache
-	"$(GO)" test ./pkg/... -cover -race -tags deadlock -coverprofile="$(OUTPUT)/coverage.txt" -covermode=atomic
+	"$(GO)" test ./pkg/... -cover -race -coverprofile="$(OUTPUT)/coverage.txt" -covermode=atomic
 	"$(GO)" vet "$(REPO)"...
 
 # Run benchmarks

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -168,7 +168,8 @@ function install_cluster() {
     --set admissionController.image.pullPolicy=IfNotPresent \
     --set web.image.repository=local/yunikorn \
     --set web.image.tag="${WEBTEST_IMAGE}" \
-    --set web.image.pullPolicy=IfNotPresent
+    --set web.image.pullPolicy=IfNotPresent \
+    --set deadlockDetection.enabled=true
   exit_on_error "failed to install yunikorn"
   "${KUBECTL}" wait --for=condition=available --timeout=300s deployment/yunikorn-scheduler -n yunikorn
   exit_on_error "failed to wait for yunikorn scheduler deployment being deployed"

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -169,7 +169,9 @@ function install_cluster() {
     --set web.image.repository=local/yunikorn \
     --set web.image.tag="${WEBTEST_IMAGE}" \
     --set web.image.pullPolicy=IfNotPresent \
-    --set deadlockDetection.enabled=true
+    --set deadlockDetection.enabled=true \
+    --set deadlockDetection.timeoutSeconds=10 \
+    --set deadlockDetection.exit=true
   exit_on_error "failed to install yunikorn"
   "${KUBECTL}" wait --for=condition=available --timeout=300s deployment/yunikorn-scheduler -n yunikorn
   exit_on_error "failed to wait for yunikorn scheduler deployment being deployed"


### PR DESCRIPTION
### Description
Enable deadlock detection when deploying YuniKorn for e2e tests by passing `--set deadlockDetection.enabled=true` during the Helm chart installation in `scripts/run-e2e-tests.sh`.


### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [X] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3359

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
This PR depends on the Helm chart changes in https://github.com/apache/yunikorn-release/pull/237 which introduce the deadlockDetection configuration.