### PR TITLE
[YUNIKORN-3392] DRA Bindings using appropriate K8s Plugins

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -14,6 +14,7 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+ limitations under the License.
 */
 
 package cache

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -742,84 +742,85 @@ func (ctx *Context) IsPodFitNodeViaPreemption(name, node string, allocations []s
 	return -1, false
 }
 
-func (ctx *Context) doPluginRequisiteChecks(name, node string) (*v1.Pod, *framework.NodeInfo, *si.BindingResponse) {
+func (ctx *Context) doPluginRequisiteChecks(name, node string) (*v1.Pod, *framework.NodeInfo, error) {
 	ctx.lock.RLock()
 	defer ctx.lock.RUnlock()
 	pod := ctx.schedulerCache.GetPod(name)
 	if pod == nil {
-		return nil, nil, &si.BindingResponse{
-			Success: false,
-			Reason:  ErrorPodNotFound.Error(),
-		}
+		return nil, nil, ErrorPodNotFound
 	}
 	// if pod exists in cache, try to run predicates
 	targetNode := ctx.schedulerCache.GetNode(node)
 	if targetNode == nil {
-		return nil, nil, &si.BindingResponse{
-			Success: false,
-			Reason:  ErrorNodeNotFound.Error(),
-		}
+		return nil, nil, ErrorNodeNotFound
 	}
 	return pod, targetNode, nil
 }
 
 // Reserve Binding Cycle - Reserve the node for binding process
-func (ctx *Context) Reserve(name, node string) *si.BindingResponse {
-	pod, targetNode, resp := ctx.doPluginRequisiteChecks(name, node)
-	if resp != nil {
-		return resp
+func (ctx *Context) Reserve(name, node string) bool {
+	pod, targetNode, err := ctx.doPluginRequisiteChecks(name, node)
+	if err != nil {
+		log.Log(log.ShimContext).Error("reserve failed",
+			zap.Error(err),
+			zap.String("pod", name),
+			zap.String("node", node))
+		return false
 	}
 	// need to lock cache here as predicates need a stable view into the cache
 	ctx.schedulerCache.LockForReads()
 	defer ctx.schedulerCache.UnlockForReads()
 	plugin, err := ctx.predManager.Reserve(pod, nil, targetNode)
 	if err != nil {
-		bindErr := errors.Join(fmt.Errorf("failed plugin: '%s'", plugin), err)
-		return &si.BindingResponse{
-			Success: false,
-			Reason:  bindErr.Error(),
-		}
+		log.Log(log.ShimContext).Error("reserve failed",
+			zap.Error(err),
+			zap.String("plugin", plugin),
+			zap.String("pod", name),
+			zap.String("node", node))
+		return false
 	}
-	return &si.BindingResponse{
-		Success: true,
-	}
+	return true
 }
 
 // PreBind Binding Cycle - PreBind the node for binding process
-func (ctx *Context) PreBind(name, node string) *si.BindingResponse {
-	pod, targetNode, resp := ctx.doPluginRequisiteChecks(name, node)
-	if resp != nil {
-		return resp
+func (ctx *Context) PreBind(name, node string) bool {
+	pod, targetNode, err := ctx.doPluginRequisiteChecks(name, node)
+	if err != nil {
+		log.Log(log.ShimContext).Error("prebind failed",
+			zap.Error(err),
+			zap.String("pod", name),
+			zap.String("node", node))
+		return false
 	}
 	// need to lock cache here as predicates need a stable view into the cache
 	ctx.schedulerCache.LockForReads()
 	defer ctx.schedulerCache.UnlockForReads()
 	plugin, err := ctx.predManager.PreBind(pod, nil, targetNode)
 	if err != nil {
-		bindErr := errors.Join(fmt.Errorf("failed plugin: '%s'", plugin), err)
-		return &si.BindingResponse{
-			Success: false,
-			Reason:  bindErr.Error(),
-		}
+		log.Log(log.ShimContext).Error("prebind failed",
+			zap.Error(err),
+			zap.String("plugin", plugin),
+			zap.String("pod", name),
+			zap.String("node", node))
+		return false
 	}
-	return &si.BindingResponse{
-		Success: true,
-	}
+	return true
 }
 
 // Unreserve Binding Cycle - Unreserve the node to clear out the binding work
-func (ctx *Context) Unreserve(name, node string) *si.BindingResponse {
-	pod, targetNode, resp := ctx.doPluginRequisiteChecks(name, node)
-	if resp != nil {
-		return resp
+func (ctx *Context) Unreserve(name, node string) {
+	pod, targetNode, err := ctx.doPluginRequisiteChecks(name, node)
+	if err != nil {
+		log.Log(log.ShimContext).Error("unreserve failed",
+			zap.Error(err),
+			zap.String("pod", name),
+			zap.String("node", node))
+		return
 	}
 	// need to lock cache here as predicates need a stable view into the cache
 	ctx.schedulerCache.LockForReads()
 	defer ctx.schedulerCache.UnlockForReads()
 	ctx.predManager.Unreserve(pod, nil, targetNode)
-	return &si.BindingResponse{
-		Success: true,
-	}
 }
 
 // call volume binder to bind pod volumes if necessary,

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
@@ -739,6 +740,86 @@ func (ctx *Context) IsPodFitNodeViaPreemption(name, node string, allocations []s
 		}
 	}
 	return -1, false
+}
+
+func (ctx *Context) doPluginRequisiteChecks(name, node string) (*v1.Pod, *framework.NodeInfo, *si.BindingResponse) {
+	ctx.lock.RLock()
+	defer ctx.lock.RUnlock()
+	pod := ctx.schedulerCache.GetPod(name)
+	if pod == nil {
+		return nil, nil, &si.BindingResponse{
+			Success: false,
+			Reason:  ErrorPodNotFound.Error(),
+		}
+	}
+	// if pod exists in cache, try to run predicates
+	targetNode := ctx.schedulerCache.GetNode(node)
+	if targetNode == nil {
+		return nil, nil, &si.BindingResponse{
+			Success: false,
+			Reason:  ErrorNodeNotFound.Error(),
+		}
+	}
+	return pod, targetNode, nil
+}
+
+// Reserve Binding Cycle - Reserve the node for binding process
+func (ctx *Context) Reserve(name, node string) *si.BindingResponse {
+	pod, targetNode, resp := ctx.doPluginRequisiteChecks(name, node)
+	if resp != nil {
+		return resp
+	}
+	// need to lock cache here as predicates need a stable view into the cache
+	ctx.schedulerCache.LockForReads()
+	defer ctx.schedulerCache.UnlockForReads()
+	plugin, err := ctx.predManager.Reserve(pod, nil, targetNode)
+	if err != nil {
+		bindErr := errors.Join(fmt.Errorf("failed plugin: '%s'", plugin), err)
+		return &si.BindingResponse{
+			Success: false,
+			Reason:  bindErr.Error(),
+		}
+	}
+	return &si.BindingResponse{
+		Success: true,
+	}
+}
+
+// PreBind Binding Cycle - PreBind the node for binding process
+func (ctx *Context) PreBind(name, node string) *si.BindingResponse {
+	pod, targetNode, resp := ctx.doPluginRequisiteChecks(name, node)
+	if resp != nil {
+		return resp
+	}
+	// need to lock cache here as predicates need a stable view into the cache
+	ctx.schedulerCache.LockForReads()
+	defer ctx.schedulerCache.UnlockForReads()
+	plugin, err := ctx.predManager.PreBind(pod, nil, targetNode)
+	if err != nil {
+		bindErr := errors.Join(fmt.Errorf("failed plugin: '%s'", plugin), err)
+		return &si.BindingResponse{
+			Success: false,
+			Reason:  bindErr.Error(),
+		}
+	}
+	return &si.BindingResponse{
+		Success: true,
+	}
+}
+
+// Unreserve Binding Cycle - Unreserve the node to clear out the binding work
+func (ctx *Context) Unreserve(name, node string) *si.BindingResponse {
+	pod, targetNode, resp := ctx.doPluginRequisiteChecks(name, node)
+	if resp != nil {
+		return resp
+	}
+	// need to lock cache here as predicates need a stable view into the cache
+	ctx.schedulerCache.LockForReads()
+	defer ctx.schedulerCache.UnlockForReads()
+	ctx.predManager.Unreserve(pod, nil, targetNode)
+	return &si.BindingResponse{
+		Success: true,
+	}
 }
 
 // call volume binder to bind pod volumes if necessary,

--- a/pkg/cache/scheduler_callback.go
+++ b/pkg/cache/scheduler_callback.go
@@ -40,8 +40,7 @@ type AsyncRMCallback struct {
 }
 
 func (callback *AsyncRMCallback) PreFilterPredicates(args *si.PreFilterPredicatesArgs) *si.PreFilterPredicatesResponse {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 var _ api.ResourceManagerCallback = &AsyncRMCallback{}
@@ -218,18 +217,6 @@ func (callback *AsyncRMCallback) PreemptionPredicates(args *si.PreemptionPredica
 		Success: ok,
 		Index:   int32(index), //nolint:gosec
 	}
-}
-
-func (callback *AsyncRMCallback) Reserve(args *si.BindingArgs) *si.BindingResponse {
-	return callback.context.Reserve(args.AllocationKey, args.NodeID)
-}
-
-func (callback *AsyncRMCallback) PreBind(args *si.BindingArgs) *si.BindingResponse {
-	return callback.context.PreBind(args.AllocationKey, args.NodeID)
-}
-
-func (callback *AsyncRMCallback) Unreserve(args *si.BindingArgs) *si.BindingResponse {
-	return callback.context.Unreserve(args.AllocationKey, args.NodeID)
 }
 
 func (callback *AsyncRMCallback) SendEvent(eventRecords []*si.EventRecord) {

--- a/pkg/cache/scheduler_callback.go
+++ b/pkg/cache/scheduler_callback.go
@@ -39,6 +39,11 @@ type AsyncRMCallback struct {
 	context *Context
 }
 
+func (callback *AsyncRMCallback) PreFilterPredicates(args *si.PreFilterPredicatesArgs) *si.PreFilterPredicatesResponse {
+	//TODO implement me
+	panic("implement me")
+}
+
 var _ api.ResourceManagerCallback = &AsyncRMCallback{}
 var _ api.StateDumpPlugin = &AsyncRMCallback{}
 
@@ -213,6 +218,18 @@ func (callback *AsyncRMCallback) PreemptionPredicates(args *si.PreemptionPredica
 		Success: ok,
 		Index:   int32(index), //nolint:gosec
 	}
+}
+
+func (callback *AsyncRMCallback) Reserve(args *si.BindingArgs) *si.BindingResponse {
+	return callback.context.Reserve(args.AllocationKey, args.NodeID)
+}
+
+func (callback *AsyncRMCallback) PreBind(args *si.BindingArgs) *si.BindingResponse {
+	return callback.context.PreBind(args.AllocationKey, args.NodeID)
+}
+
+func (callback *AsyncRMCallback) Unreserve(args *si.BindingArgs) *si.BindingResponse {
+	return callback.context.Unreserve(args.AllocationKey, args.NodeID)
 }
 
 func (callback *AsyncRMCallback) SendEvent(eventRecords []*si.EventRecord) {

--- a/pkg/cache/scheduler_callback_test.go
+++ b/pkg/cache/scheduler_callback_test.go
@@ -575,6 +575,17 @@ var _ predicates.PredicateManager = &mockPredicateManager{}
 
 type mockPredicateManager struct{}
 
+func (m *mockPredicateManager) Reserve(pod *v1.Pod, cycleState *framework.CycleState, node *framework.NodeInfo) (string, error) {
+	return "", nil
+}
+
+func (m *mockPredicateManager) PreBind(pod *v1.Pod, cycleState *framework.CycleState, node *framework.NodeInfo) (string, error) {
+	return "", nil
+}
+
+func (m *mockPredicateManager) Unreserve(pod *v1.Pod, cycleState *framework.CycleState, node *framework.NodeInfo) {
+}
+
 func (m *mockPredicateManager) EventsToRegister(_ fwk.QueueingHintFn) []fwk.ClusterEventWithHint {
 	return nil
 }

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -379,10 +379,10 @@ func (task *Task) postTaskAllocated() {
 				zap.String("podUID", string(pod.UID)))
 			reserve := task.context.Reserve(pod.Name, nodeName)
 			reschedule := true
-			if reserve != nil && reserve.Success {
+			if reserve {
 				reschedule = false
 				preBind := task.context.PreBind(pod.Name, nodeName)
-				if preBind != nil && !preBind.Success {
+				if !preBind {
 					reschedule = true
 					task.context.Unreserve(pod.Name, nodeName)
 				}
@@ -395,56 +395,55 @@ func (task *Task) postTaskAllocated() {
 		}
 
 		// Bind Pod Volumes
-		if len(pod.Spec.Volumes) > 0 {
-			// before binding pod to node, first bind volumes to pod
-			log.Log(log.ShimCacheTask).Debug("bind pod volumes",
-				zap.String("podName", pod.Name),
-				zap.String("podUID", string(pod.UID)))
-			if err := retry.OnError(retryBackoff, func(err error) bool {
-				if strings.HasPrefix(err.Error(), "binding volumes:") {
-					log.Log(log.ShimCacheTask).Warn("bind volumes to pod failed due to volume binding error, stopping retries",
-						zap.String("taskID", task.taskID), zap.Error(err))
-					return false
-				}
-				log.Log(log.ShimCacheTask).Error("bind volumes to pod failed, retrying",
-					zap.String("taskID", task.taskID), zap.Error(err))
-				return true
-			}, func() error {
-				return task.context.bindPodVolumes(pod)
-			}); err != nil {
-				log.Log(log.ShimCacheTask).Error("bind volumes to pod failed after retries",
-					zap.String("taskID", task.taskID), zap.Error(err))
-				// release task lock before calling rescheduleOnBindFailure to avoid deadlock
-				task.lock.Unlock()
-				task.rescheduleOnBindFailure(allocationKey, nodeName, "PodVolumesBindFailure",
-					fmt.Sprintf("Failed to bind volumes for %s on node %s, it will be retried", alias, nodeName))
-				return
-			}
-			log.Log(log.ShimCacheTask).Debug("bind pod",
-				zap.String("podName", pod.Name),
-				zap.String("podUID", string(pod.UID)))
 
-			if err := retry.OnError(retryBackoff, func(err error) bool {
-				log.Log(log.ShimCacheTask).Error("bind pod to node failed, retrying",
+		// before binding pod to node, first bind volumes to pod
+		log.Log(log.ShimCacheTask).Debug("bind pod volumes",
+			zap.String("podName", pod.Name),
+			zap.String("podUID", string(pod.UID)))
+		if err := retry.OnError(retryBackoff, func(err error) bool {
+			if strings.HasPrefix(err.Error(), "binding volumes:") {
+				log.Log(log.ShimCacheTask).Warn("bind volumes to pod failed due to volume binding error, stopping retries",
 					zap.String("taskID", task.taskID), zap.Error(err))
-				return true
-			}, func() error {
-				return task.context.apiProvider.GetAPIs().KubeClient.Bind(pod, nodeName)
-			}); err != nil {
-				log.Log(log.ShimCacheTask).Error("bind pod to node failed after retries",
-					zap.String("taskID", task.taskID), zap.Error(err))
-				task.lock.Unlock()
-				task.rescheduleOnBindFailure(allocationKey, nodeName, "PodBindFailure",
-					fmt.Sprintf("Failed to bind %s to node %s, it will be retried", alias, nodeName))
-				return
+				return false
 			}
-			// post a message to indicate the pod gets its allocation
-			events.GetRecorder().Eventf(pod.DeepCopy(),
-				nil, v1.EventTypeNormal, "Scheduled", "Scheduled",
-				"Successfully assigned %s to node %s", alias, nodeName)
-			log.Log(log.ShimCacheTask).Info("successfully bound pod", zap.String("podName", pod.Name))
-
+			log.Log(log.ShimCacheTask).Error("bind volumes to pod failed, retrying",
+				zap.String("taskID", task.taskID), zap.Error(err))
+			return true
+		}, func() error {
+			return task.context.bindPodVolumes(pod)
+		}); err != nil {
+			log.Log(log.ShimCacheTask).Error("bind volumes to pod failed after retries",
+				zap.String("taskID", task.taskID), zap.Error(err))
+			// release task lock before calling rescheduleOnBindFailure to avoid deadlock
+			task.lock.Unlock()
+			task.rescheduleOnBindFailure(allocationKey, nodeName, "PodVolumesBindFailure",
+				fmt.Sprintf("Failed to bind volumes for %s on node %s, it will be retried", alias, nodeName))
+			return
 		}
+		log.Log(log.ShimCacheTask).Debug("bind pod",
+			zap.String("podName", pod.Name),
+			zap.String("podUID", string(pod.UID)))
+
+		if err := retry.OnError(retryBackoff, func(err error) bool {
+			log.Log(log.ShimCacheTask).Error("bind pod to node failed, retrying",
+				zap.String("taskID", task.taskID), zap.Error(err))
+			return true
+		}, func() error {
+			return task.context.apiProvider.GetAPIs().KubeClient.Bind(pod, nodeName)
+		}); err != nil {
+			log.Log(log.ShimCacheTask).Error("bind pod to node failed after retries",
+				zap.String("taskID", task.taskID), zap.Error(err))
+			task.lock.Unlock()
+			task.rescheduleOnBindFailure(allocationKey, nodeName, "PodBindFailure",
+				fmt.Sprintf("Failed to bind %s to node %s, it will be retried", alias, nodeName))
+			return
+		}
+		// post a message to indicate the pod gets its allocation
+		events.GetRecorder().Eventf(pod.DeepCopy(),
+			nil, v1.EventTypeNormal, "Scheduled", "Scheduled",
+			"Successfully assigned %s to node %s", alias, nodeName)
+		log.Log(log.ShimCacheTask).Info("successfully bound pod", zap.String("podName", pod.Name))
+
 		task.schedulingState = TaskSchedAllocated
 
 		dispatcher.Dispatch(NewBindTaskEvent(task.applicationID, task.taskID))

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -370,54 +370,81 @@ func (task *Task) postTaskAllocated() {
 		// once all task related operations are done, release the lock
 		// This is important specially while calling rollbackAllocation, which needs to acquire the context lock, so we cannot hold the task lock while calling it.
 		task.lock.Lock()
-		// before binding pod to node, first bind volumes to pod
-		log.Log(log.ShimCacheTask).Debug("bind pod volumes",
-			zap.String("podName", pod.Name),
-			zap.String("podUID", string(pod.UID)))
-		if err := retry.OnError(retryBackoff, func(err error) bool {
-			if strings.HasPrefix(err.Error(), "binding volumes:") {
-				log.Log(log.ShimCacheTask).Warn("bind volumes to pod failed due to volume binding error, stopping retries",
-					zap.String("taskID", task.taskID), zap.Error(err))
-				return false
+
+		// DRA Bindings
+		if len(pod.Spec.ResourceClaims) > 0 { // Have to make check more robust
+			// before binding pod to node, dra bindings to pod
+			log.Log(log.ShimCacheTask).Debug("dra bindings",
+				zap.String("podName", pod.Name),
+				zap.String("podUID", string(pod.UID)))
+			reserve := task.context.Reserve(pod.Name, nodeName)
+			reschedule := true
+			if reserve != nil && reserve.Success {
+				reschedule = false
+				preBind := task.context.PreBind(pod.Name, nodeName)
+				if preBind != nil && !preBind.Success {
+					reschedule = true
+					task.context.Unreserve(pod.Name, nodeName)
+				}
 			}
-			log.Log(log.ShimCacheTask).Error("bind volumes to pod failed, retrying",
-				zap.String("taskID", task.taskID), zap.Error(err))
-			return true
-		}, func() error {
-			return task.context.bindPodVolumes(pod)
-		}); err != nil {
-			log.Log(log.ShimCacheTask).Error("bind volumes to pod failed after retries",
-				zap.String("taskID", task.taskID), zap.Error(err))
-			// release task lock before calling rescheduleOnBindFailure to avoid deadlock
-			task.lock.Unlock()
-			task.rescheduleOnBindFailure(allocationKey, nodeName, "PodVolumesBindFailure",
-				fmt.Sprintf("Failed to bind volumes for %s on node %s, it will be retried", alias, nodeName))
-			return
+			if reschedule {
+				task.rescheduleOnBindFailure(allocationKey, nodeName, "PodDRABindFailure",
+					fmt.Sprintf("Failed to bind dra for %s on node %s, it will be retried", alias, nodeName))
+				return
+			}
 		}
-		log.Log(log.ShimCacheTask).Debug("bind pod",
-			zap.String("podName", pod.Name),
-			zap.String("podUID", string(pod.UID)))
 
-		if err := retry.OnError(retryBackoff, func(err error) bool {
-			log.Log(log.ShimCacheTask).Error("bind pod to node failed, retrying",
-				zap.String("taskID", task.taskID), zap.Error(err))
-			return true
-		}, func() error {
-			return task.context.apiProvider.GetAPIs().KubeClient.Bind(pod, nodeName)
-		}); err != nil {
-			log.Log(log.ShimCacheTask).Error("bind pod to node failed after retries",
-				zap.String("taskID", task.taskID), zap.Error(err))
-			task.lock.Unlock()
-			task.rescheduleOnBindFailure(allocationKey, nodeName, "PodBindFailure",
-				fmt.Sprintf("Failed to bind %s to node %s, it will be retried", alias, nodeName))
-			return
+		// Bind Pod Volumes
+		if len(pod.Spec.Volumes) > 0 {
+			// before binding pod to node, first bind volumes to pod
+			log.Log(log.ShimCacheTask).Debug("bind pod volumes",
+				zap.String("podName", pod.Name),
+				zap.String("podUID", string(pod.UID)))
+			if err := retry.OnError(retryBackoff, func(err error) bool {
+				if strings.HasPrefix(err.Error(), "binding volumes:") {
+					log.Log(log.ShimCacheTask).Warn("bind volumes to pod failed due to volume binding error, stopping retries",
+						zap.String("taskID", task.taskID), zap.Error(err))
+					return false
+				}
+				log.Log(log.ShimCacheTask).Error("bind volumes to pod failed, retrying",
+					zap.String("taskID", task.taskID), zap.Error(err))
+				return true
+			}, func() error {
+				return task.context.bindPodVolumes(pod)
+			}); err != nil {
+				log.Log(log.ShimCacheTask).Error("bind volumes to pod failed after retries",
+					zap.String("taskID", task.taskID), zap.Error(err))
+				// release task lock before calling rescheduleOnBindFailure to avoid deadlock
+				task.lock.Unlock()
+				task.rescheduleOnBindFailure(allocationKey, nodeName, "PodVolumesBindFailure",
+					fmt.Sprintf("Failed to bind volumes for %s on node %s, it will be retried", alias, nodeName))
+				return
+			}
+			log.Log(log.ShimCacheTask).Debug("bind pod",
+				zap.String("podName", pod.Name),
+				zap.String("podUID", string(pod.UID)))
+
+			if err := retry.OnError(retryBackoff, func(err error) bool {
+				log.Log(log.ShimCacheTask).Error("bind pod to node failed, retrying",
+					zap.String("taskID", task.taskID), zap.Error(err))
+				return true
+			}, func() error {
+				return task.context.apiProvider.GetAPIs().KubeClient.Bind(pod, nodeName)
+			}); err != nil {
+				log.Log(log.ShimCacheTask).Error("bind pod to node failed after retries",
+					zap.String("taskID", task.taskID), zap.Error(err))
+				task.lock.Unlock()
+				task.rescheduleOnBindFailure(allocationKey, nodeName, "PodBindFailure",
+					fmt.Sprintf("Failed to bind %s to node %s, it will be retried", alias, nodeName))
+				return
+			}
+			// post a message to indicate the pod gets its allocation
+			events.GetRecorder().Eventf(pod.DeepCopy(),
+				nil, v1.EventTypeNormal, "Scheduled", "Scheduled",
+				"Successfully assigned %s to node %s", alias, nodeName)
+			log.Log(log.ShimCacheTask).Info("successfully bound pod", zap.String("podName", pod.Name))
+
 		}
-		// post a message to indicate the pod gets its allocation
-		events.GetRecorder().Eventf(pod.DeepCopy(),
-			nil, v1.EventTypeNormal, "Scheduled", "Scheduled",
-			"Successfully assigned %s to node %s", alias, nodeName)
-		log.Log(log.ShimCacheTask).Info("successfully bound pod", zap.String("podName", pod.Name))
-
 		task.schedulingState = TaskSchedAllocated
 
 		dispatcher.Dispatch(NewBindTaskEvent(task.applicationID, task.taskID))
@@ -691,12 +718,14 @@ func (task *Task) rollbackAllocation(podCopy *v1.Pod, appID, partition, allocati
 	events.GetRecorder().Eventf(podCopy, nil,
 		v1.EventTypeWarning, eventReason, eventReason, eventMsg)
 
-	// Revert any PV/PVC assumptions made by the volume binder. Idempotent: safe to call
-	// even if AssumePodVolumes was never reached or already cleaned up internally.
-	task.context.RevertPodVolumeAssumptions(allocationKey, nodeID)
+	if len(podCopy.Spec.Volumes) > 0 {
+		// Revert any PV/PVC assumptions made by the volume binder. Idempotent: safe to call
+		// even if AssumePodVolumes was never reached or already cleaned up internally.
+		task.context.RevertPodVolumeAssumptions(allocationKey, nodeID)
 
-	// ForgetPod is idempotent: removes the pod from the assumed-pods cache.
-	task.context.ForgetPod(allocationKey)
+		// ForgetPod is idempotent: removes the pod from the assumed-pods cache.
+		task.context.ForgetPod(allocationKey)
+	}
 
 	// Notify the core to roll back the allocation to a pending ask.
 	if schedulerAPI := task.context.apiProvider.GetAPIs().SchedulerAPI; schedulerAPI != nil {

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -1085,6 +1085,7 @@ func TestPostTaskAllocated_BindRetrySucceeds(t *testing.T) {
 	events.SetRecorder(events.NewMockedRecorder())
 	defer events.SetRecorder(events.NewMockedRecorder())
 	defer setShortBindBackoff(5)()
+	dispatcher.Start()
 
 	var bindCalls atomic.Int32
 	apiProvider.MockBindFn(func(_ *v1.Pod, _ string) error {

--- a/pkg/plugin/predicates/predicate_manager.go
+++ b/pkg/plugin/predicates/predicate_manager.go
@@ -52,6 +52,12 @@ type PredicateManager interface {
 	// PreemptionPredicates checks if a pod can be scheduled on the node by preempting victims.
 	// Returns the victim index that allows the pod to fit, or -1 if none.
 	PreemptionPredicates(pod *v1.Pod, node *framework.NodeInfo, victims []*v1.Pod, startIndex int) int
+	// Reserve Binding cycle - Reserve the node
+	Reserve(pod *v1.Pod, cycleState *framework.CycleState, node *framework.NodeInfo) (string, error)
+	// PreBind Binding cycle - PreBind the node
+	PreBind(pod *v1.Pod, cycleState *framework.CycleState, node *framework.NodeInfo) (string, error)
+	// Unreserve Binding cycle - Unreserve the node
+	Unreserve(pod *v1.Pod, cycleState *framework.CycleState, node *framework.NodeInfo)
 }
 
 var _ PredicateManager = &predicateManagerImpl{}
@@ -63,6 +69,8 @@ type predicateManagerImpl struct {
 	allocationPreFilters  *[]fwk.PreFilterPlugin
 	reservationFilters    *[]fwk.FilterPlugin
 	allocationFilters     *[]fwk.FilterPlugin
+	reservePlugins        *[]fwk.ReservePlugin
+	preBindPlugins        *[]fwk.PreBindPlugin
 	klogger               klog.Logger
 	sharedLister          fwk.SharedLister
 }
@@ -176,6 +184,45 @@ func (p *predicateManagerImpl) PreemptionPredicates(pod *v1.Pod, node *framework
 		zap.String("podUID", string(pod.UID)),
 		zap.String("nodeID", node.Node().Name))
 	return -1
+}
+
+func (p *predicateManagerImpl) Reserve(pod *v1.Pod, cycleState *framework.CycleState, node *framework.NodeInfo) (string, error) {
+	reservePl := *p.reservePlugins
+	for _, pl := range reservePl {
+		plugin := pl.Name()
+		status := pl.Reserve(context.Background(), cycleState, pod, node.Node().Name)
+		if status.IsError() {
+			log.Log(log.ShimPredicates).Error("failed running Reserve plugin",
+				zap.String("pluginName", plugin),
+				zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+				zap.String("message", status.Message()))
+			return plugin, errors.New(status.Message())
+		}
+	}
+	return "", nil
+}
+
+func (p *predicateManagerImpl) PreBind(pod *v1.Pod, cycleState *framework.CycleState, node *framework.NodeInfo) (string, error) {
+	preBindPl := *p.preBindPlugins
+	for _, pl := range preBindPl {
+		plugin := pl.Name()
+		status := pl.PreBind(context.Background(), cycleState, pod, node.Node().Name)
+		if status.IsError() {
+			log.Log(log.ShimPredicates).Error("failed running PreBind plugin",
+				zap.String("pluginName", plugin),
+				zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+				zap.String("message", status.Message()))
+			return plugin, errors.New(status.Message())
+		}
+	}
+	return "", nil
+}
+
+func (p *predicateManagerImpl) Unreserve(pod *v1.Pod, cycleState *framework.CycleState, node *framework.NodeInfo) {
+	reservePl := *p.reservePlugins
+	for _, pl := range reservePl {
+		pl.Unreserve(context.Background(), cycleState, pod, node.Node().Name)
+	}
 }
 
 func (p *predicateManagerImpl) removePodFromNodeNoFail(node fwk.NodeInfo, pod *v1.Pod) {
@@ -372,7 +419,15 @@ func NewPredicateManager(handle fwk.Handle) PredicateManager {
 		"*": true,
 	}
 
-	return newPredicateManagerInternal(handle, reservationPreFilters, allocationPreFilters, reservationFilters, allocationFilters)
+	reservePlugins := map[string]bool{
+		names.DynamicResources: true,
+	}
+
+	preBindPlugins := map[string]bool{
+		names.DynamicResources: true,
+	}
+
+	return newPredicateManagerInternal(handle, reservationPreFilters, allocationPreFilters, reservationFilters, allocationFilters, reservePlugins, preBindPlugins)
 }
 
 func newPredicateManagerInternal(
@@ -380,7 +435,9 @@ func newPredicateManagerInternal(
 	reservationPreFilters map[string]bool,
 	allocationPreFilters map[string]bool,
 	reservationFilters map[string]bool,
-	allocationFilters map[string]bool) *predicateManagerImpl {
+	allocationFilters map[string]bool,
+	reservePluginsMap map[string]bool,
+	preBindPluginsMap map[string]bool) *predicateManagerImpl {
 	// ensure K8s scheduler metrics have been initialized in YK standalone mode to avoid SIGSEGV
 	if metrics.Goroutines == nil {
 		metrics.InitMetrics()
@@ -406,16 +463,23 @@ func newPredicateManagerInternal(
 	resFilt := make([]fwk.Plugin, 0)
 	allocFilt := make([]fwk.Plugin, 0)
 
+	reserve := make([]fwk.Plugin, 0)
+	preBind := make([]fwk.Plugin, 0)
+
 	addPlugins("PreFilter", createdPlugins, &resPre, reservationPreFilters)
 	addPlugins("PreFilter", createdPlugins, &allocPre, allocationPreFilters)
 	addPlugins("Filter", createdPlugins, &resFilt, reservationFilters)
 	addPlugins("Filter", createdPlugins, &allocFilt, allocationFilters)
+	addPlugins("Reserve", createdPlugins, &reserve, reservePluginsMap)
+	addPlugins("PreBind", createdPlugins, &preBind, preBindPluginsMap)
 
 	pm := &predicateManagerImpl{
 		reservationPreFilters: preFilterPlugins(resPre),
 		allocationPreFilters:  preFilterPlugins(allocPre),
 		reservationFilters:    filterPlugins(resFilt),
 		allocationFilters:     filterPlugins(allocFilt),
+		reservePlugins:        reservePlugins(reserve),
+		preBindPlugins:        preBindPlugins(preBind),
 		klogger:               klog.NewKlogr(),
 		sharedLister:          handle.SnapshotSharedLister(),
 	}
@@ -440,6 +504,28 @@ func filterPlugins(plugins []fwk.Plugin) *[]fwk.FilterPlugin {
 		filter, ok := plugin.(fwk.FilterPlugin)
 		if ok {
 			result = append(result, filter)
+		}
+	}
+	return &result
+}
+
+func reservePlugins(plugins []fwk.Plugin) *[]fwk.ReservePlugin {
+	result := make([]fwk.ReservePlugin, 0)
+	for _, plugin := range plugins {
+		reserve, ok := plugin.(fwk.ReservePlugin)
+		if ok {
+			result = append(result, reserve)
+		}
+	}
+	return &result
+}
+
+func preBindPlugins(plugins []fwk.Plugin) *[]fwk.PreBindPlugin {
+	result := make([]fwk.PreBindPlugin, 0)
+	for _, plugin := range plugins {
+		preBind, ok := plugin.(fwk.PreBindPlugin)
+		if ok {
+			result = append(result, preBind)
 		}
 	}
 	return &result

--- a/pkg/plugin/predicates/predicate_manager_test.go
+++ b/pkg/plugin/predicates/predicate_manager_test.go
@@ -58,7 +58,7 @@ var (
 func TestPreemptionPredicatesEmpty(t *testing.T) {
 	ep := enabledPlugins(noderesources.Name)
 	handle, _ := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 
 	pod := &v1.Pod{}
 	node := framework.NewNodeInfo()
@@ -71,7 +71,7 @@ func TestPreemptionPredicatesEmpty(t *testing.T) {
 func TestPreemptionPredicates(t *testing.T) {
 	ep := enabledPlugins(noderesources.Name)
 	handle, _ := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 
 	pod := newResourcePod(framework.Resource{MilliCPU: 500, Memory: 5000000})
 	pod.Name = "smallpod"
@@ -119,7 +119,7 @@ func TestPreemptionPredicates(t *testing.T) {
 func TestEventsToRegister(t *testing.T) {
 	ep := enabledPlugins(nodename.Name, interpodaffinity.Name, podtopologyspread.Name)
 	handle, _ := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 
 	var queueingHintFn fwk.QueueingHintFn = func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
 		// illegal sentinel to ensure we called the correct function
@@ -141,7 +141,7 @@ func TestEventsToRegister(t *testing.T) {
 func TestPodFitsHost(t *testing.T) {
 	ep := enabledPlugins(nodename.Name)
 	handle, _ := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 	tests := []struct {
 		pod  *v1.Pod
 		node *v1.Node
@@ -224,7 +224,7 @@ func newPod(host string, hostPortInfos ...string) *v1.Pod {
 func TestPodFitsHostPorts(t *testing.T) {
 	ep := enabledPlugins(nodeports.Name)
 	handle, _ := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 
 	tests := []struct {
 		pod      *v1.Pod
@@ -338,7 +338,7 @@ func TestPodFitsHostPorts(t *testing.T) {
 func TestPodFitsSelector(t *testing.T) {
 	ep := enabledPlugins(nodeports.Name, nodeaffinity.Name)
 	handle, _ := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 
 	tests := []struct {
 		pod      *v1.Pod
@@ -1095,7 +1095,7 @@ func TestEnableOptionalKubernetesFeatureGates(t *testing.T) {
 func TestRunGeneralPredicates(t *testing.T) {
 	ep := enabledPlugins(noderesources.Name, nodename.Name, nodeports.Name, nodevolumelimits.CSIName)
 	handle, _ := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 
 	resourceTests := []struct {
 		pod      *v1.Pod
@@ -1171,7 +1171,7 @@ func TestRunGeneralPredicates(t *testing.T) {
 func TestInterPodAffinity(t *testing.T) {
 	ep := enabledPlugins(interpodaffinity.Name, nodeaffinity.Name)
 	handle, lister := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 
 	podLabel := map[string]string{"service": "securityscan"}
 	labels1 := map[string]string{
@@ -2129,13 +2129,13 @@ func TestReserveAlloc(t *testing.T) {
 	// no predicates configured that are run by reservations
 	ep := enabledPlugins()
 	handle, _ := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 	_, err := predicateManager.Predicates(pod, nodeInfo, false)
 	assert.NilError(t, err, "error should have been nil, no predicates given")
 
 	// add one predicate also run by reservations
 	ep[nodeunschedulable.Name] = true
-	predicateManager = newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager = newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 	_, err = predicateManager.Predicates(pod, nodeInfo, false)
 	assert.NilError(t, err, "error should have been nil, node is schedulable")
 
@@ -2170,7 +2170,7 @@ func TestReserveNodeSelector(t *testing.T) {
 
 	ep := enabledPlugins(nodename.Name, nodeports.Name, podtopologyspread.Name, nodeaffinity.Name)
 	handle, _ := getFrameworkHandle()
-	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep)
+	predicateManager := newPredicateManagerInternal(handle, ep, ep, ep, ep, nil, nil)
 
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
### Description

Similar to how predicate checks are preformed K8s PreFilter & Filter Plugins to choose the node during Scheduling cycle, perform DRA bindings using K8s Reserve & PreBind Plugins once the task is allocated. 

Reserve() reserve the resource claims requested by the pod on that specific node
PreBind() Bind the resource claims reserved in previous step
Unreserve() In case of any failures in PreBind(), undo or free up the reserved resource claims done earlier for the pod.

In case of any failures in any of these 3 steps, reschedule the pod by notifying the Core using appropriate SI message (TerminationType_SCHEDULING_FAILED_ON_RM).

Note: Dependent on https://github.com/apache/yunikorn-k8shim/pull/1043. Once that goes in, need to refine this PR further more. 

### Type of change
Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
- [X] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3392

- [X] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
