### PR TITLE
[YUNIKORN-3408] Adopt the vet-lock static lock analyser (annotations + build wiring)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,10 +23,20 @@ jobs:
         with:
           go-version-file: .go_version
           check-latest: true
+      - name: Cache and Restore required tools
+        uses: actions/cache@v5
+        with:
+          path: |
+            tools
+          key: ${{ runner.os }}-tools-${{ hashFiles('Makefile', 'scripts/vetlock/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-tools-
       - name: Check license
         run: make license-check
       - name: Go lint
         run: make lint
+      - name: Check lock annotations
+        run: make vetlock
       - name: Run Version Check
         run: make pseudo
       - name: Run ShellCheck

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 .PHONY: run build build_web_test_server_prod build_web_test_server_dev
 # test targets
 .PHONY: test_all test bench fsm_graph clean distclean arch
-.PHONY: lint check_scripts license-check go-license-check pseudo
+.PHONY: lint vetlock vetlock-toolchain check_scripts license-check go-license-check pseudo
 # e2e test targets
 .PHONY: print_kubectl_version print_kind_version print_helm_version
 .PHONY: e2e_test kind-e2e start-cluster stop-cluster
@@ -177,6 +177,28 @@ GOLANGCI_LINT_ARCHIVEBASE=golangci-lint-$(GOLANGCI_LINT_VERSION)-$(OS)-$(EXEC_AR
 GOLANGCI_LINT_ARCHIVE=$(GOLANGCI_LINT_ARCHIVEBASE).tar.gz
 export PATH := $(BASE_DIR)/$(GOLANGCI_LINT_PATH):$(PATH)
 
+# vetlock
+# The version is pinned in the go.mod of the tools module: bump it with "go get" in that directory
+# followed by "go mod tidy".
+VETLOCK_MOD_DIR=scripts/vetlock
+VETLOCK_VERSION=$(shell "$(GO)" list -C "$(BASE_DIR)/$(VETLOCK_MOD_DIR)" -m -f '{{ .Version }}' github.com/tigerquoll/vet-lock)
+# The path is keyed on the go version as well as the tool version: the export data of a vet tool
+# must match the toolchain that runs "go vet", so a go upgrade must rebuild the tool.
+VETLOCK_PATH=$(TOOLS_DIR)/vetlock-$(VETLOCK_VERSION)-$(shell "$(GO)" env GOVERSION)
+VETLOCK_BIN=$(VETLOCK_PATH)/vet-lock
+# The go version the tools module needs against the version that is running, both without the
+# "go" prefix. Read from the go directive so that a tool update cannot make these drift.
+VETLOCK_GO_REQUIRED=$(shell "$(GO)" list -C "$(BASE_DIR)/$(VETLOCK_MOD_DIR)" -m -f '{{ .GoVersion }}')
+VETLOCK_GO_CURRENT=$(patsubst go%,%,$(shell "$(GO)" env GOVERSION))
+# Fixture holding a known lock violation, see the vetlock target.
+VETLOCK_CANARY=pkg/locking/checklocks_canary.go
+# The messages the canary must produce, one per class of violation it holds.
+# The last two are the derived facts: an exclusion the canary does not state, and a field guard
+# the canary states on the type rather than on the field. Both are required by name because the
+# other messages here would keep the canary green if either derivation were lost, and 179
+# annotations were deleted from this repository on the strength of them.
+VETLOCK_CANARY_MESSAGES := "invalid field access" "must not hold" "already locked" "to call callbackSelfLocking" "guarded read races" "a wait under a lock" "to call derivedSelfLocking" "when accessing structGuardedValue"
+
 # kubectl
 KUBECTL_VERSION=$(shell go list -m 'k8s.io/kubernetes' | cut -d' ' -f 2)
 KUBECTL_PATH=$(TOOLS_DIR)/kubectl-$(KUBECTL_VERSION)
@@ -250,7 +272,7 @@ SCHEDULER_INSTRUMENTED_TAG := $(SCHEDULER_TAG)-instrumented
 all:
 	$(MAKE) -C $(dir $(BASE_DIR)) build
 
-test_all: lint check_scripts license-check go-license-check pseudo test
+test_all: lint vetlock check_scripts license-check go-license-check pseudo test
 
 # Print tools version
 print_kubectl_version:
@@ -261,7 +283,7 @@ print_helm_version:
 	@echo $(HELM_VERSION)
 
 # Install tools
-tools: $(SHELLCHECK_BIN) $(GOLANGCI_LINT_BIN) $(KUBECTL_BIN) $(KIND_BIN) $(HELM_BIN) $(GO_LICENSES_BIN) $(GINKGO_BIN)
+tools: $(SHELLCHECK_BIN) $(GOLANGCI_LINT_BIN) $(KUBECTL_BIN) $(KIND_BIN) $(HELM_BIN) $(GO_LICENSES_BIN) $(GINKGO_BIN) $(VETLOCK_BIN)
 
 # Install shellcheck
 $(SHELLCHECK_BIN):
@@ -311,11 +333,104 @@ $(GINKGO_BIN):
 	@mkdir -p "$(GINKGO_PATH)"
 	@GOBIN="$(BASE_DIR)/$(GINKGO_PATH)" "$(GO)" install "github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)"
 
+# Install vetlock
+# Built from the tools module in $(VETLOCK_MOD_DIR): the analyser is a tool only dependency and
+# must not end up in the go.mod of the shim. Building from a module instead of using
+# "go install pkg@version" pins the whole dependency tree via its go.sum.
+$(VETLOCK_BIN): | vetlock-toolchain
+	@echo "installing vet-lock $(VETLOCK_VERSION)"
+	@mkdir -p "$(VETLOCK_PATH)"
+	@"$(GO)" build -C "$(BASE_DIR)/$(VETLOCK_MOD_DIR)" \
+		-o "$(BASE_DIR)/$(VETLOCK_BIN)" github.com/tigerquoll/vet-lock/cmd/vet-lock
+
+# Refuse to build or run the analyser with a go that is older than the tools module needs.
+# A vet tool must be built with the toolchain that runs "go vet" or the export data does not
+# match. Letting the toolchain switch happen would do exactly that: the tool would be built
+# with the newer go while "go vet" keeps running on the older one. An order only prerequisite
+# of the binary, so that the check runs before the build and before every use without making
+# the binary itself out of date.
+vetlock-toolchain:
+	@if [ "$(VETLOCK_GO_CURRENT)" != "$(VETLOCK_GO_REQUIRED)" ] && \
+		[ "$$(printf '%s\n%s\n' "$(VETLOCK_GO_CURRENT)" "$(VETLOCK_GO_REQUIRED)" | sort -V | head -1)" = "$(VETLOCK_GO_CURRENT)" ]; then \
+		echo "vet-lock needs go $(VETLOCK_GO_REQUIRED) or later, found go $(VETLOCK_GO_CURRENT)"; \
+		echo "  the analyser must be built with the same toolchain that runs \"go vet\": upgrade go"; \
+		exit 1; \
+	fi
+
 # Run lint against the previous commit for PR and branch build
 # In dev setup look at all changes on top of master
 lint: $(GOLANGCI_LINT_BIN)
 	@echo "running golangci-lint"
 	@"${GOLANGCI_LINT_BIN}" run
+
+# Check the lock annotations. The list covers every package under pkg/ now that all locked
+# structs there are annotated, it is kept as a variable because a new package with locks in it
+# has to be annotated before it can be checked: an unannotated package still triggers lock
+# balance errors which would fail the check. The e2e helpers under test/ are outside the list,
+# they are test scaffolding and are not annotated. Note that the "+checklocks:" requirements of
+# a function are only enforced for callers in the listed packages.
+# Only the non test files of each package are checked, go vet has no way to exclude test
+# files so they are passed to it explicitly. The inferred lock analysis is turned off, it
+# only produces suggestions, and those are unstable and cannot always be acted upon.
+# The three analyses are named rather than left to the defaults of the tool, so that a release
+# that changes what runs by default cannot silently stop one of them:
+#   checklocks    guarded fields and the lock preconditions of a function
+#   lockstringer  lazily evaluated methods reading guarded fields
+#   lockblocking  waits taken while a declared lock class is held
+# "lockorder" is deliberately not named: the order in which the shim nests its lock classes is a
+# separate piece of work. The "+lockclass" annotations it shares are still carried, because
+# "lockblocking" reports a wait made while a CLASSED lock is held and a type without a class
+# leaves it silent.
+# The listing is a single pass, one line of file names per package, and a listing that fails
+# aborts the target: a package that cannot be loaded must not be skipped silently. Every
+# package is checked before the target fails so that one violation does not hide the rest,
+# which is why the loop carries a status rather than stopping at the first failure. The loop
+# is the last element of the pipeline and exits with that status, the pipeline takes it as
+# its own, otherwise it would be lost with the subshell the loop runs in.
+VETLOCK_ANALYZERS := -checklocks -lockstringer -lockblocking
+VETLOCK_FLAGS := $(VETLOCK_ANALYZERS) -checklocks.inferred=false
+VETLOCK_PACKAGES := $(REPO)/...
+vetlock: $(VETLOCK_BIN)
+	@echo "running vet-lock"
+	@list=$$("$(GO)" list -f '{{$$dir := .Dir}}{{range .GoFiles}}{{$$dir}}/{{.}} {{end}}' $(VETLOCK_PACKAGES)) || exit 1 ; \
+	printf '%s\n' "$$list" | { \
+		status=0 ; \
+		while IFS= read -r files ; do \
+			[ -n "$$files" ] || continue ; \
+			"$(GO)" vet "-vettool=$(BASE_DIR)/$(VETLOCK_BIN)" $(VETLOCK_FLAGS) $$files || status=1 ; \
+		done ; \
+		exit $$status ; \
+	}
+# Prove that the analysis still detects anything at all. The canary is a file with known
+# violations that no build compiles, it is passed explicitly which makes the analysis ignore
+# its build constraint. It is checked together with the locking package as it uses the locks
+# defined there. Both the exit code and the messages are checked: a canary that fails to build
+# or is not found would otherwise look exactly like a violation that was caught. Every class of
+# violation is required separately, one per analysis plus the extra checklocks ones, as they are
+# detected independently: an analysis that stops reporting or that is dropped from the command
+# line above would otherwise leave the canary green on the strength of the other messages.
+# The number of diagnostics is checked against the number of messages as well, so that the cases
+# the canary holds to be clean stay clean: a report that grows is a false positive the fixture
+# says must never be raised, and the messages above would keep matching through it.
+	@canary="$$("$(GO)" list -f '{{$$dir := .Dir}}{{range .GoFiles}}{{$$dir}}/{{.}} {{end}}' $(REPO)/locking) $(BASE_DIR)/$(VETLOCK_CANARY)" ; \
+	report=$$("$(GO)" vet "-vettool=$(BASE_DIR)/$(VETLOCK_BIN)" $(VETLOCK_FLAGS) $$canary 2>&1) ; \
+	found=$$? ; \
+	missing="" ; \
+	for message in $(VETLOCK_CANARY_MESSAGES) ; do \
+		printf '%s' "$$report" | grep -q "$$message" || missing="$$missing $$message" ; \
+	done ; \
+	count=$$(printf '%s\n' "$$report" | grep -c -E '^.+:[0-9]+:[0-9]+: ' || true) ; \
+	expected=$$(set -- $(VETLOCK_CANARY_MESSAGES) ; echo $$#) ; \
+	if [ $$found -eq 0 ] || [ -n "$$missing" ] ; then \
+		echo "vetlock canary failed: analyzer did not detect a known violation:$$missing" ; \
+		printf '%s\n' "$$report" ; \
+		exit 1 ; \
+	fi ; \
+	if [ "$$count" -ne "$$expected" ] ; then \
+		echo "vetlock canary failed: expected $$expected diagnostics, got $$count" ; \
+		printf '%s\n' "$$report" ; \
+		exit 1 ; \
+	fi
 
 # Check scripts
 ALLSCRIPTS := $(shell find . -not \( -path ./spark -prune \) -not \( -path ./tools -prune \) -not \( -path ./build -prune \) -name '*.sh')

--- a/pkg/admission/conf/am_conf.go
+++ b/pkg/admission/conf/am_conf.go
@@ -82,11 +82,13 @@ const (
 	DefaultAccessControlExternalGroups   = ""
 )
 
+// +checklocksguardedby:lock
 type AdmissionControllerConf struct {
-	namespace  string
+	// +checklocksunguarded
+	namespace string
+	// +checklocksunguarded
 	kubeConfig string
 
-	// mutable values require locking
 	enableConfigHotRefresh  bool
 	policyGroup             string
 	amServiceName           string
@@ -224,6 +226,7 @@ type configMapUpdateHandler struct {
 	conf *AdmissionControllerConf
 }
 
+// +checklocksexclude:h.conf.lock
 func (h *configMapUpdateHandler) OnAdd(obj interface{}, _ bool) {
 	cm := utils.Convert2ConfigMap(obj)
 	if idx, ok := h.configMapIndex(cm); ok {
@@ -231,6 +234,7 @@ func (h *configMapUpdateHandler) OnAdd(obj interface{}, _ bool) {
 	}
 }
 
+// +checklocksexclude:h.conf.lock
 func (h *configMapUpdateHandler) OnUpdate(_, newObj interface{}) {
 	cm := utils.Convert2ConfigMap(newObj)
 	if idx, ok := h.configMapIndex(cm); ok {
@@ -238,6 +242,7 @@ func (h *configMapUpdateHandler) OnUpdate(_, newObj interface{}) {
 	}
 }
 
+// +checklocksexclude:h.conf.lock
 func (h *configMapUpdateHandler) OnDelete(obj interface{}) {
 	var cm *v1.ConfigMap
 	switch t := obj.(type) {
@@ -335,6 +340,7 @@ func (acc *AdmissionControllerConf) DumpConfiguration() {
 	acc.dumpConfigurationInternal()
 }
 
+// +checklocksread:acc.lock
 func (acc *AdmissionControllerConf) dumpConfigurationInternal() {
 	log.Log(log.AdmissionConf).Info("Loaded admission controller configuration",
 		zap.String("namespace", acc.namespace),

--- a/pkg/admission/namespace_cache.go
+++ b/pkg/admission/namespace_cache.go
@@ -31,6 +31,7 @@ import (
 )
 
 type NamespaceCache struct {
+	// +checklocks:RWMutex
 	nameSpaces map[string]nsFlags
 
 	locking.RWMutex
@@ -109,6 +110,7 @@ type namespaceUpdateHandler struct {
 // OnAdd adds or replaces the namespace entry in the cache.
 // The cached value is only the resulting value of the annotation, not the whole namespace object.
 // An empty string for the Name is technically possible but should not occur.
+// +checklocksexclude:h.cache.RWMutex
 func (h *namespaceUpdateHandler) OnAdd(obj interface{}, _ bool) {
 	ns := convert2Namespace(obj)
 	if ns == nil {
@@ -122,11 +124,13 @@ func (h *namespaceUpdateHandler) OnAdd(obj interface{}, _ bool) {
 }
 
 // OnUpdate calls OnAdd for processing the namespace cache update.
+// +checklocksexclude:h.cache.RWMutex
 func (h *namespaceUpdateHandler) OnUpdate(_, newObj interface{}) {
 	h.OnAdd(newObj, false)
 }
 
 // OnDelete removes the namespace from the cache.
+// +checklocksexclude:h.cache.RWMutex
 func (h *namespaceUpdateHandler) OnDelete(obj interface{}) {
 	var ns *v1.Namespace
 	switch t := obj.(type) {

--- a/pkg/admission/priority_class_cache.go
+++ b/pkg/admission/priority_class_cache.go
@@ -32,6 +32,7 @@ import (
 )
 
 type PriorityClassCache struct {
+	// +checklocks:RWMutex
 	priorityClasses map[string]bool
 
 	locking.RWMutex
@@ -80,6 +81,7 @@ type priorityClassUpdateHandler struct {
 // OnAdd adds or replaces the priority class entry in the cache.
 // The cached value is only the resulting value of the annotation, not the whole PriorityClass object.
 // An empty string for the Name is technically possible but should not occur.
+// +checklocksexclude:h.cache.RWMutex
 func (h *priorityClassUpdateHandler) OnAdd(obj interface{}, _ bool) {
 	pc := utils.Convert2PriorityClass(obj)
 	if pc == nil {
@@ -93,11 +95,13 @@ func (h *priorityClassUpdateHandler) OnAdd(obj interface{}, _ bool) {
 }
 
 // OnUpdate calls OnAdd for processing the PriorityClass cache update.
+// +checklocksexclude:h.cache.RWMutex
 func (h *priorityClassUpdateHandler) OnUpdate(_, newObj interface{}) {
 	h.OnAdd(newObj, false)
 }
 
 // OnDelete removes the PriorityClass from the cache.
+// +checklocksexclude:h.cache.RWMutex
 func (h *priorityClassUpdateHandler) OnDelete(obj interface{}) {
 	var pc *schedulingv1.PriorityClass
 	switch t := obj.(type) {

--- a/pkg/admission/webhook_manager.go
+++ b/pkg/admission/webhook_manager.go
@@ -68,6 +68,10 @@ type WebhookManager interface {
 	WaitForCertificateExpiration()
 }
 
+// The class exists so that lockblocking can see this lock is held. It is deliberately outside
+// the order taxonomy that pkg/locking declares and the runtime check carries: that taxonomy is
+// the scheduler cache objects, and this class has no ordering relation to any of them.
+// +lockclass:admission.WebhookManager
 type webhookManagerImpl struct {
 	conf             *conf.AdmissionControllerConf
 	serviceName      string
@@ -75,10 +79,15 @@ type webhookManagerImpl struct {
 	conflictAttempts int
 
 	// mutable values (require locking)
-	caCert1    *x509.Certificate
-	caKey1     *rsa.PrivateKey
-	caCert2    *x509.Certificate
-	caKey2     *rsa.PrivateKey
+	// +checklocks:RWMutex
+	caCert1 *x509.Certificate
+	// +checklocks:RWMutex
+	caKey1 *rsa.PrivateKey
+	// +checklocks:RWMutex
+	caCert2 *x509.Certificate
+	// +checklocks:RWMutex
+	caKey2 *rsa.PrivateKey
+	// +checklocks:RWMutex
 	expiration time.Time
 
 	locking.RWMutex
@@ -660,7 +669,10 @@ func (wm *webhookManagerImpl) loadCaCertificatesInternal() (bool, error) {
 	defer wm.Unlock()
 
 	namespace := wm.conf.GetNamespace()
-	secret, err := wm.clientset.CoreV1().Secrets(namespace).Get(ctx.Background(), secretName, metav1.GetOptions{})
+	// the Secrets round trip runs under the write lock so the certificate fields publish
+	// atomically; every reader runs after the loader returns on the same goroutine, only the
+	// expiry timer reads across goroutines and it starts after the load
+	secret, err := wm.clientset.CoreV1().Secrets(namespace).Get(ctx.Background(), secretName, metav1.GetOptions{}) // +lockblockingignore
 	if err != nil {
 		log.Log(log.AdmissionWebhook).Error("Unable to retrieve admission-controller-secrets secrets", zap.Error(err))
 		return false, err
@@ -736,7 +748,8 @@ func (wm *webhookManagerImpl) loadCaCertificatesInternal() (bool, error) {
 		secret.Data[caCert2Path] = *cert2Pem
 		secret.Data[caPrivateKey2Path] = *key2Pem
 
-		_, err = wm.clientset.CoreV1().Secrets(namespace).Update(ctx.Background(), secret, metav1.UpdateOptions{})
+		// same as the read above
+		_, err = wm.clientset.CoreV1().Secrets(namespace).Update(ctx.Background(), secret, metav1.UpdateOptions{}) // +lockblockingignore
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				// signal to caller that we need to be run again

--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -43,35 +43,52 @@ import (
 	"github.com/apache/yunikorn-scheduler-interface/lib/go/si"
 )
 
+// +lockclass:cache.Application
 type Application struct {
-	applicationID              string
-	queue                      string
-	partition                  string
-	user                       string
-	groups                     []string
-	taskMap                    map[string]*Task
-	tags                       map[string]string
-	taskGroups                 []TaskGroup
-	taskGroupsDefinition       string
+	applicationID string
+	queue         string
+	partition     string
+	user          string
+	groups        []string
+	// +checklocks:lock
+	taskMap map[string]*Task
+	tags    map[string]string
+	// +checklocks:lock
+	taskGroups []TaskGroup
+	// +checklocks:lock
+	taskGroupsDefinition string
+	// +checklocks:lock
 	schedulingParamsDefinition string
+	// +checklocks:lock
 	placeholderOwnerReferences []metav1.OwnerReference
 	sm                         *fsm.FSM
 	lock                       *locking.RWMutex
 	schedulerAPI               api.SchedulerAPI
-	placeholderAsk             *si.Resource // total placeholder request for the app (all task groups)
-	placeholderTimeoutInSec    int64
-	schedulingStyle            string
-	originatingTask            *Task // Original Pod which creates the requests
-	releaseableTasks           []*Task
-	context                    *Context
+	// +checklocks:lock
+	placeholderAsk *si.Resource // total placeholder request for the app (all task groups)
+	// +checklocks:lock
+	placeholderTimeoutInSec int64
+	// +checklocks:lock
+	schedulingStyle string
+	// +checklocks:lock
+	originatingTask *Task // Original Pod which creates the requests
+	// +checklocks:lock
+	releaseableTasks []*Task
+	context          *Context
 }
 
 const transitionErr = "no transition"
 
+// String must never take the application lock: it is used as a lazily evaluated zap field
+// and is evaluated while the write lock is held, handleSubmitApplicationEvent logs the
+// application while running under handle(). Taking the read lock here deadlocks the
+// submission path.
+// YUNIKORN-3428: taskMap length read without the lock from a lazily evaluated String()
+// +lockstringerignore
 func (app *Application) String() string {
 	return fmt.Sprintf("applicationID: %s, queue: %s, partition: %s,"+
 		" totalNumOfTasks: %d, currentState: %s",
-		app.applicationID, app.queue, app.partition, len(app.taskMap), app.GetApplicationState())
+		app.applicationID, app.queue, app.partition, len(app.taskMap), app.GetApplicationState()) // +checklocksignore
 }
 
 func NewApplication(appID, queueName, user string, groups []string, tags map[string]string, scheduler api.SchedulerAPI) *Application {
@@ -240,6 +257,7 @@ func (app *Application) RemoveTask(taskID string) {
 	app.removeTask(taskID)
 }
 
+// +checklocks:app.lock
 func (app *Application) removeTask(taskID string) {
 	if _, ok := app.taskMap[taskID]; !ok {
 		log.Log(log.ShimCacheApplication).Debug("Attempted to remove non-existent task", zap.String("taskID", taskID))
@@ -285,6 +303,7 @@ func (app *Application) GetPlaceHolderTasks() []*Task {
 	return app.getPlaceHolderTasks()
 }
 
+// +checklocksread:app.lock
 func (app *Application) getPlaceHolderTasks() []*Task {
 	placeholders := make([]*Task, 0)
 	for _, task := range app.taskMap {
@@ -296,6 +315,7 @@ func (app *Application) getPlaceHolderTasks() []*Task {
 	return placeholders
 }
 
+// +checklocksread:app.lock
 func (app *Application) getTasks(state string) []*Task {
 	taskList := make([]*Task, 0)
 	if len(app.taskMap) > 0 {
@@ -323,6 +343,7 @@ func (app *Application) GetTags() map[string]string {
 	return app.tags
 }
 
+// +checklocksread:app.lock
 func (app *Application) getNonTerminatedTaskAlias() []string {
 	var nonTerminatedTaskAlias []string
 	for _, task := range app.taskMap {
@@ -333,6 +354,8 @@ func (app *Application) getNonTerminatedTaskAlias() []string {
 	return nonTerminatedTaskAlias
 }
 
+// YUNIKORN-3428: task map walked without the application lock from outside the cache
+// +checklocksignore
 func (app *Application) AreAllTasksTerminated() bool {
 	return len(app.getNonTerminatedTaskAlias()) == 0
 }
@@ -428,6 +451,7 @@ func (app *Application) scheduleTasks(taskScheduleCondition func(t *Task) bool) 
 	}
 }
 
+// +checklocks:app.lock
 func (app *Application) handleSubmitApplicationEvent() error {
 	log.Log(log.ShimCacheApplication).Info("handle app submission",
 		zap.Stringer("app", app),
@@ -460,6 +484,7 @@ func (app *Application) handleSubmitApplicationEvent() error {
 	return nil
 }
 
+// +checklocksread:app.lock
 func (app *Application) skipReservationStage() bool {
 	// no task groups defined, skip reservation
 	if len(app.taskGroups) == 0 {
@@ -485,6 +510,8 @@ func (app *Application) skipReservationStage() bool {
 	return false
 }
 
+// YUNIKORN-3423: taskGroups/taskMap read without the lock outside the state machine
+// +checklocksignore
 func (app *Application) postAppAccepted() {
 	// if app has taskGroups defined, and it has no allocated tasks,
 	// it goes to the Reserving state before getting to Running.
@@ -509,6 +536,7 @@ func (app *Application) postAppAccepted() {
 
 // onResuming triggered when entering the resuming state which is triggered by the time out of the gang placeholders
 // if SOFT gang scheduling is configured.
+// +checklocks:app.lock
 func (app *Application) onResuming() {
 	if app.originatingTask != nil {
 		events.GetRecorder().Eventf(app.originatingTask.GetTaskPod().DeepCopy(), nil, v1.EventTypeWarning, "GangScheduling",
@@ -519,6 +547,7 @@ func (app *Application) onResuming() {
 // isPlaceholderTimeoutElapsed returns true when the configured placeholder timeout has already
 // elapsed since the application creation time. Used on restart to avoid creating placeholder
 // pods that would immediately time out.
+// +checklocksread:app.lock
 func (app *Application) isPlaceholderTimeoutElapsed() bool {
 	if app.placeholderTimeoutInSec <= 0 {
 		return false
@@ -538,6 +567,7 @@ func (app *Application) isPlaceholderTimeoutElapsed() bool {
 // onReserving triggered when entering the reserving state.
 // During normal operation this creates all the placeholders. During recovery this call could cause the application
 // in the shim and core to progress to the next state.
+// +checklocks:app.lock
 func (app *Application) onReserving() {
 	// if any placeholder already exist during recovery we might need to send
 	// an event to trigger Application state change in the core
@@ -576,8 +606,9 @@ func (app *Application) onReserving() {
 			ev := NewRunApplicationEvent(app.applicationID)
 			dispatcher.Dispatch(ev)
 			// failed at least one placeholder creation progress as a normal application
-			if app.originatingTask != nil {
-				events.GetRecorder().Eventf(app.originatingTask.GetTaskPod().DeepCopy(), nil, v1.EventTypeWarning, "GangScheduling",
+			// YUNIKORN-3429: detached goroutine reads originatingTask after the lock is gone
+			if app.originatingTask != nil { // +checklocksignore
+				events.GetRecorder().Eventf(app.originatingTask.GetTaskPod().DeepCopy(), nil, v1.EventTypeWarning, "GangScheduling", // +checklocksignore
 					"PlaceholderCreateFailed", "Application %s fall back to normal scheduling", app.applicationID)
 			}
 		}
@@ -586,6 +617,7 @@ func (app *Application) onReserving() {
 
 // onReservationStateChange is called when there is an add or a release of a placeholder
 // If we have all the required placeholders progress the application status, otherwise nothing happens
+// +checklocks:app.lock
 func (app *Application) onReservationStateChange() {
 	if app.originatingTask != nil {
 		events.GetRecorder().Eventf(app.originatingTask.GetTaskPod().DeepCopy(), nil, v1.EventTypeNormal, "GangScheduling",
@@ -625,6 +657,7 @@ func (app *Application) onReservationStateChange() {
 	dispatcher.Dispatch(NewRunApplicationEvent(app.applicationID))
 }
 
+// +checklocks:app.lock
 func (app *Application) handleRejectApplicationEvent(reason string) {
 	log.Log(log.ShimCacheApplication).Info("app is rejected by scheduler", zap.String("appID", app.applicationID))
 	app.clearReleaseableTasks()
@@ -639,6 +672,7 @@ func (app *Application) handleCompleteApplicationEvent() {
 	}()
 }
 
+// +checklocksexclude:task.lock
 func failTaskPodWithReasonAndMsg(task *Task, reason string, msg string) {
 	podCopy := task.GetTaskPod().DeepCopy()
 	podCopy.Status = v1.PodStatus{
@@ -655,6 +689,7 @@ func failTaskPodWithReasonAndMsg(task *Task, reason string, msg string) {
 	}
 }
 
+// +checklocks:app.lock
 func (app *Application) handleFailApplicationEvent(errMsg string) {
 	go func() {
 		getPlaceholderManager().cleanUp(app)
@@ -682,6 +717,7 @@ func (app *Application) handleFailApplicationEvent(errMsg string) {
 	}
 }
 
+// +checklocks:app.lock
 func (app *Application) handleReleaseAppAllocationEvent(taskID string, terminationType string) {
 	log.Log(log.ShimCacheApplication).Info("try to release pod from application",
 		zap.String("appID", app.applicationID),
@@ -702,6 +738,7 @@ func (app *Application) handleReleaseAppAllocationEvent(taskID string, terminati
 	}
 }
 
+// +checklocks:app.lock
 func (app *Application) handleAppTaskCompletedEvent() {
 	for _, task := range app.taskMap {
 		if task.placeholder && task.GetTaskState() != TaskStates().Completed {
@@ -713,6 +750,8 @@ func (app *Application) handleAppTaskCompletedEvent() {
 	dispatcher.Dispatch(NewRunApplicationEvent(app.applicationID))
 }
 
+// +checklocks:app.lock
+// +checklocksexclude:task.lock
 func (app *Application) publishPlaceholderTimeoutEvents(task *Task) {
 	taskTerminationType := task.GetTaskTerminationType()
 	if app.originatingTask != nil && task.IsPlaceholder() && taskTerminationType == si.TerminationType_name[int32(si.TerminationType_TIMEOUT)] {
@@ -761,12 +800,16 @@ func (app *Application) tryAddReleasableTask(task *Task) bool {
 	return false
 }
 
+// +checklocks:app.lock
 func (app *Application) clearReleaseableTasks() {
 	app.releaseableTasks = nil
 }
 
 // flushReleaseableTasks replays deferred task releases after the application has been accepted
 // by the scheduler core. Must be called while the application lock is held.
+//
+// YUNIKORN-3421: self-deadlock on tryAddReleasableTask avoided only by force=true
+// +checklocks:app.lock
 func (app *Application) flushReleaseableTasks() {
 	if len(app.releaseableTasks) == 0 {
 		return
@@ -777,13 +820,15 @@ func (app *Application) flushReleaseableTasks() {
 	if app.AreAllTasksTerminated() {
 		app.removeFromSchedulerCore()
 		if app.context != nil {
-			app.context.removeApplication(app.applicationID)
+			// YUNIKORN-3427: context application map updated under the application lock only
+			app.context.removeApplication(app.applicationID) // +checklocksignore
 		}
 		return
 	}
 
 	for _, task := range tasks {
-		task.releaseAllocation(true)
+		// YUNIKORN-3427: task fields read under the application lock only
+		task.releaseAllocation(true) // +checklocksignore
 	}
 }
 

--- a/pkg/cache/application_state.go
+++ b/pkg/cache/application_state.go
@@ -446,7 +446,22 @@ func newAppState() *fsm.FSM { //nolint:funlen
 				Dst:  states.Killed,
 			},
 		},
+		// The callbacks below are invoked by the state machine from Application.handle which
+		// holds the application lock. The dispatch goes through the fsm library so the lock
+		// cannot be tracked across it, and the application is not nameable from out here: it
+		// exists only inside each body, recovered from the event arguments. Each callback
+		// therefore states its lock by naming the expression its own body uses.
+		//
+		// These are preconditions and not exemptions, so the bodies are ENFORCED: each one is
+		// analysed with the application lock held, and a guarded field of any other object, a
+		// call that must not be entered with this lock held, or taking the lock again are all
+		// reported. Every callback carries one, including those that touch nothing guarded
+		// today, so that the next line added to one is checked rather than reported.
+		//
+		// A guard that matches no assertion in its body records nothing, silently. Changing
+		// how a callback recovers its application means changing the annotation with it.
 		fsm.Callbacks{
+			// +checklocks:event.Args[0].(*Application).lock
 			events.EnterState: func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				log.Log(log.ShimFSM).Debug("shim app state transition",
@@ -455,22 +470,27 @@ func newAppState() *fsm.FSM { //nolint:funlen
 					zap.String("destination", event.Dst),
 					zap.String("event", event.Event))
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			states.Accepted: func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				app.flushReleaseableTasks()
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			states.Reserving: func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				app.onReserving()
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			states.Resuming: func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				app.onResuming()
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			SubmitApplication.String(): func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				event.Err = app.handleSubmitApplicationEvent()
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			RejectApplication.String(): func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				eventArgs := make([]string, 1)
@@ -482,10 +502,12 @@ func newAppState() *fsm.FSM { //nolint:funlen
 				reason := eventArgs[0]
 				app.handleRejectApplicationEvent(reason)
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			CompleteApplication.String(): func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				app.handleCompleteApplicationEvent()
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			FailApplication.String(): func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				eventArgs := make([]string, 1)
@@ -497,10 +519,12 @@ func newAppState() *fsm.FSM { //nolint:funlen
 				errMsg := eventArgs[0]
 				app.handleFailApplicationEvent(errMsg)
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			UpdateReservation.String(): func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				app.onReservationStateChange()
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			ReleaseAppAllocation.String(): func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				eventArgs := make([]string, 2)
@@ -513,6 +537,7 @@ func newAppState() *fsm.FSM { //nolint:funlen
 				terminationType := eventArgs[1]
 				app.handleReleaseAppAllocationEvent(taskID, terminationType)
 			},
+			// +checklocks:event.Args[0].(*Application).lock
 			AppTaskCompleted.String(): func(_ context.Context, event *fsm.Event) {
 				app := event.Args[0].(*Application) //nolint:errcheck
 				app.handleAppTaskCompletedEvent()

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -69,16 +69,19 @@ var (
 )
 
 // context maintains scheduling state, like apps and apps' tasks.
+// +lockclass:cache.Context
 type Context struct {
+	// +checklocks:lock
 	applications   map[string]*Application        // apps
 	schedulerCache *schedulercache.SchedulerCache // external cache
 	apiProvider    client.APIProvider             // apis to interact with api-server, scheduler-core, etc
 	predManager    predicates.PredicateManager    // K8s predicates
 	namespace      string                         // yunikorn namespace
-	configMaps     []*v1.ConfigMap                // cached yunikorn configmaps
-	lock           *locking.RWMutex               // lock - used not only for context data but also to ensure that multiple event types are not executed concurrently
-	txnID          atomic.Uint64                  // transaction ID counter
-	klogger        klog.Logger
+	// +checklocks:lock
+	configMaps []*v1.ConfigMap  // cached yunikorn configmaps
+	lock       *locking.RWMutex // lock - used not only for context data but also to ensure that multiple event types are not executed concurrently
+	txnID      atomic.Uint64    // transaction ID counter
+	klogger    klog.Logger
 }
 
 // NewContext create a new context for the scheduler using a default (empty) configuration
@@ -192,6 +195,7 @@ func (ctx *Context) updateNode(_, obj interface{}) {
 	ctx.updateNodeInternal(node, true)
 }
 
+// +checklocks:ctx.lock
 func (ctx *Context) updateNodeInternal(node *v1.Node, register bool) {
 	// update scheduler cache
 	if prevNode, adoptedPods := ctx.schedulerCache.UpdateNode(node); prevNode == nil {
@@ -351,6 +355,7 @@ func (ctx *Context) UpdatePod(oldObj, newObj interface{}) {
 	}
 }
 
+// +checklocks:ctx.lock
 func (ctx *Context) updateYuniKornPod(appID string, oldPod, pod *v1.Pod) {
 	taskID := string(pod.UID)
 	app := ctx.getApplication(appID)
@@ -386,6 +391,8 @@ func (ctx *Context) updateYuniKornPod(appID string, oldPod, pod *v1.Pod) {
 	}
 }
 
+// +checklocks:ctx.lock
+// +checklocksexclude:app.lock
 func (ctx *Context) ensureAppAndTaskCreated(pod *v1.Pod, app *Application) {
 	// add app if it doesn't already exist
 	if app == nil {
@@ -1011,6 +1018,7 @@ func (ctx *Context) AddApplication(request *AddApplicationRequest) *Application 
 	return ctx.addApplication(request)
 }
 
+// +checklocks:ctx.lock
 func (ctx *Context) addApplication(request *AddApplicationRequest) *Application {
 	log.Log(log.ShimContext).Debug("AddApplication", zap.Any("Request", request))
 	if app := ctx.getApplication(request.Metadata.ApplicationID); app != nil {
@@ -1071,6 +1079,7 @@ func (ctx *Context) GetApplication(appID string) *Application {
 	return ctx.getApplication(appID)
 }
 
+// +checklocksread:ctx.lock
 func (ctx *Context) getApplication(appID string) *Application {
 	if app, ok := ctx.applications[appID]; ok {
 		return app
@@ -1084,6 +1093,7 @@ func (ctx *Context) RemoveApplication(appID string) {
 	ctx.removeApplication(appID)
 }
 
+// +checklocks:ctx.lock
 func (ctx *Context) removeApplication(appID string) {
 	if _, exist := ctx.applications[appID]; !exist {
 		log.Log(log.ShimContext).Debug("Attempted to remove non-existent application", zap.String("appID", appID))
@@ -1099,6 +1109,7 @@ func (ctx *Context) AddTask(request *AddTaskRequest) *Task {
 	return ctx.addTask(request)
 }
 
+// +checklocks:ctx.lock
 func (ctx *Context) addTask(request *AddTaskRequest) *Task {
 	log.Log(log.ShimContext).Debug("AddTask",
 		zap.String("appID", request.Metadata.ApplicationID),
@@ -1229,6 +1240,7 @@ func (ctx *Context) PublishEvents(eventRecords []*si.EventRecord) {
 
 // update task's pod condition when the condition has not yet updated,
 // return true if the update was done and false if the update is skipped due to any error, or a dup operation
+// +checklocksexclude:task.lock
 func (ctx *Context) updatePodCondition(task *Task, podCondition *v1.PodCondition) bool {
 	if task.GetTaskState() == TaskStates().Scheduling {
 		// only update the pod when pod condition changes
@@ -1533,6 +1545,7 @@ func (ctx *Context) loadNodes() ([]*v1.Node, error) {
 	return nodes, err
 }
 
+// +checklocks:ctx.lock
 func (ctx *Context) registerNode(node *v1.Node) error {
 	acceptedNodes, err := ctx.registerNodes([]*v1.Node{node})
 	if err != nil {
@@ -1552,6 +1565,7 @@ func (ctx *Context) RegisterNodes(nodes []*v1.Node) ([]*v1.Node, error) {
 
 // registerNodes registers the nodes to the scheduler core.
 // This method must be called while holding the Context write lock.
+// +checklocks:ctx.lock
 func (ctx *Context) registerNodes(nodes []*v1.Node) ([]*v1.Node, error) {
 	nodesToRegister := make([]*si.NodeInfo, 0)
 	pendingNodes := make(map[string]*v1.Node)
@@ -1592,6 +1606,8 @@ func (ctx *Context) registerNodes(nodes []*v1.Node) ([]*v1.Node, error) {
 	return acceptedNodes, nil
 }
 
+// YUNIKORN-3430: context lock released and retaken around the wait
+// +checklocksignore
 func (ctx *Context) registerNodesInternal(nodesToRegister []*si.NodeInfo, pendingNodes map[string]*v1.Node) ([]*v1.Node, []*v1.Node, error) {
 	acceptedNodes := make([]*v1.Node, 0)
 	rejectedNodes := make([]*v1.Node, 0)

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -40,6 +40,8 @@ import (
 // SchedulerCache maintains some critical information about nodes and pods used for scheduling.
 // Nodes are cached in the form of de-scheduler nodeInfo. Instead of re-creating all nodes info from scratch,
 // we replicate nodes info from de-scheduler, in order to re-use predicates functions.
+// +lockclass:external.SchedulerCache
+// +checklocksguardedby:lock
 type SchedulerCache struct {
 	nodesMap     map[string]*framework.NodeInfo // node name to NodeInfo map
 	podsMap      map[string]*v1.Pod
@@ -49,8 +51,10 @@ type SchedulerCache struct {
 	orphanedPods map[string]*v1.Pod // map of orphaned pods, keyed by pod UID
 	pvcRefCounts map[string]map[string]int
 	lock         locking.RWMutex
-	clients      *client.Clients // client APIs
-	klogger      klog.Logger
+	// +checklocksunguarded
+	clients *client.Clients // client APIs
+	// +checklocksunguarded
+	klogger klog.Logger
 
 	// cached data, re-calculated on demand from nodesMap
 	nodesInfo                        []fwk.NodeInfo
@@ -75,19 +79,22 @@ func NewSchedulerCache(clients *client.Clients) *SchedulerCache {
 
 // GetNodesInfoMap returns a reference to the internal node map. This is explicitly for the use of the predicate
 // shared lister and requires that the scheduler cache lock be held while accessing.
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) GetNodesInfoMap() map[string]*framework.NodeInfo {
 	return cache.nodesMap
 }
 
 // GetNodesInfo returns a (possibly cached) list of nodes. This is explicitly for the use of the predicate
 // shared lister and requires that the scheduler cache lock be held while accessing.
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) GetNodesInfo() []fwk.NodeInfo {
 	if cache.nodesInfo == nil {
 		nodeList := make([]fwk.NodeInfo, 0, len(cache.nodesMap))
 		for _, node := range cache.nodesMap {
 			nodeList = append(nodeList, node)
 		}
-		cache.nodesInfo = nodeList
+		// YUNIKORN-3422: cached node list written while only the read lock is held
+		cache.nodesInfo = nodeList // +checklocksignore
 	}
 
 	return cache.nodesInfo
@@ -96,6 +103,7 @@ func (cache *SchedulerCache) GetNodesInfo() []fwk.NodeInfo {
 // GetNodesInfoPodsWithAffinity returns a (possibly cached) list of nodes which contain pods with affinity.
 // This is explicitly for the use of the predicate shared lister and requires that the scheduler cache lock
 // be held while accessing.
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) GetNodesInfoPodsWithAffinity() []fwk.NodeInfo {
 	if cache.nodesInfoPodsWithAffinity == nil {
 		nodeList := make([]fwk.NodeInfo, 0, len(cache.nodesMap))
@@ -104,7 +112,8 @@ func (cache *SchedulerCache) GetNodesInfoPodsWithAffinity() []fwk.NodeInfo {
 				nodeList = append(nodeList, node)
 			}
 		}
-		cache.nodesInfoPodsWithAffinity = nodeList
+		// YUNIKORN-3422: same as above
+		cache.nodesInfoPodsWithAffinity = nodeList // +checklocksignore
 	}
 
 	return cache.nodesInfoPodsWithAffinity
@@ -113,6 +122,7 @@ func (cache *SchedulerCache) GetNodesInfoPodsWithAffinity() []fwk.NodeInfo {
 // GetNodesInfoPodsWithReqAntiAffinity returns a (possibly cached) list of nodes which contain pods with required anti-affinity.
 // This is explicitly for the use of the predicate shared lister and requires that the scheduler cache lock
 // be held while accessing.
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) GetNodesInfoPodsWithReqAntiAffinity() []fwk.NodeInfo {
 	if cache.nodesInfoPodsWithReqAntiAffinity == nil {
 		nodeList := make([]fwk.NodeInfo, 0, len(cache.nodesMap))
@@ -121,20 +131,35 @@ func (cache *SchedulerCache) GetNodesInfoPodsWithReqAntiAffinity() []fwk.NodeInf
 				nodeList = append(nodeList, node)
 			}
 		}
-		cache.nodesInfoPodsWithReqAntiAffinity = nodeList
+		// YUNIKORN-3422: same as above
+		cache.nodesInfoPodsWithReqAntiAffinity = nodeList // +checklocksignore
 	}
 
 	return cache.nodesInfoPodsWithReqAntiAffinity
 }
 
+// LockForReads hands the read lock to the caller, it is never valid to call it while any
+// hold on the lock is already in place: a write hold deadlocks and a read hold is a
+// recursive read lock, which deadlocks as soon as a writer is queued in between. The
+// acquire annotation states that on its own, a lock that is acquired must not be held on
+// entry, so no exclusion is written here.
+// The same holds for every method below that takes the lock itself, which is why they all
+// exclude the lock instead of only excluding a write hold: this is the one cache in the
+// shim that hands its read lock to its callers, so a read hold is a state code can really
+// be in, and taking the lock again from there is the recursive read lock above. None of
+// those exclusions is derived: they take the read lock, which would be derived as an
+// exclusion of a writer alone, and the wider rule is the one meant, so it is written.
+// +checklocksacquireread:cache.lock
 func (cache *SchedulerCache) LockForReads() {
 	cache.lock.RLock()
 }
 
+// +checklocksreleaseread:cache.lock
 func (cache *SchedulerCache) UnlockForReads() {
 	cache.lock.RUnlock()
 }
 
+// +checklocksexclude:cache.lock
 func (cache *SchedulerCache) GetNode(name string) *framework.NodeInfo {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
@@ -153,6 +178,7 @@ func (cache *SchedulerCache) UpdateNode(node *v1.Node) (*v1.Node, []*v1.Pod) {
 	return cache.updateNode(node)
 }
 
+// +checklocks:cache.lock
 func (cache *SchedulerCache) updateNode(node *v1.Node) (*v1.Node, []*v1.Pod) {
 	var prevNode *v1.Node
 	adopted := make([]*v1.Pod, 0)
@@ -195,6 +221,7 @@ func (cache *SchedulerCache) RemoveNode(node *v1.Node) (*v1.Node, []*v1.Pod) {
 	return cache.removeNode(node)
 }
 
+// +checklocks:cache.lock
 func (cache *SchedulerCache) removeNode(node *v1.Node) (*v1.Node, []*v1.Pod) {
 	orphans := make([]*v1.Pod, 0)
 	nodeInfo, ok := cache.nodesMap[node.Name]
@@ -238,6 +265,7 @@ func (cache *SchedulerCache) removeNode(node *v1.Node) (*v1.Node, []*v1.Pod) {
 	return result, orphans
 }
 
+// +checklocksexclude:cache.lock
 func (cache *SchedulerCache) GetPriorityClass(name string) *schedulingv1.PriorityClass {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
@@ -257,6 +285,7 @@ func (cache *SchedulerCache) UpdatePriorityClass(priorityClass *schedulingv1.Pri
 	cache.updatePriorityClass(priorityClass)
 }
 
+// +checklocks:cache.lock
 func (cache *SchedulerCache) updatePriorityClass(priorityClass *schedulingv1.PriorityClass) {
 	_, ok := cache.pcMap[priorityClass.Name]
 	if !ok {
@@ -276,23 +305,27 @@ func (cache *SchedulerCache) RemovePriorityClass(priorityClass *schedulingv1.Pri
 	cache.removePriorityClass(priorityClass)
 }
 
+// +checklocks:cache.lock
 func (cache *SchedulerCache) removePriorityClass(priorityClass *schedulingv1.PriorityClass) {
 	log.Log(log.ShimCacheExternal).Debug("Removing priorityClass from cache", zap.String("name", priorityClass.Name))
 	delete(cache.pcMap, priorityClass.Name)
 }
 
 // IsAssumedPod returns if pod is assumed in cache, avoid nil
+// +checklocksexclude:cache.lock
 func (cache *SchedulerCache) IsAssumedPod(podKey string) bool {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
 	return cache.isAssumedPod(podKey)
 }
 
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) isAssumedPod(podKey string) bool {
 	_, ok := cache.assumedPods[podKey]
 	return ok
 }
 
+// +checklocksexclude:cache.lock
 func (cache *SchedulerCache) ArePodVolumesAllBound(podKey string) bool {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
@@ -308,6 +341,7 @@ func (cache *SchedulerCache) UpdatePod(newPod *v1.Pod) bool {
 	return cache.updatePod(newPod)
 }
 
+// +checklocks:cache.lock
 func (cache *SchedulerCache) updatePod(pod *v1.Pod) bool {
 	key := string(pod.UID)
 	result := true
@@ -400,6 +434,7 @@ func (cache *SchedulerCache) RemovePod(pod *v1.Pod) {
 	cache.removePod(pod)
 }
 
+// +checklocks:cache.lock
 func (cache *SchedulerCache) removePod(pod *v1.Pod) {
 	key := string(pod.UID)
 	log.Log(log.ShimCacheExternal).Debug("Removing deleted pod from cache", zap.String("podName", pod.Name), zap.String("podKey", key))
@@ -424,12 +459,14 @@ func (cache *SchedulerCache) removePod(pod *v1.Pod) {
 	cache.nodesInfoPodsWithReqAntiAffinity = nil
 }
 
+// +checklocksexclude:cache.lock
 func (cache *SchedulerCache) GetPod(uid string) *v1.Pod {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
 	return cache.GetPodNoLock(uid)
 }
 
+// +checklocksexclude:cache.lock
 func (cache *SchedulerCache) IsPodOrphaned(uid string) bool {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
@@ -437,6 +474,7 @@ func (cache *SchedulerCache) IsPodOrphaned(uid string) bool {
 	return ok
 }
 
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) GetPodNoLock(uid string) *v1.Pod {
 	if pod, ok := cache.podsMap[uid]; ok {
 		return pod
@@ -452,6 +490,7 @@ func (cache *SchedulerCache) AssumePod(pod *v1.Pod, allBound bool) {
 	cache.assumePod(pod, allBound)
 }
 
+// +checklocks:cache.lock
 func (cache *SchedulerCache) assumePod(pod *v1.Pod, allBound bool) {
 	key := string(pod.UID)
 
@@ -473,6 +512,7 @@ func (cache *SchedulerCache) ForgetPod(pod *v1.Pod) {
 	cache.forgetPod(pod)
 }
 
+// +checklocks:cache.lock
 func (cache *SchedulerCache) forgetPod(pod *v1.Pod) {
 	key := string(pod.UID)
 
@@ -499,6 +539,7 @@ func (cache *SchedulerCache) forgetPod(pod *v1.Pod) {
 }
 
 // Implement k8s.io/client-go/listers/core/v1#PodLister interface
+// +checklocksexclude:cache.lock
 func (cache *SchedulerCache) List(selector labels.Selector) ([]*v1.Pod, error) {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
@@ -519,6 +560,7 @@ func (cache *SchedulerCache) List(selector labels.Selector) ([]*v1.Pod, error) {
 }
 
 // Implement scheduler/algorithm/predicates/predicates.go#NodeInfo interface
+// +checklocksexclude:cache.lock
 func (cache *SchedulerCache) GetNodeInfo(nodeName string) (*v1.Node, error) {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
@@ -545,6 +587,7 @@ func (cache *SchedulerCache) GetPersistentVolumeInfo(name string) (*v1.Persisten
 }
 
 // dumpState dumps summary statistics for the cache. Must be called with lock already acquired
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) dumpState(context string) {
 	if log.Log(log.ShimCacheExternal).Core().Enabled(zapcore.DebugLevel) {
 		log.Log(log.ShimCacheExternal).Debug("Scheduler cache state ("+context+")",
@@ -556,6 +599,7 @@ func (cache *SchedulerCache) dumpState(context string) {
 	}
 }
 
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) podPhases() map[string]int {
 	result := make(map[string]int)
 
@@ -571,6 +615,7 @@ func (cache *SchedulerCache) podPhases() map[string]int {
 	return result
 }
 
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) nodePodCount() int {
 	result := 0
 	for _, node := range cache.nodesMap {
@@ -581,11 +626,13 @@ func (cache *SchedulerCache) nodePodCount() int {
 
 // IsPVCUsedByPods determines if a given volume claim is in use by any current pods. This is explicitly for the use
 // of the predicate shared lister and requires that the scheduler cache lock be held while accessing.
+// +checklocksread:cache.lock
 func (cache *SchedulerCache) IsPVCUsedByPods(key string) bool {
 	_, ok := cache.pvcRefCounts[key]
 	return ok
 }
 
+// +checklocks:cache.lock
 func (cache *SchedulerCache) updatePVCRefCounts(node *framework.NodeInfo, removeNode bool) {
 	nodeName := node.Node().Name
 	for k, v := range cache.pvcRefCounts {
@@ -607,6 +654,7 @@ func (cache *SchedulerCache) updatePVCRefCounts(node *framework.NodeInfo, remove
 	}
 }
 
+// +checklocksexclude:cache.lock
 func (cache *SchedulerCache) GetSchedulerCacheDao() SchedulerCacheDao {
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()

--- a/pkg/cache/placeholder.go
+++ b/pkg/cache/placeholder.go
@@ -38,6 +38,7 @@ type Placeholder struct {
 	pod           *v1.Pod
 }
 
+// +checklocksexclude:app.lock
 func newPlaceholder(placeholderName string, app *Application, taskGroup TaskGroup) *Placeholder {
 	logger := log.Log(log.ShimPlaceHolderConfig)
 	// Here the owner reference is always the originator pod

--- a/pkg/cache/placeholder_manager.go
+++ b/pkg/cache/placeholder_manager.go
@@ -32,25 +32,30 @@ import (
 )
 
 // PlaceholderManager is a service to manage the lifecycle of app placeholders
+// +lockclass:cache.PlaceholderManager
 type PlaceholderManager struct {
 	// clients can neve be nil, even the kubeclient cannot be nil as the shim will not start without it
 	clients *client.Clients
 	// when the placeholder manager is unable to delete a pod,
 	// this pod becomes to be an "orphan" pod. We add them to a map
 	// and keep retrying deleting them in order to avoid wasting resources.
-	orphanPods  map[string]*v1.Pod
-	stopChan    chan struct{}
-	running     atomic.Bool
+	// +checklocks:RWMutex
+	orphanPods map[string]*v1.Pod
+	stopChan   chan struct{}
+	running    atomic.Bool
+	// +checklocks:RWMutex
 	cleanupTime time.Duration
 	// a simple mutex will do we do not have separate read and write paths
 	locking.RWMutex
 }
 
 var (
+	// +checklocks:mu
 	placeholderMgr *PlaceholderManager
 	mu             locking.Mutex
 )
 
+// +checklocksexclude:mu
 func NewPlaceholderManager(clients *client.Clients) *PlaceholderManager {
 	mu.Lock()
 	defer mu.Unlock()
@@ -63,19 +68,22 @@ func NewPlaceholderManager(clients *client.Clients) *PlaceholderManager {
 	return placeholderMgr
 }
 
+// +checklocksexclude:mu
 func getPlaceholderManager() *PlaceholderManager {
 	mu.Lock()
 	defer mu.Unlock()
 	return placeholderMgr
 }
 
+// +checklocksexclude:app.lock
 func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
 	mgr.Lock()
 	defer mgr.Unlock()
 
 	// map task group to count of already created placeholders
 	tgCounts := make(map[string]int32)
-	for _, ph := range app.getPlaceHolderTasks() {
+	// YUNIKORN-3424: application task map walked under the placeholder manager lock only
+	for _, ph := range app.getPlaceHolderTasks() { // +checklocksignore
 		tgCounts[ph.GetTaskGroupName()]++
 	}
 
@@ -102,6 +110,7 @@ func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
 }
 
 // clean up all the placeholders for an application
+// +checklocksexclude:app.lock
 func (mgr *PlaceholderManager) cleanUp(app *Application) {
 	mgr.Lock()
 	defer mgr.Unlock()

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -50,26 +50,35 @@ var retryBackoff = wait.Backoff{
 	Cap:      30 * time.Second,
 }
 
+// +lockclass:cache.Task
 type Task struct {
 	taskID        string
 	alias         string
 	applicationID string
 	application   *Application
-	podStatus     v1.PodStatus // pod status, maintained separately for efficiency reasons
-	context       *Context
-	createTime    time.Time
-	placeholder   bool
-	originator    bool
-	sm            *fsm.FSM
+	// +checklocks:lock
+	podStatus   v1.PodStatus // pod status, maintained separately for efficiency reasons
+	context     *Context
+	createTime  time.Time
+	placeholder bool
+	originator  bool
+	sm          *fsm.FSM
 
 	// mutable resources, require locking
-	allocationKey   string
-	nodeName        string
-	taskGroupName   string
+	// +checklocks:lock
+	allocationKey string
+	// +checklocks:lock
+	nodeName string
+	// +checklocks:lock
+	taskGroupName string
+	// +checklocks:lock
 	terminationType string
+	// +checklocks:lock
 	schedulingState TaskSchedulingState
-	resource        *si.Resource
-	pod             *v1.Pod
+	// +checklocks:lock
+	resource *si.Resource
+	// +checklocks:lock
+	pod *v1.Pod
 
 	lock *locking.RWMutex
 }
@@ -241,6 +250,7 @@ func (task *Task) IsOriginator() bool {
 	return task.originator
 }
 
+// +checklocksread:task.lock
 func (task *Task) isPreemptSelfAllowed() bool {
 	value := utils.GetPodAnnotationValue(task.pod, constants.AnnotationAllowPreemption)
 	switch value {
@@ -253,6 +263,7 @@ func (task *Task) isPreemptSelfAllowed() bool {
 	}
 }
 
+// +checklocksread:task.lock
 func (task *Task) isPreemptOtherAllowed() bool {
 	policy := task.pod.Spec.PreemptionPolicy
 	if policy == nil {
@@ -296,6 +307,7 @@ func (task *Task) GetTaskSchedulingState() TaskSchedulingState {
 	return task.schedulingState
 }
 
+// +checklocks:task.lock
 func (task *Task) handleSubmitTaskEvent() {
 	log.Log(log.ShimCacheTask).Debug("scheduling pod",
 		zap.String("podName", task.pod.Name))
@@ -319,6 +331,7 @@ func (task *Task) handleSubmitTaskEvent() {
 
 // updateAllocation updates the core scheduler when task information changes.
 // This function must be called with the task lock held.
+// +checklocks:task.lock
 func (task *Task) updateAllocation() {
 	// build preemption policy
 	preemptionPolicy := &si.PreemptionPolicy{
@@ -357,6 +370,7 @@ func (task *Task) postTaskPending() {
 // Volume binding and pod binding are retried with a backoff; if they ultimately fail
 // the allocation is rolled back to a pending ask so the core can re-schedule the task
 // on a different node. On success we move the task to the next state BOUND.
+// +checklocksread:task.lock
 func (task *Task) postTaskAllocated() {
 	// Snapshot the fields needed for binding before launching the goroutine without re-acquiring the lock.
 	// We already hold task.lock (via task.handle()) during state transitions.
@@ -374,7 +388,8 @@ func (task *Task) postTaskAllocated() {
 		log.Log(log.ShimCacheTask).Debug("bind pod volumes",
 			zap.String("podName", pod.Name),
 			zap.String("podUID", string(pod.UID)))
-		if err := retry.OnError(retryBackoff, func(err error) bool {
+		// YUNIKORN-3426: bind retries with backoff run under the task write lock
+		if err := retry.OnError(retryBackoff, func(err error) bool { // +lockblockingignore
 			if strings.HasPrefix(err.Error(), "binding volumes:") {
 				log.Log(log.ShimCacheTask).Warn("bind volumes to pod failed due to volume binding error, stopping retries",
 					zap.String("taskID", task.taskID), zap.Error(err))
@@ -398,7 +413,8 @@ func (task *Task) postTaskAllocated() {
 			zap.String("podName", pod.Name),
 			zap.String("podUID", string(pod.UID)))
 
-		if err := retry.OnError(retryBackoff, func(err error) bool {
+		// YUNIKORN-3426: same as above
+		if err := retry.OnError(retryBackoff, func(err error) bool { // +lockblockingignore
 			log.Log(log.ShimCacheTask).Error("bind pod to node failed, retrying",
 				zap.String("taskID", task.taskID), zap.Error(err))
 			return true
@@ -435,6 +451,7 @@ func (task *Task) postTaskAllocated() {
 // If we find the task is already in Completed state while handling TaskAllocated
 // event, we need to explicitly release this allocation because it is no
 // longer valid.
+// +checklocks:task.lock
 func (task *Task) beforeTaskAllocated(eventSrc string, allocationKey string, nodeID string) {
 	// task is allocated on a node with a allocationKey set the details in the task here to allow referencing later.
 	task.allocationKey = allocationKey
@@ -451,6 +468,7 @@ func (task *Task) beforeTaskAllocated(eventSrc string, allocationKey string, nod
 	}
 }
 
+// +checklocksread:task.lock
 func (task *Task) postTaskBound() {
 	if task.placeholder {
 		log.Log(log.ShimCacheTask).Info("placeholder is bound",
@@ -461,6 +479,7 @@ func (task *Task) postTaskBound() {
 	}
 }
 
+// +checklocksread:task.lock
 func (task *Task) postTaskRejected() {
 	// currently, once task is rejected by scheduler, we directly move task to failed state.
 	// so this function simply triggers the state transition when it is rejected.
@@ -475,6 +494,7 @@ func (task *Task) postTaskRejected() {
 // beforeTaskFail releases the allocation or ask from scheduler core
 // this is done as a before hook because the releaseAllocation() call needs to
 // send different requests to scheduler-core, depending on current task state
+// +checklocks:task.lock
 func (task *Task) beforeTaskFail() {
 	events.GetRecorder().Eventf(task.pod.DeepCopy(), nil,
 		v1.EventTypeNormal, "TaskFailed", "TaskFailed",
@@ -485,6 +505,7 @@ func (task *Task) beforeTaskFail() {
 // beforeTaskCompleted releases the allocation or ask from scheduler core
 // this is done as a before hook because the releaseAllocation() call needs to
 // send different requests to scheduler-core, depending on current task state
+// +checklocks:task.lock
 func (task *Task) beforeTaskCompleted() {
 	task.releaseAllocation(false)
 
@@ -494,6 +515,7 @@ func (task *Task) beforeTaskCompleted() {
 }
 
 // releaseAllocation sends the release request for the Allocation to the core.
+// +checklocks:task.lock
 func (task *Task) releaseAllocation(force bool) {
 	terminationType := common.GetTerminationTypeFromString(task.terminationType)
 
@@ -548,6 +570,8 @@ func (task *Task) releaseAllocation(force bool) {
 	}
 }
 
+// YUNIKORN-3421: task lock dropped and retaken inside an FSM callback
+// +checklocksignore
 func (task *Task) shouldAppRelease() bool {
 	task.lock.Unlock()
 	defer task.lock.Lock()
@@ -659,6 +683,7 @@ func (task *Task) FailWithEvent(errorMessage, actionReason string) {
 	task.failWithEvent(errorMessage, actionReason)
 }
 
+// +checklocksread:task.lock
 func (task *Task) failWithEvent(errorMessage, actionReason string) {
 	events.GetRecorder().Eventf(task.pod.DeepCopy(),
 		nil, v1.EventTypeWarning, actionReason, actionReason, errorMessage)

--- a/pkg/cache/task_state.go
+++ b/pkg/cache/task_state.go
@@ -375,7 +375,14 @@ func eventDesc(states *TStates) fsm.Events {
 }
 
 func callbacks(states *TStates) fsm.Callbacks {
+	// The callbacks below are invoked by the state machine from Task.handle which holds the
+	// task lock. The dispatch goes through the fsm library so the lock cannot be tracked
+	// across it, and the task is not nameable from out here: it exists only inside each body,
+	// recovered from the event arguments. Each callback therefore states its lock by naming
+	// the expression its own body uses, exactly as the application callbacks do; see the
+	// longer note in application_state.go for what that buys and what it demands.
 	return fsm.Callbacks{
+		// +checklocks:event.Args[0].(*Task).lock
 		events.EnterState: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			log.Log(log.ShimFSM).Info("Task state transition",
@@ -386,18 +393,22 @@ func callbacks(states *TStates) fsm.Callbacks {
 				zap.String("destination", event.Dst),
 				zap.String("event", event.Event))
 		},
+		// +checklocks:event.Args[0].(*Task).lock
 		states.Pending: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			task.postTaskPending()
 		},
+		// +checklocks:event.Args[0].(*Task).lock
 		states.Allocated: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			task.postTaskAllocated()
 		},
+		// +checklocks:event.Args[0].(*Task).lock
 		states.Rejected: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			task.postTaskRejected()
 		},
+		// +checklocks:event.Args[0].(*Task).lock
 		states.Failed: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			eventArgs := make([]string, 1)
@@ -414,14 +425,17 @@ func callbacks(states *TStates) fsm.Callbacks {
 				zap.String("taskID", task.taskID),
 				zap.String("reason", reason))
 		},
+		// +checklocks:event.Args[0].(*Task).lock
 		states.Bound: func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			task.postTaskBound()
 		},
+		// +checklocks:event.Args[0].(*Task).lock
 		beforeHook(TaskFail): func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			task.beforeTaskFail()
 		},
+		// +checklocks:event.Args[0].(*Task).lock
 		beforeHook(TaskAllocated): func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			eventArgs := make([]string, 2)
@@ -434,10 +448,12 @@ func callbacks(states *TStates) fsm.Callbacks {
 			nodeID := eventArgs[1]
 			task.beforeTaskAllocated(event.Src, allocationKey, nodeID)
 		},
+		// +checklocks:event.Args[0].(*Task).lock
 		beforeHook(CompleteTask): func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			task.beforeTaskCompleted()
 		},
+		// +checklocks:event.Args[0].(*Task).lock
 		SubmitTask.String(): func(_ context.Context, event *fsm.Event) {
 			task := event.Args[0].(*Task) //nolint:errcheck
 			task.handleSubmitTaskEvent()

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -46,7 +46,8 @@ type MockedAPIProvider struct {
 	stop         chan struct{}
 	eventHandler chan *ResourceEventHandlers
 	events       chan informerEvent
-	running      bool
+	// +checklocks:Mutex
+	running bool
 }
 
 type operation int

--- a/pkg/client/kubeclient_mock.go
+++ b/pkg/client/kubeclient_mock.go
@@ -41,10 +41,13 @@ type KubeClientMock struct {
 	updateStatusFn func(pod *v1.Pod) (*v1.Pod, error)
 	getFn          func(podName string) (*v1.Pod, error)
 	clientSet      kubernetes.Interface
-	pods           map[string]*v1.Pod
-	lock           locking.RWMutex
-	bindStats      BindStats
-	boundPods      []BoundPod
+	// +checklocks:lock
+	pods map[string]*v1.Pod
+	lock locking.RWMutex
+	// +checklocks:lock
+	bindStats BindStats
+	// +checklocks:lock
+	boundPods []BoundPod
 }
 
 // BindStats statistics about KubeClientMock.Bind() calls
@@ -111,9 +114,12 @@ func NewKubeClientMock(err bool) *KubeClientMock {
 		boundPods: make([]BoundPod, 0, 1024),
 	}
 
+	// this closure is only ever called through kubeMock.bindFn from Bind, which holds the
+	// write lock, the analysis cannot see that through the function field so the accesses to
+	// the guarded fields below are ignored
 	kubeMock.bindFn = func(pod *v1.Pod, hostID string) error {
 		// kubeMock must be locked for this
-		stats := &kubeMock.bindStats
+		stats := &kubeMock.bindStats // +checklocksignore
 
 		if err {
 			stats.Errors++
@@ -129,7 +135,7 @@ func NewKubeClientMock(err bool) *KubeClientMock {
 		}
 		stats.Last = now
 		stats.LastPod = pod.Name
-		kubeMock.boundPods = append(kubeMock.boundPods, BoundPod{
+		kubeMock.boundPods = append(kubeMock.boundPods, BoundPod{ // +checklocksignore
 			Pod:  pod.Name,
 			Host: hostID,
 		})

--- a/pkg/cmd/admissioncontroller/main.go
+++ b/pkg/cmd/admissioncontroller/main.go
@@ -46,8 +46,9 @@ const (
 )
 
 type WebHook struct {
-	ac     *admission.AdmissionController
-	port   int
+	ac   *admission.AdmissionController
+	port int
+	// +checklocks:Mutex
 	server *http.Server
 	locking.Mutex
 }
@@ -166,7 +167,8 @@ func (wh *WebHook) Startup(certs *tls.Certificate) {
 	}
 
 	go func() {
-		if err := wh.server.ListenAndServeTLS("", ""); err != nil {
+		// YUNIKORN-3425: server field read in the serving goroutine while Shutdown can nil it
+		if err := wh.server.ListenAndServeTLS("", ""); err != nil { // +checklocksignore
 			if errors.Is(err, http.ErrServerClosed) {
 				log.Log(log.Admission).Info("existing server closed")
 			} else {

--- a/pkg/common/test/schedulerapi_mock.go
+++ b/pkg/common/test/schedulerapi_mock.go
@@ -31,12 +31,16 @@ type SchedulerAPIMock struct {
 	UpdateAllocationCount  atomic.Int32
 	UpdateApplicationCount atomic.Int32
 	UpdateNodeCount        atomic.Int32
-	registerFn             func(request *si.RegisterResourceManagerRequest,
+	// +checklocks:lock
+	registerFn func(request *si.RegisterResourceManagerRequest,
 		callback api.ResourceManagerCallback) (*si.RegisterResourceManagerResponse, error)
-	UpdateAllocationFn  func(request *si.AllocationRequest) error
+	// +checklocks:lock
+	UpdateAllocationFn func(request *si.AllocationRequest) error
+	// +checklocks:lock
 	UpdateApplicationFn func(request *si.ApplicationRequest) error
-	UpdateNodeFn        func(request *si.NodeRequest) error
-	lock                locking.Mutex
+	// +checklocks:lock
+	UpdateNodeFn func(request *si.NodeRequest) error
+	lock         locking.Mutex
 }
 
 func NewSchedulerAPIMock() *SchedulerAPIMock {
@@ -60,6 +64,8 @@ func NewSchedulerAPIMock() *SchedulerAPIMock {
 
 func (api *SchedulerAPIMock) RegisterFunction(rfn func(request *si.RegisterResourceManagerRequest,
 	callback api.ResourceManagerCallback) (*si.RegisterResourceManagerResponse, error)) *SchedulerAPIMock {
+	api.lock.Lock()
+	defer api.lock.Unlock()
 	api.registerFn = rfn
 	return api
 }

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -49,10 +49,11 @@ const (
 type Dispatcher struct {
 	eventChan chan events.SchedulingEvent
 	stopChan  chan struct{}
-	handlers  map[EventType]map[string]func(interface{})
-	running   atomic.Bool
-	lock      locking.RWMutex
-	stopped   sync.WaitGroup
+	// +checklocks:lock
+	handlers map[EventType]map[string]func(interface{})
+	running  atomic.Bool
+	lock     locking.RWMutex
+	stopped  sync.WaitGroup
 
 	asyncDispatchLimit         int32
 	asyncDispatchCheckInterval time.Duration
@@ -80,6 +81,17 @@ func initDispatcher() {
 		zap.Float64("DispatchTimeoutInSeconds", dispatcher.dispatchTimeout.Seconds()))
 }
 
+// The functions below are the self locking API of this package: they take the lock of the
+// dispatcher singleton, so it must not be held when they are called. The annotations say so, and
+// the analysis enforces them for a caller in this package that holds the lock, whether it reaches
+// it through the package level variable or through getDispatcher(), which it resolves to that
+// variable. The one shape it cannot see:
+//   - a caller in another package. The variable is unexported and export data does not carry
+//     unexported package level variables, so the guard cannot be resolved in pkg/cache or
+//     pkg/shim where most callers live.
+//
+// The runtime lock class order check covers what crosses packages.
+// +checklocksexclude:dispatcher.lock
 func RegisterEventHandler(handlerID string, eventType EventType, handlerFn func(interface{})) {
 	eventDispatcher := getDispatcher()
 	eventDispatcher.lock.Lock()
@@ -90,6 +102,7 @@ func RegisterEventHandler(handlerID string, eventType EventType, handlerFn func(
 	eventDispatcher.handlers[eventType][handlerID] = handlerFn
 }
 
+// +checklocksexclude:dispatcher.lock
 func UnregisterEventHandler(handlerID string, eventType EventType) {
 	eventDispatcher := getDispatcher()
 	eventDispatcher.lock.Lock()
@@ -102,6 +115,7 @@ func UnregisterEventHandler(handlerID string, eventType EventType) {
 	}
 }
 
+// +checklocksexclude:dispatcher.lock
 func UnregisterAllEventHandlers() {
 	eventDispatcher := getDispatcher()
 	eventDispatcher.lock.Lock()
@@ -110,6 +124,7 @@ func UnregisterAllEventHandlers() {
 }
 
 // a thread-safe way to get event handlers
+// +checklocksexcludewrite:dispatcher.lock
 func getEventHandler(eventType EventType) func(interface{}) {
 	eventDispatcher := getDispatcher()
 	eventDispatcher.lock.RLock()

--- a/pkg/locking/checklocks_canary.go
+++ b/pkg/locking/checklocks_canary.go
@@ -1,0 +1,234 @@
+//go:build checklocks_canary
+
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package locking
+
+import "fmt"
+
+// This file is never built, the build constraint above is never set. It is the fixture for
+// the self test of the "vetlock" make target: files named on the go vet command line are
+// analysed even when a build constraint excludes them, so the target can hand this file to
+// the analysis without it ever becoming part of the shim.
+//
+// The fixture holds a violation of each class that is in use: setValue writes
+// a guarded field without holding the lock, reEnter calls a method that must not be called
+// with the lock held while holding it, doubleLock takes one lock twice, and the callback
+// table reaches the second of those from a body whose lock is named by the value it asserts.
+// The self test asserts that the analysis reports all four. Without that assertion checklocks could
+// silently stop finding anything at all and every run would still be green: the lock
+// wrappers are recognised by their declaration in locking.go, so removing it, renaming the
+// types, changing the forwarding methods or moving to a version that behaves differently
+// all end in an analysis that reports less than it did. The fixture uses the wrappers of
+// this package, which makes the self test cover the whole chain: wrapper type, forwarding
+// methods, field annotation and lock precondition.
+//
+// Two more classes are here for a different reason: nothing in the shim states them any more.
+// The exclusion of a method that takes its own lock is derived from the body, and a structure
+// states the guard for its fields once instead of once per field, and between them they let
+// 179 hand written annotations be deleted. An analyser that stopped deriving either would
+// take that protection with it and leave every other message of this fixture intact, so both
+// are required by name: see derivedReentrantCall and structGuardViolation below.
+
+// canary carries a lock class, which is what lockblocking keys on: it reports a wait made while
+// a CLASSED lock is held, so a type with no class of its own would leave waitUnderLock below
+// silent and the coverage lost without a single message going missing elsewhere.
+//
+// +lockclass:canary.Canary
+type canary struct {
+	lock RWMutex
+	// +checklocks:lock
+	value int
+}
+
+// setValueLocked writes the guarded field the way it is supposed to be done. It must never
+// be reported, a violation here means the forwarding methods stopped working.
+func (c *canary) setValueLocked(value int) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.value = value
+}
+
+// setValue writes the guarded field without holding the lock. The self test in the Makefile
+// requires the analysis to report "invalid field access" for this line.
+func (c *canary) setValue(value int) {
+	c.value = value
+}
+
+// setValueSelfLocking takes the lock itself, which makes it invalid to call while the lock
+// is held. It must never be reported itself.
+// +checklocksexclude:c.lock
+func (c *canary) setValueSelfLocking(value int) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.value = value
+}
+
+// reEnter calls a method that excludes the lock while holding it, the self deadlock shape.
+// The self test in the Makefile requires the analysis to report "must not hold" for this
+// line.
+func (c *canary) reEnter(value int) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.setValueSelfLocking(value)
+}
+
+// relock takes and releases the lock twice over, which is balanced. It must never be reported.
+func (c *canary) relock(value int) {
+	c.lock.Lock()
+	c.value = value
+	c.lock.Unlock()
+	c.lock.Lock()
+	c.value = value
+	c.lock.Unlock()
+}
+
+// doubleLock takes the lock a second time on the same path, the self deadlock shape at its
+// simplest. The self test in the Makefile requires the analysis to report "already locked"
+// for this line.
+//
+// The diagnostic only exists while the wrappers declare themselves lock primitives. Without
+// that declaration the forwarding methods need a "+checklocksignore" each, and an ignore is
+// read at every call site of the function that carries it, so the whole class disappears for
+// every wrapper lock in the shim while every other message of this fixture stays exactly as
+// it is.
+func (c *canary) doubleLock(value int) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.lock.Lock()
+	c.value = value
+}
+
+// derivedCanary is the subject of the derived exclusion fixture. Its lock and its field are
+// apart from the ones above so a diagnostic about either can only have come from here.
+type derivedCanary struct {
+	lock         RWMutex
+	derivedValue int // +checklocks:lock
+}
+
+// derivedSelfLocking carries no exclusion annotation on purpose. It takes its own lock, which
+// is all the analysis needs to know that a caller holding that lock deadlocks, so the fact is
+// derived from this body. The hand written exclusions the shim used to carry on every method
+// of this shape were deleted on the strength of that derivation.
+func (d *derivedCanary) derivedSelfLocking(value int) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.derivedValue = value
+}
+
+// derivedReentrantCall holds the lock over a call to a method that takes it. Nothing states
+// the exclusion, so the analysis must have derived it, and the self test requires the message
+// by the callee's name: the exclusions written by hand elsewhere in this fixture would keep it
+// green otherwise.
+func (d *derivedCanary) derivedReentrantCall(value int) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.derivedSelfLocking(value)
+}
+
+// structGuardCanary states the guard once, on the type, instead of once per field. Every field
+// is guarded by it except the ones opting out, which is how the shim caches are annotated since
+// the per field guards were collapsed.
+//
+// +checklocksguardedby:lock
+type structGuardCanary struct {
+	lock               RWMutex
+	structGuardedValue int
+	// +checklocksunguarded
+	structFixedValue int
+}
+
+// structGuardedWrite writes the guarded field with the lock held. It must never be reported.
+func (s *structGuardCanary) structGuardedWrite(value int) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.structGuardedValue = value
+}
+
+// structGuardViolation writes a field that carries no annotation of its own without the lock,
+// so it is only guarded while the annotation on the type expands to it. The self test requires
+// the message by the field's name. The second write must never be reported: an expansion that
+// ignored the opt out would report both, and requiring only the first message would pass in
+// that world too.
+func (s *structGuardCanary) structGuardViolation(value int) {
+	s.structGuardedValue = value
+	s.structFixedValue = value
+}
+
+// callbackCanary is the subject of the callback fixture below. Its guarded field is named
+// apart from the one above so a diagnostic about it can only have come from there.
+type callbackCanary struct {
+	lock RWMutex
+	// +checklocks:lock
+	callbackValue int
+}
+
+// callbackSelfLocking takes the subject's own lock, so holding it on entry would deadlock.
+// +checklocksexclude:c.lock
+func (c *callbackCanary) callbackSelfLocking(value int) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.callbackValue = value
+}
+
+// callbackEvent stands in for what a state machine library hands a callback: the subject
+// arrives inside an interface and the body recovers it by asserting a type.
+type callbackEvent struct {
+	Args []any
+}
+
+// callbackTable is the shape the fsm callbacks in pkg/cache have: a table of literals handed
+// to a library, each stating the lock its caller holds by naming the value its own body
+// recovers, because that value exists nowhere else to be named.
+//
+// Both polarities are in the one literal. The write through the asserted subject is correct
+// and must never be reported, and the call below it must be, because the guard put that
+// subject's lock in scope and the callee takes it again.
+//
+// The second is what the self test requires, and it is the only message here that a guard
+// which stopped binding would take with it: a guard matching nothing records no lock,
+// silently, and then the call is fine while the write is reported instead. Requiring the
+// report on the WRITE would pass in both worlds and prove nothing.
+func callbackTable() map[string]func(*callbackEvent) {
+	return map[string]func(*callbackEvent){
+		// +checklocks:event.Args[0].(*callbackCanary).lock
+		"enter": func(event *callbackEvent) {
+			subject := event.Args[0].(*callbackCanary)
+			subject.callbackValue = 1
+			subject.callbackSelfLocking(2)
+		},
+	}
+}
+
+// String reads a guarded field from a method that is evaluated wherever a log entry is encoded,
+// which the stringer analysis reports. The guarded field check is silenced here on purpose: it
+// is the usual way this hazard is hidden, and the stringer analysis is meant to report it
+// anyway. That also leaves setValue as the only source of the guarded field diagnostic, so the
+// self test covers one fixture per analysis.
+// +checklocksignore
+func (c *canary) String() string {
+	return fmt.Sprintf("canary %d", c.value)
+}
+
+// waitUnderLock waits on a channel with the lock held, which the blocking analysis reports.
+func (c *canary) waitUnderLock(ch chan int) int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return <-ch
+}

--- a/pkg/locking/forwarders.go
+++ b/pkg/locking/forwarders.go
@@ -1,0 +1,74 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package locking
+
+// The methods below forward to the inner lock, they are the complete lock API of this
+// package. Two things about the shape are deliberate:
+//
+// The inner lock is a named field and not embedded. Embedding promotes the whole
+// go-deadlock API, which includes TryLock, TryRLock and RLocker. The first two would be
+// tracked against the inner field by the gVisor checklocks analysis instead of the wrapper
+// and the last one hands out a plain sync.Locker that cannot be tracked at all. With a
+// named field none of them exist on the wrapper: using one becomes a compile error and thus
+// a deliberate decision instead of a silent hole in the analysis.
+//
+// The forwarding itself exists so that checklocks (see the "vetlock" make target) tracks
+// the locking.Mutex and locking.RWMutex fields directly. When the inner lock is called
+// directly the analysis attributes the acquisition to the inner field, i.e. "lock.mu"
+// instead of "lock", and all "+checklocks:" field annotations fail to match. The forwarders
+// need nothing of their own from the analysis: the wrapper types declare themselves lock
+// primitives (see locking.go), so a call to one is intercepted at the call site exactly as a
+// call to the inner lock would be and the body is not analysed, a lock implementation not
+// being a critical section. Until that declaration existed every forwarder carried a
+// "+checklocksignore" instead, because a lock method acquires a lock and returns while
+// holding it, which is exactly what the lock balance check flags. Those ignores are gone, and
+// with them the checking they cost: an ignore is read at every call site of the function that
+// carries it, so one per forwarder suppressed the "already locked" and "unlock without lock"
+// diagnostics for every wrapper lock in the code base. That class is checked again. The rest
+// of the lock state tracking never depended on this: guarded field access, the lock
+// preconditions of a function and the lock balance of the calling function were all still
+// checked.
+//
+// The forwarding costs nothing at runtime, the methods are inlined. The only visible effect
+// is one extra stack frame in a go-deadlock report: the "<<<<<" marker points at the
+// forwarder in this file with the real caller one frame below it.
+
+func (m *Mutex) Lock() {
+	m.mu.Lock()
+}
+
+func (m *Mutex) Unlock() {
+	m.mu.Unlock()
+}
+
+func (m *RWMutex) Lock() {
+	m.mu.Lock()
+}
+
+func (m *RWMutex) Unlock() {
+	m.mu.Unlock()
+}
+
+func (m *RWMutex) RLock() {
+	m.mu.RLock()
+}
+
+func (m *RWMutex) RUnlock() {
+	m.mu.RUnlock()
+}

--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -35,10 +35,19 @@ func init() {
 	})
 }
 
+// Mutex, and RWMutex below it, declare themselves lock primitives to the checklocks analysis.
+// Without the declaration the analysis recognises a lock by its type name only, so the
+// forwarders in forwarders.go read as ordinary methods that take a lock and return without
+// releasing it and every one of them needs a "+checklocksignore" to silence that; see
+// forwarders.go for what those ignores cost. Whether a type behaves as a Mutex or an RWMutex
+// is taken from the type itself: it has an RLock method or it does not.
+//
+// +checklockslocktype
 type Mutex struct {
-	godeadlock.Mutex
+	mu godeadlock.Mutex
 }
 
+// +checklockslocktype
 type RWMutex struct {
-	godeadlock.RWMutex
+	mu godeadlock.RWMutex
 }

--- a/pkg/plugin/support/nodeinfo_lister.go
+++ b/pkg/plugin/support/nodeinfo_lister.go
@@ -30,19 +30,23 @@ type nodeInfoListerImpl struct {
 	cache *external.SchedulerCache
 }
 
-func (n nodeInfoListerImpl) List() ([]fwk.NodeInfo, error) {
+// +checklocksread:n.cache.lock
+func (n *nodeInfoListerImpl) List() ([]fwk.NodeInfo, error) {
 	return n.cache.GetNodesInfo(), nil
 }
 
-func (n nodeInfoListerImpl) HavePodsWithAffinityList() ([]fwk.NodeInfo, error) {
+// +checklocksread:n.cache.lock
+func (n *nodeInfoListerImpl) HavePodsWithAffinityList() ([]fwk.NodeInfo, error) {
 	return n.cache.GetNodesInfoPodsWithAffinity(), nil
 }
 
-func (n nodeInfoListerImpl) HavePodsWithRequiredAntiAffinityList() ([]fwk.NodeInfo, error) {
+// +checklocksread:n.cache.lock
+func (n *nodeInfoListerImpl) HavePodsWithRequiredAntiAffinityList() ([]fwk.NodeInfo, error) {
 	return n.cache.GetNodesInfoPodsWithReqAntiAffinity(), nil
 }
 
-func (n nodeInfoListerImpl) Get(nodeName string) (fwk.NodeInfo, error) {
+// +checklocksread:n.cache.lock
+func (n *nodeInfoListerImpl) Get(nodeName string) (fwk.NodeInfo, error) {
 	nodes := n.cache.GetNodesInfoMap()
 	node, ok := nodes[nodeName]
 	if !ok {

--- a/pkg/plugin/support/storageinfo_lister.go
+++ b/pkg/plugin/support/storageinfo_lister.go
@@ -28,7 +28,8 @@ type storageInfoListerImpl struct {
 	cache *external.SchedulerCache
 }
 
-func (s storageInfoListerImpl) IsPVCUsedByPods(key string) bool {
+// +checklocksread:s.cache.lock
+func (s *storageInfoListerImpl) IsPVCUsedByPods(key string) bool {
 	return s.cache.IsPVCUsedByPods(key)
 }
 

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -45,13 +45,14 @@ import (
 
 // shim scheduler watches api server and interacts with unity scheduler to allocate pods
 type KubernetesShim struct {
-	apiFactory           client.APIProvider
-	context              *cache.Context
-	phManager            *cache.PlaceholderManager
-	callback             api.ResourceManagerCallback
-	stopChan             chan struct{}
-	stopOnce             sync.Once
-	lock                 *locking.RWMutex
+	apiFactory client.APIProvider
+	context    *cache.Context
+	phManager  *cache.PlaceholderManager
+	callback   api.ResourceManagerCallback
+	stopChan   chan struct{}
+	stopOnce   sync.Once
+	lock       *locking.RWMutex
+	// +checklocks:lock
 	outstandingAppsFound bool
 }
 

--- a/scripts/vetlock/go.mod
+++ b/scripts/vetlock/go.mod
@@ -25,7 +25,7 @@ go 1.25.0
 // annotations in this repository either panic the tool or are silently dropped, plus the
 // additional analyses this repository runs. The module is a temporary home until a permanent one
 // is sorted out.
-require github.com/tigerquoll/vet-lock v0.8.0
+require github.com/tigerquoll/vet-lock v0.9.0
 
 require (
 	golang.org/x/mod v0.34.0 // indirect

--- a/scripts/vetlock/go.mod
+++ b/scripts/vetlock/go.mod
@@ -1,0 +1,34 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+module github.com/apache/yunikorn-k8shim/scripts/vetlock
+
+go 1.25.0
+
+// The analyser is taken from a standalone module rather than from gvisor: it is the gvisor
+// checklocks analyser with the fixes that are still pending upstream, without which the
+// annotations in this repository either panic the tool or are silently dropped, plus the
+// additional analyses this repository runs. The module is a temporary home until a permanent one
+// is sorted out.
+require github.com/tigerquoll/vet-lock v0.8.0
+
+require (
+	golang.org/x/mod v0.34.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/tools v0.43.0 // indirect
+)

--- a/scripts/vetlock/go.sum
+++ b/scripts/vetlock/go.sum
@@ -1,0 +1,10 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/tigerquoll/vet-lock v0.8.0 h1:jkKENXlq90tT4zJeyvYK8OWsSvRrnDLgYu5nzZDhD90=
+github.com/tigerquoll/vet-lock v0.8.0/go.mod h1:B/0U+gEZGlGFA2FPye3ayBiACsx/P4FshTQ3lSX1QjE=
+golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
+golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
+golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=

--- a/scripts/vetlock/go.sum
+++ b/scripts/vetlock/go.sum
@@ -1,7 +1,7 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/tigerquoll/vet-lock v0.8.0 h1:jkKENXlq90tT4zJeyvYK8OWsSvRrnDLgYu5nzZDhD90=
-github.com/tigerquoll/vet-lock v0.8.0/go.mod h1:B/0U+gEZGlGFA2FPye3ayBiACsx/P4FshTQ3lSX1QjE=
+github.com/tigerquoll/vet-lock v0.9.0 h1:S3kBDwEILlfrBQjy4qZs9rsDBsIM9w7bIOEa+x1EGHM=
+github.com/tigerquoll/vet-lock v0.9.0/go.mod h1:B/0U+gEZGlGFA2FPye3ayBiACsx/P4FshTQ3lSX1QjE=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/scripts/vetlock/tools.go
+++ b/scripts/vetlock/tools.go
@@ -1,0 +1,28 @@
+//go:build tools
+
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package tools pins the build tools that are not imported by the code base. This is a
+// module of its own so that the tool dependencies never end up in the go.mod of the shim
+// itself. The blank import is what keeps the version in go.mod and go.sum.
+package tools
+
+import (
+	_ "github.com/tigerquoll/vet-lock/cmd/vet-lock"
+)


### PR DESCRIPTION
### Description

Machine-checks the lock conventions that are today enforced only by review (which fields a lock guards, which functions require a lock held on entry, which must not be called with a lock held, `String()` taking its own lock). Adds the [vet-lock](https://github.com/tigerquoll/vet-lock) static analyser pinned in an isolated tools module, wires it into `make vetlock` / `test_all` / pre-commit, and annotates the shim. Companion of the core PR apache/yunikorn-core#1137.

Behaviour-neutral apart from one test-support fix (`pkg/common/test/schedulerapi_mock.go`: `RegisterFunction` now takes the mock's lock like its three sibling setters). The annotations are comments; the only other runtime code change is the `pkg/locking` named-field lock + forwarding methods (inlined) that let annotations resolve to the wrapper field.

- **Analysers gated**: `checklocks`, `lockstringer`, `lockblocking` (as in core).
- **Tool pinned**: `github.com/tigerquoll/vet-lock v0.8.0` in `scripts/vetlock`; `-checklocks.inferred=false`.
- **Annotated**: `pkg/locking`, `pkg/cache` (+ `external`), `pkg/admission`, `pkg/client`, `pkg/dispatcher`, `pkg/shim`, `pkg/plugin`, `pkg/common/test`, `pkg/cmd/admissioncontroller`. FSM callback dispatch sites carry line-level ignores with a comment: the lock is held by `Application`/`Task.handle` but the acquisition is invisible across the fsm library boundary.
- **Canary** fixture fails the build if an analyser silently stops covering what it should.
- `+lockclass:<name>` declarations kept for `lockblocking`; lock-ordering relations are a separate PR.

**The suppression list is a burn-down list.** Pre-existing locking issues surfaced while annotating are marked in-code with a one-line `// YUNIKORN-NNNN:` marker plus the ignore directive; each is its own JIRA (linked from YUNIKORN-3408) with the analysis and the fix shape, and each fix PR deletes its marker. None is fixed here — same split as YUNIKORN-3357.

Not in this PR: lock-order analyser / runtime lock-class checker; `lockgap`.

Worth noting: rebasing this branch onto current master made the gate report two new sites in code merged since the annotations were written — YUNIKORN-2884 runs both bind attempts through `retry.OnError` (up to ~121 s of backoff) while holding the task write lock. That is the class of change the gate is meant to stop at review time; it is marked and tracked as YUNIKORN-3426 (its own JIRA), not fixed here.

### Type of change

- [x] Improvement

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3408

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
Generated by the Author with assistance from Claude Code
- [x] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths. (The canary fixture is the test of the gate.)
- [x] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported. (No runtime change to exercise end-to-end.)
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
`make vetlock` produces no output on this branch. The canary stage of the same target proves each analyser still reports: it runs the fixture with one known violation per check and fails the build if any expected report is missing.
