### PR TITLE
[YUNIKORN-3374] Revert assumed pods instead of orphaning them on node removal

### DIFF
--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -207,8 +207,23 @@ func (cache *SchedulerCache) removeNode(node *v1.Node) (*v1.Node, []*v1.Pod) {
 	for _, fwkPod := range nodeInfo.Pods {
 		pod := fwkPod.GetPod()
 		key := string(pod.UID)
+		// a pod that is still assumed was never bound to the node: the node name it carries was set
+		// by the shim when the pod was assumed, it is not an assignment made by the cluster
+		revert := cache.isAssumedPod(key)
 		delete(cache.assignedPods, key)
 		delete(cache.assumedPods, key)
+		if revert {
+			// the assumed node is gone before the bind completed, revert the assignment instead of
+			// orphaning the pod: an orphan is adopted again when the node comes back and the pod
+			// would be recovered as an existing allocation for a bind that never happened. The pod
+			// is just pending again and is scheduled on whatever node is available.
+			// Copy before updating, the pod is shared with the pods map and can be owned by the
+			// informer cache.
+			unassigned := pod.DeepCopy()
+			unassigned.Spec.NodeName = ""
+			cache.podsMap[key] = unassigned
+			continue
+		}
 		cache.orphanedPods[key] = pod
 		orphans = append(orphans, pod)
 	}

--- a/pkg/cache/external/scheduler_cache_test.go
+++ b/pkg/cache/external/scheduler_cache_test.go
@@ -1140,3 +1140,100 @@ func TestOrphanPods(t *testing.T) {
 	cache.UpdateNode(node)
 	assert.Check(t, !cache.IsPodOrphaned(podUID1), "pod on added node still marked as orphaned")
 }
+
+// this test verifies that removing the node an assumed pod is assumed on reverts the assignment
+// instead of orphaning the pod: the bind never happened, so the pod must not be adopted, and
+// recovered as an existing allocation, when the node comes back
+func TestRemoveNodeWithAssumedPod(t *testing.T) {
+	cache := NewSchedulerCache(client.NewMockedAPIProvider(false).GetAPIs())
+	node := newTestNode()
+	cache.UpdateNode(node)
+
+	pod := newTestPod()
+	cache.UpdatePod(pod)
+
+	assumedPod := pod.DeepCopy()
+	assumedPod.Spec.NodeName = host1
+	cache.AssumePod(assumedPod, true)
+	assert.Check(t, cache.IsAssumedPod(podUID1), "pod is not assumed")
+
+	// the node is removed before the bind completed: the assignment must be reverted
+	_, orphans := cache.RemoveNode(node)
+	assert.Equal(t, len(orphans), 0, "assumed pod is returned as an orphan")
+	assert.Check(t, !cache.IsAssumedPod(podUID1), "pod is still assumed after the node was removed")
+	assert.Check(t, !cache.IsPodOrphaned(podUID1), "pod is orphaned after the node was removed")
+	assert.Equal(t, cache.GetPod(podUID1).Spec.NodeName, "", "pod is still assigned to the removed node")
+	assert.Equal(t, len(cache.assignedPods), 0, "pod is still in the assigned pods")
+
+	// the node comes back: the pod is pending, it must not be adopted onto the node
+	_, adopted := cache.UpdateNode(node)
+	assert.Equal(t, len(adopted), 0, "pod is adopted after the node was added back")
+	assert.Equal(t, cache.GetPod(podUID1).Spec.NodeName, "", "pod is assigned to the node that came back")
+	assert.Equal(t, len(cache.assignedPods), 0, "pod is in the assigned pods after the node came back")
+	// nolint:staticcheck
+	assert.Equal(t, len(cache.GetNode(host1).Pods), 0, "pod is added to the node that came back")
+}
+
+// this test verifies that a pod which the cluster reports as assigned to a node is orphaned when
+// that node is removed and is adopted again when the node comes back: that assignment is real
+func TestRemoveNodeWithBoundPod(t *testing.T) {
+	cache := NewSchedulerCache(client.NewMockedAPIProvider(false).GetAPIs())
+	node := newTestNode()
+	cache.UpdateNode(node)
+
+	pod := newTestPod()
+	pod.Spec.NodeName = host1
+	pod.Status.Phase = v1.PodRunning
+	cache.UpdatePod(pod)
+	assert.Check(t, !cache.IsAssumedPod(podUID1), "running pod is assumed")
+
+	_, orphans := cache.RemoveNode(node)
+	assert.Equal(t, len(orphans), 1, "bound pod is not returned as an orphan")
+	assert.Check(t, cache.IsPodOrphaned(podUID1), "bound pod is not orphaned after the node was removed")
+	assert.Equal(t, cache.GetPod(podUID1).Spec.NodeName, host1, "bound pod lost its node assignment")
+
+	// the node comes back: the pod is still on it and must be adopted
+	_, adopted := cache.UpdateNode(node)
+	assert.Equal(t, len(adopted), 1, "bound pod is not adopted after the node was added back")
+	assert.Check(t, !cache.IsPodOrphaned(podUID1), "adopted pod is still an orphan")
+	assert.Equal(t, cache.GetPod(podUID1).Spec.NodeName, host1, "adopted pod lost its node assignment")
+	assert.Equal(t, cache.assignedPods[podUID1], host1, "adopted pod is not in the assigned pods")
+	// nolint:staticcheck
+	assert.Equal(t, len(cache.GetNode(host1).Pods), 1, "adopted pod is not added to the node")
+}
+
+// newTestNode returns a node with a name of host1 and enough capacity for the test pods
+func newTestNode() *v1.Node {
+	resourceList := make(map[v1.ResourceName]resource.Quantity)
+	resourceList[v1.ResourceName("memory")] = *resource.NewQuantity(1024*1000*1000, resource.DecimalSI)
+	resourceList[v1.ResourceName("cpu")] = *resource.NewQuantity(10, resource.DecimalSI)
+	return &v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      host1,
+			Namespace: "default",
+			UID:       nodeUID1,
+		},
+		Status: v1.NodeStatus{
+			Allocatable: resourceList,
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: false,
+		},
+	}
+}
+
+// newTestPod returns an unassigned pod with a name of podName1
+func newTestPod() *v1.Pod {
+	return &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name:      podName1,
+			Namespace: "default",
+			UID:       podUID1,
+		},
+		Spec: v1.PodSpec{},
+	}
+}


### PR DESCRIPTION
### What is this PR for?

`removeNode` orphans every pod on the removed node's NodeInfo, including pods that were only *assumed* on it. An assumed pod's `Spec.NodeName` was stamped by the shim at assume time -- it is not an assignment the cluster made -- so when the node comes back, the orphan adoption path matches on a node name we invented ourselves: the never-bound pod is assigned to the node again, `Context.addNode` re-registers it, and task recovery reports an existing allocation to the core for a bind that never happened. A node flap (a kubelet re-registration, for example) is enough to create the phantom allocation of [YUNIKORN-3355](https://issues.apache.org/jira/browse/YUNIKORN-3355) without a single failed bind. The shim cache self-heals on the next informer update for the pod, but the core-side allocation persists.

The fix: in `removeNode`, a pod that is still assumed is reverted instead of orphaned -- assumed and assigned state dropped, node name cleared on a `DeepCopy`, pod kept in the cache as pending. It is then simply rescheduled on whatever node is available, which is also the correct outcome, as the node it was assumed on is gone. Pods the cluster actually placed on the node keep the existing orphan/adopt behaviour unchanged: their assignment is real.

This is the same discipline the [YUNIKORN-3355](https://issues.apache.org/jira/browse/YUNIKORN-3355) fix (#1066) established for `forgetPod`. Found by the invariant property fuzzer of [YUNIKORN-3373](https://issues.apache.org/jira/browse/YUNIKORN-3373) (#1067), whose "a pod that never bound is not assigned to a node" invariant fails on master via this path on every seed; with this fix (and #1066) the fuzzer passes.

Note: this PR duplicates two small test helpers (`newTestNode`/`newTestPod`) also added by #1066; whichever merges second will be rebased to drop the duplicate.

### How was this patch tested?

- New regression test: assume a pod, remove its node, re-add the node; asserts the pod is unassigned, not assumed, not orphaned, and not adopted. Fails on unmodified master (`assumed pod is returned as an orphan`), passes with the fix.
- Companion test pins the preserved behaviour: a pod the cluster reports as bound to the node IS orphaned on removal and adopted on re-add.
- Full package suites green with `-race` and deadlock detection; `make lint` and `make license-check` clean.
- The [YUNIKORN-3373](https://issues.apache.org/jira/browse/YUNIKORN-3373) fuzzer, run on top of this fix plus #1066, is green over 150+ seeds and 100k-step runs.

Generated by the Author with assistance from Claude Code

