### PR TITLE
[YUNIKORN-3345] Turn on nonamedreturns linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters:
     - dogsled
     - whitespace
     - ginkgolinter
+    - nonamedreturns
   exclusions:
     generated: lax
     presets:

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -450,7 +450,7 @@ func TestReleaseAppAllocation(t *testing.T) {
 
 func newMockSchedulerAPI() *mockSchedulerAPI {
 	return &mockSchedulerAPI{
-		registerFn: func(request *si.RegisterResourceManagerRequest, callback api.ResourceManagerCallback) (response *si.RegisterResourceManagerResponse, e error) {
+		registerFn: func(request *si.RegisterResourceManagerRequest, callback api.ResourceManagerCallback) (*si.RegisterResourceManagerResponse, error) {
 			return nil, nil
 		},
 		UpdateAllocationFn: func(request *si.AllocationRequest) error {

--- a/pkg/cache/scheduler_callback_test.go
+++ b/pkg/cache/scheduler_callback_test.go
@@ -579,11 +579,11 @@ func (m *mockPredicateManager) EventsToRegister(_ fwk.QueueingHintFn) []fwk.Clus
 	return nil
 }
 
-func (m *mockPredicateManager) Predicates(_ *v1.Pod, _ *framework.NodeInfo, _ bool) (plugin string, error error) {
+func (m *mockPredicateManager) Predicates(_ *v1.Pod, _ *framework.NodeInfo, _ bool) (string, error) {
 	return "", nil
 }
 
-func (m *mockPredicateManager) PreemptionPredicates(_ *v1.Pod, _ *framework.NodeInfo, _ []*v1.Pod, _ int) (index int) {
+func (m *mockPredicateManager) PreemptionPredicates(_ *v1.Pod, _ *framework.NodeInfo, _ []*v1.Pod, _ int) int {
 	return 0
 }
 

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -53,7 +53,7 @@ func (w *ResourceBuilder) Build() *si.Resource {
 // GetPodResource from a pod's containers and convert that into an internal resource.
 // Scheduling only accounts for requests.
 // Convert the pod into a resource to allow for pod count checks in quotas and nodes.
-func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
+func GetPodResource(pod *v1.Pod) *si.Resource {
 	podResource := &si.Resource{
 		Resources: map[string]*si.Quantity{"pods": {Value: 1}},
 	}

--- a/pkg/common/test/configmap_lister_mock.go
+++ b/pkg/common/test/configmap_lister_mock.go
@@ -44,7 +44,7 @@ func NewConfigMapListerMock() *ConfigMapListerMock {
 	}
 }
 
-func (c ConfigMapListerMock) List(selector labels.Selector) (ret []*v1.ConfigMap, err error) {
+func (c ConfigMapListerMock) List(selector labels.Selector) ([]*v1.ConfigMap, error) {
 	return c.configMaps, nil
 }
 

--- a/pkg/common/test/csi_lister_mock.go
+++ b/pkg/common/test/csi_lister_mock.go
@@ -40,6 +40,6 @@ func (n CSINodeListerMock) Get(name string) (*storagev1.CSINode, error) {
 }
 
 // List lists all CSINodes in the indexer.
-func (n CSINodeListerMock) List(selector labels.Selector) (ret []*storagev1.CSINode, err error) {
+func (n CSINodeListerMock) List(selector labels.Selector) ([]*storagev1.CSINode, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/pkg/common/test/namespacelister_mock.go
+++ b/pkg/common/test/namespacelister_mock.go
@@ -38,7 +38,7 @@ func NewMockNamespaceLister(errIfNotFound bool) listersV1.NamespaceLister {
 	}
 }
 
-func (nsl *MockNamespaceLister) List(labels.Selector) (ret []*v1.Namespace, err error) {
+func (nsl *MockNamespaceLister) List(labels.Selector) ([]*v1.Namespace, error) {
 	return nil, nil
 }
 

--- a/pkg/common/test/nodelister_mock.go
+++ b/pkg/common/test/nodelister_mock.go
@@ -43,7 +43,7 @@ func (n *NodeListerMock) RemoveNode(node *v1.Node) {
 	delete(n.nodes, node)
 }
 
-func (n *NodeListerMock) List(selector labels.Selector) (ret []*v1.Node, err error) {
+func (n *NodeListerMock) List(selector labels.Selector) ([]*v1.Node, error) {
 	list := make([]*v1.Node, 0, len(n.nodes))
 	for node := range n.nodes {
 		if selector.Matches(labels.Set(node.Labels)) {

--- a/pkg/common/test/podlister_mock.go
+++ b/pkg/common/test/podlister_mock.go
@@ -44,7 +44,7 @@ func (n *PodListerMock) DeletePod(pod *v1.Pod) {
 	delete(n.pods, pod)
 }
 
-func (n *PodListerMock) List(selector labels.Selector) (ret []*v1.Pod, err error) {
+func (n *PodListerMock) List(selector labels.Selector) ([]*v1.Pod, error) {
 	result := make([]*v1.Pod, 0)
 	for pod := range n.pods {
 		if selector.Matches(labels.Set(pod.Labels)) {

--- a/pkg/common/test/priorityclass_lister_mock.go
+++ b/pkg/common/test/priorityclass_lister_mock.go
@@ -36,8 +36,8 @@ func NewMockPriorityClassLister() listersV1.PriorityClassLister {
 	}
 }
 
-func (nsl *MockPriorityClassLister) List(labels.Selector) (ret []*v1.PriorityClass, err error) {
-	ret = make([]*v1.PriorityClass, 0)
+func (nsl *MockPriorityClassLister) List(labels.Selector) ([]*v1.PriorityClass, error) {
+	ret := make([]*v1.PriorityClass, 0)
 	for _, pc := range nsl.priorityClasses {
 		ret = append(ret, pc)
 	}

--- a/pkg/common/test/schedulerapi_mock.go
+++ b/pkg/common/test/schedulerapi_mock.go
@@ -42,7 +42,7 @@ type SchedulerAPIMock struct {
 func NewSchedulerAPIMock() *SchedulerAPIMock {
 	return &SchedulerAPIMock{
 		registerFn: func(request *si.RegisterResourceManagerRequest,
-			callback api.ResourceManagerCallback) (response *si.RegisterResourceManagerResponse, e error) {
+			callback api.ResourceManagerCallback) (*si.RegisterResourceManagerResponse, error) {
 			return nil, nil
 		},
 		UpdateAllocationFn: func(request *si.AllocationRequest) error {

--- a/pkg/common/test/volumeattachment_lister_mock.go
+++ b/pkg/common/test/volumeattachment_lister_mock.go
@@ -36,8 +36,8 @@ func NewMockVolumeAttachmentLister() listersv1.VolumeAttachmentLister {
 	}
 }
 
-func (nsl *MockVolumeAttachmentLister) List(labels.Selector) (ret []*storagev1.VolumeAttachment, err error) {
-	ret = make([]*storagev1.VolumeAttachment, 0)
+func (nsl *MockVolumeAttachmentLister) List(labels.Selector) ([]*storagev1.VolumeAttachment, error) {
+	ret := make([]*storagev1.VolumeAttachment, 0)
 	for _, pc := range nsl.volumeAttachments {
 		ret = append(ret, pc)
 	}

--- a/pkg/common/test/volumebinder_mock.go
+++ b/pkg/common/test/volumebinder_mock.go
@@ -49,7 +49,7 @@ func NewVolumeBinderMock() *VolumeBinderMock {
 	}
 }
 
-func (v *VolumeBinderMock) GetPodVolumeClaims(_ klog.Logger, _ *v1.Pod) (podVolumeClaims *volumebinding.PodVolumeClaims, err error) {
+func (v *VolumeBinderMock) GetPodVolumeClaims(_ klog.Logger, _ *v1.Pod) (*volumebinding.PodVolumeClaims, error) {
 	if v.volumeClaimError != nil {
 		return nil, v.volumeClaimError
 	}
@@ -57,11 +57,11 @@ func (v *VolumeBinderMock) GetPodVolumeClaims(_ klog.Logger, _ *v1.Pod) (podVolu
 	return v.podVolumeClaim, nil
 }
 
-func (v *VolumeBinderMock) GetEligibleNodes(_ klog.Logger, _ []*v1.PersistentVolumeClaim) (eligibleNodes sets.Set[string]) {
+func (v *VolumeBinderMock) GetEligibleNodes(_ klog.Logger, _ []*v1.PersistentVolumeClaim) sets.Set[string] {
 	return nil
 }
 
-func (v *VolumeBinderMock) FindPodVolumes(_ klog.Logger, _ *v1.Pod, _ *volumebinding.PodVolumeClaims, _ *v1.Node) (podVolumes *volumebinding.PodVolumes, reasons volumebinding.ConflictReasons, err error) {
+func (v *VolumeBinderMock) FindPodVolumes(_ klog.Logger, _ *v1.Pod, _ *volumebinding.PodVolumeClaims, _ *v1.Node) (*volumebinding.PodVolumes, volumebinding.ConflictReasons, error) {
 	if v.findPodVolumesError != nil {
 		return nil, nil, v.findPodVolumesError
 	}
@@ -73,7 +73,7 @@ func (v *VolumeBinderMock) FindPodVolumes(_ klog.Logger, _ *v1.Pod, _ *volumebin
 	return v.podVolumes, nil, nil
 }
 
-func (v *VolumeBinderMock) AssumePodVolumes(_ klog.Logger, _ *v1.Pod, _ string, _ *volumebinding.PodVolumes) (allFullyBound bool, err error) {
+func (v *VolumeBinderMock) AssumePodVolumes(_ klog.Logger, _ *v1.Pod, _ string, _ *volumebinding.PodVolumes) (bool, error) {
 	if v.assumeVolumeError != nil {
 		return false, v.assumeVolumeError
 	}

--- a/pkg/plugin/predicates/predicate_manager.go
+++ b/pkg/plugin/predicates/predicate_manager.go
@@ -45,8 +45,13 @@ import (
 )
 
 type PredicateManager interface {
+	// EventsToRegister returns the cluster events that should be registered for predicate plugins.
 	EventsToRegister(queueingHintFn fwk.QueueingHintFn) []fwk.ClusterEventWithHint
+	// Predicates checks if a pod can fit on a node.
+	// Returns the name of the predicate plugin that failed (may be empty) and any error encountered.
 	Predicates(pod *v1.Pod, node *framework.NodeInfo, allocate bool) (string, error)
+	// PreemptionPredicates checks if a pod can be scheduled on the node by preempting victims.
+	// Returns the victim index that allows the pod to fit, or -1 if none.
 	PreemptionPredicates(pod *v1.Pod, node *framework.NodeInfo, victims []*v1.Pod, startIndex int) int
 }
 

--- a/pkg/plugin/predicates/predicate_manager.go
+++ b/pkg/plugin/predicates/predicate_manager.go
@@ -45,7 +45,6 @@ import (
 )
 
 type PredicateManager interface {
-	// EventsToRegister returns the cluster events that should be registered for predicate plugins.
 	EventsToRegister(queueingHintFn fwk.QueueingHintFn) []fwk.ClusterEventWithHint
 	// Predicates checks if a pod can fit on a node.
 	// Returns the name of the predicate plugin that failed (may be empty) and any error encountered.

--- a/pkg/plugin/predicates/predicate_manager.go
+++ b/pkg/plugin/predicates/predicate_manager.go
@@ -46,8 +46,8 @@ import (
 
 type PredicateManager interface {
 	EventsToRegister(queueingHintFn fwk.QueueingHintFn) []fwk.ClusterEventWithHint
-	Predicates(pod *v1.Pod, node *framework.NodeInfo, allocate bool) (plugin string, error error)
-	PreemptionPredicates(pod *v1.Pod, node *framework.NodeInfo, victims []*v1.Pod, startIndex int) (index int)
+	Predicates(pod *v1.Pod, node *framework.NodeInfo, allocate bool) (string, error)
+	PreemptionPredicates(pod *v1.Pod, node *framework.NodeInfo, victims []*v1.Pod, startIndex int) int
 }
 
 var _ PredicateManager = &predicateManagerImpl{}
@@ -127,7 +127,7 @@ func buildClusterEvents(actionMap map[fwk.EventResource]fwk.ActionType, queueing
 	return events
 }
 
-func (p *predicateManagerImpl) Predicates(pod *v1.Pod, node *framework.NodeInfo, allocate bool) (plugin string, error error) {
+func (p *predicateManagerImpl) Predicates(pod *v1.Pod, node *framework.NodeInfo, allocate bool) (string, error) {
 	if allocate {
 		return p.predicatesAllocate(pod, node)
 	}

--- a/pkg/shim/scheduler_perf_test.go
+++ b/pkg/shim/scheduler_perf_test.go
@@ -112,7 +112,7 @@ func BenchmarkSchedulingThroughPut(b *testing.B) {
 	for i := 0; i < numNodes; i++ {
 		addNode(cluster, "test.host."+strconv.Itoa(i))
 	}
-	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Second*60, true, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Second*60, true, func(ctx context.Context) (bool, error) {
 		return cluster.GetActiveNodeCountInCore(partitionName) == numNodes, nil
 	})
 	assert.NilError(b, err, "node initialization did not finish in time")
@@ -128,7 +128,7 @@ func BenchmarkSchedulingThroughPut(b *testing.B) {
 	defer ps.stop()
 
 	// await binding of pods
-	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Second*60, true, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Second*60, true, func(ctx context.Context) (bool, error) {
 		c := ps.getCompletedPodsCount()
 		fmt.Printf("Number of completed pods: %d\n", c)
 		return c == totalPods, nil

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -167,7 +167,7 @@ func TestSchedulerRegistrationFailed(t *testing.T) {
 	mockedAPIProvider := client.NewMockedAPIProvider(false)
 	mockedAPIProvider.GetAPIs().SchedulerAPI = test.NewSchedulerAPIMock().RegisterFunction(
 		func(request *si.RegisterResourceManagerRequest,
-			callback api.ResourceManagerCallback) (response *si.RegisterResourceManagerResponse, e error) {
+			callback api.ResourceManagerCallback) (*si.RegisterResourceManagerResponse, error) {
 			return nil, fmt.Errorf("some error")
 		})
 

--- a/test/e2e/framework/helpers/k8s/k8s_utils.go
+++ b/test/e2e/framework/helpers/k8s/k8s_utils.go
@@ -1485,8 +1485,8 @@ func GetWorkerNodes(nodes v1.NodeList) []v1.Node {
 }
 
 // Sums up current resource usage in a list of pods. Non-running pods are filtered out.
-func GetPodsTotalRequests(podList *v1.PodList) (reqs v1.ResourceList) {
-	reqs = make(v1.ResourceList)
+func GetPodsTotalRequests(podList *v1.PodList) v1.ResourceList {
+	reqs := make(v1.ResourceList)
 	for i := range podList.Items {
 		pod := podList.Items[i]
 		podReqs := v1.ResourceList{}
@@ -1502,7 +1502,7 @@ func GetPodsTotalRequests(podList *v1.PodList) (reqs v1.ResourceList) {
 			}
 		}
 	}
-	return
+	return reqs
 }
 
 // GetNodesAvailRes Returns map of nodeName to list of available resource (memory and cpu only) amounts.
@@ -1868,7 +1868,7 @@ func (k *KubeCtl) GetSecret(namespace, secretName string) (*v1.Secret, error) {
 
 func (k *KubeCtl) WaitForSecret(namespace, secretName string, timeout time.Duration) error {
 	var cond wait.ConditionFunc // nolint:staticcheck
-	cond = func() (done bool, err error) {
+	cond = func() (bool, error) {
 		secret, err := k.GetSecret(namespace, secretName)
 		if err != nil {
 			return false, err

--- a/test/e2e/gang_scheduling/gang_scheduling_test.go
+++ b/test/e2e/gang_scheduling/gang_scheduling_test.go
@@ -672,8 +672,9 @@ var _ = Describe("", func() {
 
 })
 
-func createJob(applicationID string, minResource map[string]resource.Quantity, annotations k8s.PodAnnotation, parallelism int32) (job *batchv1.Job) {
+func createJob(applicationID string, minResource map[string]resource.Quantity, annotations k8s.PodAnnotation, parallelism int32) *batchv1.Job {
 	var (
+		job      *batchv1.Job
 		err      error
 		requests = v1.ResourceList{}
 		limits   = v1.ResourceList{}

--- a/test/e2e/spark_jobs_scheduling/spark_jobs_scheduling_test.go
+++ b/test/e2e/spark_jobs_scheduling/spark_jobs_scheduling_test.go
@@ -97,7 +97,7 @@ var _ = Describe("", func() {
 		By(fmt.Sprintf("Get apps from specific queue: %s", sparkQueueName))
 		var appsFromQueue []*dao.ApplicationDAOInfo
 		// Poll for apps to appear in the queue
-		err = wait.PollUntilContextTimeout(context.TODO(), time.Millisecond*100, time.Duration(120)*time.Second, false, func(context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(context.TODO(), time.Millisecond*100, time.Duration(120)*time.Second, false, func(context.Context) (bool, error) {
 			appsFromQueue, err = restClient.GetApps(configmanager.DefaultPartition, sparkQueueName)
 			if err != nil {
 				return false, err


### PR DESCRIPTION
### Description
This PR turns on the nonamedreturns linter in .golangci.yml and refactors existing functions. 

### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [ ] Feature
- [X] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3345

- [ ] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A