### PR TITLE
[YUNIKORN-3376] Fix data race on Task.pod in the pre-scheduling metadata check

### DIFF
--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -520,20 +520,22 @@ func (task *Task) sanityCheckBeforeScheduling() error {
 
 // throw a warning if the pod has inconsistent metadata
 func (task *Task) checkPodMetadataBeforeScheduling() {
-	appID := utils.GetApplicationIDFromPod(task.pod)
-	ignoredAppIDLabels, ignoredAppIDAnnotation := utils.GetIgnoredLabelAnnotationInPod(task.pod, appID, constants.AppIdLabelKeys, constants.AppIdAnnotationKeys)
+	// take a reference under the task lock: the informer can replace task.pod concurrently
+	pod := task.GetTaskPod()
+	appID := utils.GetApplicationIDFromPod(pod)
+	ignoredAppIDLabels, ignoredAppIDAnnotation := utils.GetIgnoredLabelAnnotationInPod(pod, appID, constants.AppIdLabelKeys, constants.AppIdAnnotationKeys)
 	if len(ignoredAppIDLabels) > 0 || len(ignoredAppIDAnnotation) > 0 {
-		task.logIgnoredPodMetadata("app-id", appID, ignoredAppIDLabels, ignoredAppIDAnnotation)
+		task.logIgnoredPodMetadata(pod, "app-id", appID, ignoredAppIDLabels, ignoredAppIDAnnotation)
 	}
 
-	queueName := utils.GetQueueNameFromPod(task.pod)
-	ignoredQueueLabels, ignoredQueueAnnotation := utils.GetIgnoredLabelAnnotationInPod(task.pod, queueName, constants.QueueLabelKeys, constants.QueueAnnotationKeys)
+	queueName := utils.GetQueueNameFromPod(pod)
+	ignoredQueueLabels, ignoredQueueAnnotation := utils.GetIgnoredLabelAnnotationInPod(pod, queueName, constants.QueueLabelKeys, constants.QueueAnnotationKeys)
 	if len(ignoredQueueLabels) > 0 || len(ignoredQueueAnnotation) > 0 {
-		task.logIgnoredPodMetadata("queue", queueName, ignoredQueueLabels, ignoredQueueAnnotation)
+		task.logIgnoredPodMetadata(pod, "queue", queueName, ignoredQueueLabels, ignoredQueueAnnotation)
 	}
 }
 
-func (task *Task) logIgnoredPodMetadata(metadataType string, fianlValue string, ignoredLabel map[string]string, ignoredAnnotation map[string]string) {
+func (task *Task) logIgnoredPodMetadata(pod *v1.Pod, metadataType string, fianlValue string, ignoredLabel map[string]string, ignoredAnnotation map[string]string) {
 	ignoredItems := make([]string, 0)
 	for key, value := range ignoredLabel {
 		ignoredItems = append(ignoredItems, fmt.Sprintf("(Label) %s: %s", key, value))
@@ -542,10 +544,10 @@ func (task *Task) logIgnoredPodMetadata(metadataType string, fianlValue string, 
 		ignoredItems = append(ignoredItems, fmt.Sprintf("(Annotation) %s: %s", key, value))
 	}
 	logMessage := fmt.Sprintf("Found multiple '%s' value in pod. { podName: %s, fianlValue: %s, ignored: [%s] }",
-		metadataType, task.pod.Name, fianlValue, strings.Join(ignoredItems, ", "))
+		metadataType, pod.Name, fianlValue, strings.Join(ignoredItems, ", "))
 
 	log.Log(log.ShimCacheTask).Warn(logMessage)
-	events.GetRecorder().Eventf(task.pod.DeepCopy(),
+	events.GetRecorder().Eventf(pod.DeepCopy(),
 		nil, v1.EventTypeWarning, "Scheduling", "Scheduling", logMessage)
 }
 


### PR DESCRIPTION
### What is this PR for?

`Task.checkPodMetadataBeforeScheduling` read `task.pod` without the task lock on the shim scheduling goroutine (`Application.Schedule` -> `scheduleTasks`), concurrently with `SetTaskPod`, which replaces the same field under `task.lock` from the informer handler (`Context.updateYuniKornPod`). The neighbouring `checkPodPVCs` takes `RLock` for exactly the same field, so this was a missed lock, not a lock-free design choice. Confirmed with the race detector under bind churn (the [YUNIKORN-3377](https://issues.apache.org/jira/browse/YUNIKORN-3377) fault-injection scenarios (#1069)): read frame `scheduleTasks` via the `wait.BackoffUntil` scheduling loop, write frame `SetTaskPod` via `Context.UpdatePod` -- both production paths. An audit of every other `task.pod` access in the file found them correctly protected, so this was the only gap.

The fix takes one reference under the lock at the top of the check (`pod := task.GetTaskPod()`) and uses it throughout, including in `logIgnoredPodMetadata`, which now receives the pod instead of re-reading the field.

The consequences of the race were limited -- the function is diagnostic-only (a warning log and a k8s event) and both racing values are complete informer objects -- but it is undefined behaviour under the Go memory model and intermittently fails any race-enabled CI run (~1 in 9-18 chaos-scenario runs).

### How was this patch tested?

- Race-hunt soak (bind churn under `-race`, the tool that found the defect): before the fix it fires in roughly every 60s run; with the fix, three consecutive runs show zero occurrences of this race (the only remaining reports are the separate [YUNIKORN-3355](https://issues.apache.org/jira/browse/YUNIKORN-3355) informer-object mutation, fixed in #1066).
- Full `pkg/cache` suite green with `-race` and deadlock detection; `make lint` and `make license-check` clean.

Generated by the Author with assistance from Claude Code


