### PR TITLE
[YUNIKORN-3404] Make PlaceholderManager lifecycle concurrency-safe

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -634,9 +634,7 @@ func (app *Application) handleRejectApplicationEvent(reason string) {
 }
 
 func (app *Application) handleCompleteApplicationEvent() {
-	go func() {
-		getPlaceholderManager().cleanUp(app)
-	}()
+	getPlaceholderManager().cleanUpAsync(app)
 }
 
 func failTaskPodWithReasonAndMsg(task *Task, reason string, msg string) {
@@ -656,9 +654,7 @@ func failTaskPodWithReasonAndMsg(task *Task, reason string, msg string) {
 }
 
 func (app *Application) handleFailApplicationEvent(errMsg string) {
-	go func() {
-		getPlaceholderManager().cleanUp(app)
-	}()
+	getPlaceholderManager().cleanUpAsync(app)
 	app.clearReleaseableTasks()
 	log.Log(log.ShimCacheApplication).Info("failApplication reason", zap.String("applicationID", app.applicationID), zap.String("errMsg", errMsg))
 	// unallocated task states include New, Pending and Scheduling

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -237,7 +237,7 @@ func TestSetUnallocatedPodsToFailedWhenFailApplication(t *testing.T) {
 			Requests: resources,
 		},
 	})
-	pod1, err := mockClient.Create(&v1.Pod{
+	pod1, err := mockClient.Create(t.Context(), &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
@@ -251,7 +251,7 @@ func TestSetUnallocatedPodsToFailedWhenFailApplication(t *testing.T) {
 		},
 	})
 	assert.NilError(t, err)
-	pod2, err := mockClient.Create(&v1.Pod{
+	pod2, err := mockClient.Create(t.Context(), &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
@@ -265,7 +265,7 @@ func TestSetUnallocatedPodsToFailedWhenFailApplication(t *testing.T) {
 		},
 	})
 	assert.NilError(t, err)
-	pod3, err := mockClient.Create(&v1.Pod{
+	pod3, err := mockClient.Create(t.Context(), &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
@@ -342,7 +342,7 @@ func TestSetUnallocatedPodsToFailedWhenRejectApplication(t *testing.T) {
 			Requests: resources,
 		},
 	})
-	pod1, err := mockClient.Create(&v1.Pod{
+	pod1, err := mockClient.Create(t.Context(), &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
@@ -356,7 +356,7 @@ func TestSetUnallocatedPodsToFailedWhenRejectApplication(t *testing.T) {
 		},
 	})
 	assert.NilError(t, err)
-	pod2, err := mockClient.Create(&v1.Pod{
+	pod2, err := mockClient.Create(t.Context(), &v1.Pod{
 		TypeMeta: apis.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",

--- a/pkg/cache/placeholder_manager.go
+++ b/pkg/cache/placeholder_manager.go
@@ -19,7 +19,9 @@
 package cache
 
 import (
+	"context"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -40,7 +42,12 @@ type PlaceholderManager struct {
 	// and keep retrying deleting them in order to avoid wasting resources.
 	orphanPods  map[string]*v1.Pod
 	stopChan    chan struct{}
+	doneChan    chan struct{}
+	stopOnce    sync.Once
+	started     atomic.Bool
 	running     atomic.Bool
+	cancel      context.CancelFunc
+	cleanupCtx  context.Context
 	cleanupTime time.Duration
 	// a simple mutex will do we do not have separate read and write paths
 	locking.RWMutex
@@ -54,10 +61,14 @@ var (
 func NewPlaceholderManager(clients *client.Clients) *PlaceholderManager {
 	mu.Lock()
 	defer mu.Unlock()
+	cleanupCtx, cancel := context.WithCancel(context.Background())
 	placeholderMgr = &PlaceholderManager{
 		clients:     clients,
 		orphanPods:  make(map[string]*v1.Pod),
 		stopChan:    make(chan struct{}),
+		doneChan:    make(chan struct{}),
+		cleanupCtx:  cleanupCtx,
+		cancel:      cancel,
 		cleanupTime: 5 * time.Second,
 	}
 	return placeholderMgr
@@ -103,18 +114,18 @@ func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
 
 // clean up all the placeholders for an application
 func (mgr *PlaceholderManager) cleanUp(app *Application) {
-	mgr.Lock()
-	defer mgr.Unlock()
 	log.Log(log.ShimCachePlaceholder).Info("start to clean up app placeholders",
 		zap.String("appID", app.GetApplicationID()))
 	for _, task := range app.GetPlaceHolderTasks() {
 		// remove pod
-		err := mgr.clients.KubeClient.Delete(task.GetTaskPod())
+		err := mgr.clients.KubeClient.Delete(context.Background(), task.GetTaskPod())
 		if err != nil {
 			log.Log(log.ShimCachePlaceholder).Warn("failed to clean up placeholder pod",
 				zap.Error(err))
 			if !strings.Contains(err.Error(), "not found") {
+				mgr.Lock()
 				mgr.orphanPods[task.GetTaskID()] = task.GetTaskPod()
+				mgr.Unlock()
 			}
 		}
 	}
@@ -122,51 +133,78 @@ func (mgr *PlaceholderManager) cleanUp(app *Application) {
 		zap.String("appID", app.GetApplicationID()))
 }
 
-func (mgr *PlaceholderManager) cleanOrphanPlaceholders() {
-	mgr.Lock()
-	defer mgr.Unlock()
+func (mgr *PlaceholderManager) cleanOrphanPlaceholders(ctx context.Context) {
+	type orphanPod struct {
+		taskID string
+		pod    *v1.Pod
+	}
+	mgr.RLock()
+	orphans := make([]orphanPod, 0, len(mgr.orphanPods))
 	for taskID, pod := range mgr.orphanPods {
+		orphans = append(orphans, orphanPod{taskID: taskID, pod: pod})
+	}
+	mgr.RUnlock()
+
+	for _, orphan := range orphans {
+		if ctx.Err() != nil {
+			return
+		}
 		log.Log(log.ShimCachePlaceholder).Debug("start to clean up orphan pod",
-			zap.String("taskID", taskID),
-			zap.String("podName", pod.Name))
-		err := mgr.clients.KubeClient.Delete(pod)
+			zap.String("taskID", orphan.taskID),
+			zap.String("podName", orphan.pod.Name))
+		err := mgr.clients.KubeClient.Delete(ctx, orphan.pod)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			log.Log(log.ShimCachePlaceholder).Warn("failed to clean up orphan pod", zap.Error(err))
 		} else {
-			delete(mgr.orphanPods, taskID)
+			mgr.Lock()
+			if mgr.orphanPods[orphan.taskID] == orphan.pod {
+				delete(mgr.orphanPods, orphan.taskID)
+			}
+			mgr.Unlock()
 		}
 	}
 }
 
 func (mgr *PlaceholderManager) Start() {
-	if mgr.isRunning() {
+	if !mgr.started.CompareAndSwap(false, true) {
 		log.Log(log.ShimCachePlaceholder).Info("PlaceholderManager is already started")
 		return
 	}
 	log.Log(log.ShimCachePlaceholder).Info("starting the PlaceholderManager")
 	mgr.setRunning(true)
 	go func() {
-		// clean orphan placeholders approximately every 5 seconds
+		ticker := time.NewTicker(mgr.getCleanupTime())
+		defer func() {
+			ticker.Stop()
+			mgr.setRunning(false)
+			close(mgr.doneChan)
+			log.Log(log.ShimCachePlaceholder).Info("PlaceholderManager has been stopped")
+		}()
 		for {
 			select {
 			case <-mgr.stopChan:
-				mgr.setRunning(false)
-				log.Log(log.ShimCachePlaceholder).Info("PlaceholderManager has been stopped")
 				return
-			case <-time.After(mgr.getCleanupTime()):
-				mgr.cleanOrphanPlaceholders()
+			case <-ticker.C:
+				mgr.cleanOrphanPlaceholders(mgr.cleanupCtx)
 			}
 		}
 	}()
 }
 
 func (mgr *PlaceholderManager) Stop() {
-	if !mgr.isRunning() {
+	if !mgr.started.Load() {
 		log.Log(log.ShimCachePlaceholder).Info("PlaceholderManager already stopped")
 		return
 	}
-	log.Log(log.ShimCachePlaceholder).Info("stopping the PlaceholderManager")
-	mgr.stopChan <- struct{}{}
+	mgr.stopOnce.Do(func() {
+		log.Log(log.ShimCachePlaceholder).Info("stopping the PlaceholderManager")
+		mgr.cancel()
+		close(mgr.stopChan)
+	})
+	<-mgr.doneChan
 }
 
 func (mgr *PlaceholderManager) isRunning() bool {

--- a/pkg/cache/placeholder_manager.go
+++ b/pkg/cache/placeholder_manager.go
@@ -43,18 +43,16 @@ type PlaceholderManager struct {
 	orphanPods map[string]*v1.Pod
 	stopChan   chan struct{}
 	// closed when the cleanup loop exits so Stop can wait for shutdown to complete
-	doneChan    chan struct{}
-	stopOnce    sync.Once
-	started     atomic.Bool
-	cancel      context.CancelFunc
-	cleanupCtx  context.Context
-	cleanupTime time.Duration
+	doneChan     chan struct{}
+	stopOnce     sync.Once
+	started      atomic.Bool
+	cancel       context.CancelFunc
+	lifecycleCtx context.Context
+	cleanupTime  time.Duration
 	// serializes placeholder creation with application cleanup
 	operationLock locking.Mutex
-	// prevents cleanup work from being added after shutdown begins
-	cleanupLock    locking.Mutex
-	cleanupWorkers sync.WaitGroup
-	stopping       bool
+	// operations hold a read lock; Stop cancels them before waiting for the write lock
+	lifecycleGate locking.RWMutex
 	// protects orphanPods and cleanupTime
 	locking.RWMutex
 }
@@ -67,15 +65,15 @@ var (
 func NewPlaceholderManager(clients *client.Clients) *PlaceholderManager {
 	mu.Lock()
 	defer mu.Unlock()
-	cleanupCtx, cancel := context.WithCancel(context.Background())
+	lifecycleCtx, cancel := context.WithCancel(context.Background())
 	placeholderMgr = &PlaceholderManager{
-		clients:     clients,
-		orphanPods:  make(map[string]*v1.Pod),
-		stopChan:    make(chan struct{}),
-		doneChan:    make(chan struct{}),
-		cleanupCtx:  cleanupCtx,
-		cancel:      cancel,
-		cleanupTime: 5 * time.Second,
+		clients:      clients,
+		orphanPods:   make(map[string]*v1.Pod),
+		stopChan:     make(chan struct{}),
+		doneChan:     make(chan struct{}),
+		lifecycleCtx: lifecycleCtx,
+		cancel:       cancel,
+		cleanupTime:  5 * time.Second,
 	}
 	return placeholderMgr
 }
@@ -87,8 +85,16 @@ func getPlaceholderManager() *PlaceholderManager {
 }
 
 func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
+	mgr.lifecycleGate.RLock()
+	defer mgr.lifecycleGate.RUnlock()
+	if err := mgr.lifecycleCtx.Err(); err != nil {
+		return err
+	}
 	mgr.operationLock.Lock()
 	defer mgr.operationLock.Unlock()
+	if err := mgr.lifecycleCtx.Err(); err != nil {
+		return err
+	}
 
 	// map task group to count of already created placeholders
 	tgCounts := make(map[string]int32)
@@ -101,10 +107,13 @@ func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
 		count := tgCounts[tg.Name]
 		// only create missing pods for each task group
 		for i := count; i < tg.MinMember; i++ {
+			if err := mgr.lifecycleCtx.Err(); err != nil {
+				return err
+			}
 			placeholderName := GeneratePlaceholderName(tg.Name, app.GetApplicationID())
 			placeholder := newPlaceholder(placeholderName, app, tg)
 			// create the placeholder on K8s
-			_, err := mgr.clients.KubeClient.Create(placeholder.pod)
+			_, err := mgr.clients.KubeClient.Create(mgr.lifecycleCtx, placeholder.pod)
 			if err != nil {
 				log.Log(log.ShimCachePlaceholder).Error("failed to create placeholder pod",
 					zap.Error(err))
@@ -120,16 +129,27 @@ func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
 
 // clean up all the placeholders for an application
 func (mgr *PlaceholderManager) cleanUp(app *Application) {
+	mgr.lifecycleGate.RLock()
+	defer mgr.lifecycleGate.RUnlock()
+	if mgr.lifecycleCtx.Err() != nil {
+		return
+	}
 	mgr.operationLock.Lock()
 	defer mgr.operationLock.Unlock()
+	if mgr.lifecycleCtx.Err() != nil {
+		return
+	}
 
 	log.Log(log.ShimCachePlaceholder).Info("start to clean up app placeholders",
 		zap.String("appID", app.GetApplicationID()))
 	for _, task := range app.GetPlaceHolderTasks() {
+		if mgr.lifecycleCtx.Err() != nil {
+			return
+		}
 		// remove pod
-		err := mgr.clients.KubeClient.Delete(mgr.cleanupCtx, task.GetTaskPod())
+		err := mgr.clients.KubeClient.Delete(mgr.lifecycleCtx, task.GetTaskPod())
 		if err != nil {
-			if mgr.cleanupCtx.Err() != nil {
+			if mgr.lifecycleCtx.Err() != nil {
 				return
 			}
 			log.Log(log.ShimCachePlaceholder).Warn("failed to clean up placeholder pod",
@@ -146,51 +166,37 @@ func (mgr *PlaceholderManager) cleanUp(app *Application) {
 }
 
 func (mgr *PlaceholderManager) cleanUpAsync(app *Application) {
-	mgr.cleanupLock.Lock()
-	if !mgr.started.Load() || mgr.stopping {
-		mgr.cleanupLock.Unlock()
+	if !mgr.started.Load() {
 		return
 	}
-	mgr.cleanupWorkers.Add(1)
-	mgr.cleanupLock.Unlock()
-
-	go func() {
-		defer mgr.cleanupWorkers.Done()
-		mgr.cleanUp(app)
-	}()
+	// The operation checks cancellation under the lifecycle gate even if this
+	// goroutine is not scheduled until after Stop returns.
+	go mgr.cleanUp(app)
 }
 
-func (mgr *PlaceholderManager) cleanOrphanPlaceholders(ctx context.Context) {
-	type orphanPod struct {
-		taskID string
-		pod    *v1.Pod
+func (mgr *PlaceholderManager) cleanOrphanPlaceholders() {
+	mgr.lifecycleGate.RLock()
+	defer mgr.lifecycleGate.RUnlock()
+	if mgr.lifecycleCtx.Err() != nil {
+		return
 	}
-	mgr.RLock()
-	orphans := make([]orphanPod, 0, len(mgr.orphanPods))
+	mgr.Lock()
+	defer mgr.Unlock()
 	for taskID, pod := range mgr.orphanPods {
-		orphans = append(orphans, orphanPod{taskID: taskID, pod: pod})
-	}
-	mgr.RUnlock()
-
-	for _, orphan := range orphans {
-		if ctx.Err() != nil {
+		if mgr.lifecycleCtx.Err() != nil {
 			return
 		}
 		log.Log(log.ShimCachePlaceholder).Debug("start to clean up orphan pod",
-			zap.String("taskID", orphan.taskID),
-			zap.String("podName", orphan.pod.Name))
-		err := mgr.clients.KubeClient.Delete(ctx, orphan.pod)
+			zap.String("taskID", taskID),
+			zap.String("podName", pod.Name))
+		err := mgr.clients.KubeClient.Delete(mgr.lifecycleCtx, pod)
 		if err != nil {
-			if ctx.Err() != nil {
+			if mgr.lifecycleCtx.Err() != nil {
 				return
 			}
 			log.Log(log.ShimCachePlaceholder).Warn("failed to clean up orphan pod", zap.Error(err))
 		} else {
-			mgr.Lock()
-			if mgr.orphanPods[orphan.taskID] == orphan.pod {
-				delete(mgr.orphanPods, orphan.taskID)
-			}
-			mgr.Unlock()
+			delete(mgr.orphanPods, taskID)
 		}
 	}
 }
@@ -205,15 +211,16 @@ func (mgr *PlaceholderManager) Start() {
 		ticker := time.NewTicker(mgr.getCleanupTime())
 		defer func() {
 			ticker.Stop()
-			close(mgr.doneChan)
 			log.Log(log.ShimCachePlaceholder).Info("PlaceholderManager has been stopped")
+			// Closing broadcasts completion to every Stop caller; no send is needed.
+			close(mgr.doneChan)
 		}()
 		for {
 			select {
 			case <-mgr.stopChan:
 				return
 			case <-ticker.C:
-				mgr.cleanOrphanPlaceholders(mgr.cleanupCtx)
+				mgr.cleanOrphanPlaceholders()
 			}
 		}
 	}()
@@ -226,15 +233,16 @@ func (mgr *PlaceholderManager) Stop() {
 	}
 	mgr.stopOnce.Do(func() {
 		log.Log(log.ShimCachePlaceholder).Info("stopping the PlaceholderManager")
-		mgr.cleanupLock.Lock()
-		mgr.stopping = true
 		mgr.cancel()
 		close(mgr.stopChan)
-		mgr.cleanupLock.Unlock()
 	})
+	// Cancel before waiting: active API requests must be able to release readers.
+	mgr.lifecycleGate.Lock()
+	mgr.lifecycleGate.Unlock() //nolint:staticcheck // The empty critical section is a barrier waiting for active operations.
+	// Do not hold the write lock here: the loop may be waiting for a read lock.
 	<-mgr.doneChan
-	mgr.cleanupWorkers.Wait()
 }
+
 func (mgr *PlaceholderManager) getOrphanPodsLength() int {
 	mgr.RLock()
 	defer mgr.RUnlock()

--- a/pkg/cache/placeholder_manager.go
+++ b/pkg/cache/placeholder_manager.go
@@ -40,16 +40,22 @@ type PlaceholderManager struct {
 	// when the placeholder manager is unable to delete a pod,
 	// this pod becomes to be an "orphan" pod. We add them to a map
 	// and keep retrying deleting them in order to avoid wasting resources.
-	orphanPods  map[string]*v1.Pod
-	stopChan    chan struct{}
+	orphanPods map[string]*v1.Pod
+	stopChan   chan struct{}
+	// closed when the cleanup loop exits so Stop can wait for shutdown to complete
 	doneChan    chan struct{}
 	stopOnce    sync.Once
 	started     atomic.Bool
-	running     atomic.Bool
 	cancel      context.CancelFunc
 	cleanupCtx  context.Context
 	cleanupTime time.Duration
-	// a simple mutex will do we do not have separate read and write paths
+	// serializes placeholder creation with application cleanup
+	operationLock locking.Mutex
+	// prevents cleanup work from being added after shutdown begins
+	cleanupLock    locking.Mutex
+	cleanupWorkers sync.WaitGroup
+	stopping       bool
+	// protects orphanPods and cleanupTime
 	locking.RWMutex
 }
 
@@ -81,8 +87,8 @@ func getPlaceholderManager() *PlaceholderManager {
 }
 
 func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
-	mgr.Lock()
-	defer mgr.Unlock()
+	mgr.operationLock.Lock()
+	defer mgr.operationLock.Unlock()
 
 	// map task group to count of already created placeholders
 	tgCounts := make(map[string]int32)
@@ -114,12 +120,18 @@ func (mgr *PlaceholderManager) createAppPlaceholders(app *Application) error {
 
 // clean up all the placeholders for an application
 func (mgr *PlaceholderManager) cleanUp(app *Application) {
+	mgr.operationLock.Lock()
+	defer mgr.operationLock.Unlock()
+
 	log.Log(log.ShimCachePlaceholder).Info("start to clean up app placeholders",
 		zap.String("appID", app.GetApplicationID()))
 	for _, task := range app.GetPlaceHolderTasks() {
 		// remove pod
-		err := mgr.clients.KubeClient.Delete(context.Background(), task.GetTaskPod())
+		err := mgr.clients.KubeClient.Delete(mgr.cleanupCtx, task.GetTaskPod())
 		if err != nil {
+			if mgr.cleanupCtx.Err() != nil {
+				return
+			}
 			log.Log(log.ShimCachePlaceholder).Warn("failed to clean up placeholder pod",
 				zap.Error(err))
 			if !strings.Contains(err.Error(), "not found") {
@@ -131,6 +143,21 @@ func (mgr *PlaceholderManager) cleanUp(app *Application) {
 	}
 	log.Log(log.ShimCachePlaceholder).Info("finished cleaning up app placeholders",
 		zap.String("appID", app.GetApplicationID()))
+}
+
+func (mgr *PlaceholderManager) cleanUpAsync(app *Application) {
+	mgr.cleanupLock.Lock()
+	if !mgr.started.Load() || mgr.stopping {
+		mgr.cleanupLock.Unlock()
+		return
+	}
+	mgr.cleanupWorkers.Add(1)
+	mgr.cleanupLock.Unlock()
+
+	go func() {
+		defer mgr.cleanupWorkers.Done()
+		mgr.cleanUp(app)
+	}()
 }
 
 func (mgr *PlaceholderManager) cleanOrphanPlaceholders(ctx context.Context) {
@@ -174,12 +201,10 @@ func (mgr *PlaceholderManager) Start() {
 		return
 	}
 	log.Log(log.ShimCachePlaceholder).Info("starting the PlaceholderManager")
-	mgr.setRunning(true)
 	go func() {
 		ticker := time.NewTicker(mgr.getCleanupTime())
 		defer func() {
 			ticker.Stop()
-			mgr.setRunning(false)
 			close(mgr.doneChan)
 			log.Log(log.ShimCachePlaceholder).Info("PlaceholderManager has been stopped")
 		}()
@@ -201,20 +226,15 @@ func (mgr *PlaceholderManager) Stop() {
 	}
 	mgr.stopOnce.Do(func() {
 		log.Log(log.ShimCachePlaceholder).Info("stopping the PlaceholderManager")
+		mgr.cleanupLock.Lock()
+		mgr.stopping = true
 		mgr.cancel()
 		close(mgr.stopChan)
+		mgr.cleanupLock.Unlock()
 	})
 	<-mgr.doneChan
+	mgr.cleanupWorkers.Wait()
 }
-
-func (mgr *PlaceholderManager) isRunning() bool {
-	return mgr.running.Load()
-}
-
-func (mgr *PlaceholderManager) setRunning(flag bool) {
-	mgr.running.Store(flag)
-}
-
 func (mgr *PlaceholderManager) getOrphanPodsLength() int {
 	mgr.RLock()
 	defer mgr.RUnlock()

--- a/pkg/cache/placeholder_manager_test.go
+++ b/pkg/cache/placeholder_manager_test.go
@@ -46,12 +46,12 @@ const (
 
 type concurrentKubeClient struct {
 	client.KubeClient
-	createFn func(pod *v1.Pod) (*v1.Pod, error)
+	createFn func(ctx context.Context, pod *v1.Pod) (*v1.Pod, error)
 	deleteFn func(ctx context.Context, pod *v1.Pod) error
 }
 
-func (c *concurrentKubeClient) Create(pod *v1.Pod) (*v1.Pod, error) {
-	return c.createFn(pod)
+func (c *concurrentKubeClient) Create(ctx context.Context, pod *v1.Pod) (*v1.Pod, error) {
+	return c.createFn(ctx, pod)
 }
 
 func (c *concurrentKubeClient) Delete(ctx context.Context, pod *v1.Pod) error {
@@ -348,7 +348,7 @@ func TestPlaceholderCreationAndCleanupAreSerialized(t *testing.T) {
 	var deleteOnce sync.Once
 	kubeClient := &concurrentKubeClient{
 		KubeClient: mockedAPIProvider.GetAPIs().KubeClient,
-		createFn: func(pod *v1.Pod) (*v1.Pod, error) {
+		createFn: func(_ context.Context, pod *v1.Pod) (*v1.Pod, error) {
 			createOnce.Do(func() {
 				close(createStarted)
 				<-continueCreate
@@ -510,7 +510,7 @@ func TestCleanOrphanPlaceholders(t *testing.T) {
 	placeholderMgr.orphanPods["task01"] = pod1
 	placeholderMgr.orphanPods["task02"] = pod2
 	assert.Equal(t, len(placeholderMgr.orphanPods), 2)
-	placeholderMgr.cleanOrphanPlaceholders(context.Background())
+	placeholderMgr.cleanOrphanPlaceholders()
 	assert.Equal(t, len(placeholderMgr.orphanPods), 1)
 }
 
@@ -681,4 +681,138 @@ func TestPlaceholderManagerCleanup(t *testing.T) {
 	assert.Equal(t, mgr.getOrphanPodsLength(), 0)
 	mgr.Stop()
 	assertPlaceholderManagerStopped(t, mgr, true)
+}
+
+func TestPlaceholderManagerStopWaitsForCreation(t *testing.T) {
+	app := createAppWIthTaskGroupAndPodsForTest()
+	provider := client.NewMockedAPIProvider(false)
+	createStarted := make(chan struct{})
+	releaseCreate := make(chan struct{})
+	var once sync.Once
+	provider.MockCreateFn(func(pod *v1.Pod) (*v1.Pod, error) {
+		once.Do(func() {
+			close(createStarted)
+			<-releaseCreate
+		})
+		return pod, nil
+	})
+	mgr := NewPlaceholderManager(provider.GetAPIs())
+	mgr.Start()
+	createDone := make(chan struct{})
+	go func() {
+		defer close(createDone)
+		assert.ErrorIs(t, mgr.createAppPlaceholders(app), context.Canceled)
+	}()
+	defer func() {
+		close(releaseCreate)
+		<-createDone
+		mgr.Stop()
+	}()
+	select {
+	case <-createStarted:
+	case <-time.After(time.Second):
+		t.Fatal("creation did not start")
+	}
+	stopDone := make(chan struct{})
+	go func() {
+		mgr.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-mgr.lifecycleCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel the lifecycle context")
+	}
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned while placeholder creation was still active")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestPlaceholderManagerOperationsAfterStop(t *testing.T) {
+	app := createAppWIthTaskGroupAndPodsForTest()
+	provider := client.NewMockedAPIProvider(false)
+	var creates, deletes atomic.Int32
+	provider.MockCreateFn(func(pod *v1.Pod) (*v1.Pod, error) {
+		creates.Add(1)
+		return pod, nil
+	})
+	provider.MockDeleteFn(func(_ *v1.Pod) error {
+		deletes.Add(1)
+		return nil
+	})
+	mgr := NewPlaceholderManager(provider.GetAPIs())
+	mgr.Start()
+	mgr.Stop()
+	assert.ErrorIs(t, mgr.createAppPlaceholders(app), context.Canceled)
+	mgr.cleanUp(app)
+	mgr.orphanPods["orphan"] = &v1.Pod{}
+	mgr.cleanOrphanPlaceholders()
+	assert.Equal(t, creates.Load(), int32(0), "creation must reject work after shutdown")
+	assert.Equal(t, deletes.Load(), int32(0), "cleanup must reject work after shutdown")
+}
+
+func TestPlaceholderManagerStopCancelsCreationWithQueuedCleanup(t *testing.T) {
+	app := createAppWIthTaskGroupAndPodsForTest()
+	provider := client.NewMockedAPIProvider(false)
+	createStarted := make(chan struct{})
+	releaseCreate := make(chan struct{})
+	var deletes atomic.Int32
+	provider.GetAPIs().KubeClient = &concurrentKubeClient{
+		KubeClient: provider.GetAPIs().KubeClient,
+		createFn: func(ctx context.Context, _ *v1.Pod) (*v1.Pod, error) {
+			close(createStarted)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-releaseCreate:
+				return nil, fmt.Errorf("test released blocked Create")
+			}
+		},
+		deleteFn: func(_ context.Context, _ *v1.Pod) error {
+			deletes.Add(1)
+			return nil
+		},
+	}
+	mgr := NewPlaceholderManager(provider.GetAPIs())
+	mgr.Start()
+	createDone := make(chan error, 1)
+	go func() { createDone <- mgr.createAppPlaceholders(app) }()
+	defer func() {
+		close(releaseCreate)
+		mgr.Stop()
+	}()
+	select {
+	case <-createStarted:
+	case <-time.After(time.Second):
+		t.Fatal("creation did not start")
+	}
+	cleanupDone := make(chan struct{})
+	go func() {
+		mgr.cleanUp(app)
+		close(cleanupDone)
+	}()
+	stopDone := make(chan struct{})
+	go func() {
+		mgr.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel creation with pending application cleanup")
+	}
+	select {
+	case err := <-createDone:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("creation did not return")
+	}
+	select {
+	case <-cleanupDone:
+	case <-time.After(time.Second):
+		t.Fatal("queued cleanup did not return")
+	}
+	assert.Equal(t, deletes.Load(), int32(0), "queued cleanup must observe cancellation before Delete")
 }

--- a/pkg/cache/placeholder_manager_test.go
+++ b/pkg/cache/placeholder_manager_test.go
@@ -19,8 +19,11 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -342,7 +345,7 @@ func TestCleanOrphanPlaceholders(t *testing.T) {
 	placeholderMgr.orphanPods["task01"] = pod1
 	placeholderMgr.orphanPods["task02"] = pod2
 	assert.Equal(t, len(placeholderMgr.orphanPods), 2)
-	placeholderMgr.cleanOrphanPlaceholders()
+	placeholderMgr.cleanOrphanPlaceholders(context.Background())
 	assert.Equal(t, len(placeholderMgr.orphanPods), 1)
 }
 
@@ -358,15 +361,15 @@ func TestPlaceholderManagerStartStop(t *testing.T) {
 	mgr.Start()
 	assert.Equal(t, mgr.isRunning(), true, "sending start 2nd time should not do anything")
 
-	// this is a blocking call
+	// Stop waits until the cleanup goroutine has exited.
 	mgr.Stop()
-	// allow time for processing as the call can return faster than the flag is set
-	time.Sleep(5 * time.Millisecond)
-	// check manager has stopped
 	assert.Equal(t, mgr.isRunning(), false, "placeholder manager has not stopped")
-	// this should not block anymore, flag should be set
+	// Repeated stops are safe and return immediately.
 	mgr.Stop()
 	assert.Equal(t, mgr.isRunning(), false, "stopping already stopped manager failed")
+	// A stopped manager is one-shot and cannot be restarted.
+	mgr.Start()
+	assert.Equal(t, mgr.isRunning(), false, "stopped placeholder manager must not restart")
 
 	// make sure stop doesn't do anything on a non running manager
 	mgr = NewPlaceholderManager(mockedAPIProvider.GetAPIs())
@@ -377,9 +380,102 @@ func TestPlaceholderManagerStartStop(t *testing.T) {
 	assert.Equal(t, mgr.isRunning(), true, "manager should be running after start (stop start sequence)")
 	// lets stop it again now things should stop correctly
 	mgr.Stop()
-	// allow time for processing as the call can return faster than the flag is set
-	time.Sleep(5 * time.Millisecond)
 	assert.Equal(t, mgr.isRunning(), false, "placeholder manager has not stopped")
+}
+
+func TestPlaceholderManagerConcurrentStop(t *testing.T) {
+	mockedAPIProvider := client.NewMockedAPIProvider(false)
+	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
+	mgr.Start()
+
+	const callers = 32
+	start := make(chan struct{})
+	var stopped sync.WaitGroup
+	stopped.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer stopped.Done()
+			<-start
+			mgr.Stop()
+		}()
+	}
+	close(start)
+
+	done := make(chan struct{})
+	go func() {
+		stopped.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent PlaceholderManager.Stop calls blocked")
+	}
+	assert.Equal(t, mgr.isRunning(), false, "manager should be stopped when every Stop call returns")
+}
+
+func TestPlaceholderManagerConcurrentStartCreatesOneCleanupLoop(t *testing.T) {
+	mockedAPIProvider := client.NewMockedAPIProvider(false)
+	var deletes atomic.Int32
+	mockedAPIProvider.MockDeleteFn(func(_ *v1.Pod) error {
+		deletes.Add(1)
+		return nil
+	})
+	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
+	mgr.setCleanupTime(time.Millisecond)
+
+	const callers = 64
+	start := make(chan struct{})
+	var started sync.WaitGroup
+	started.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer started.Done()
+			<-start
+			mgr.Start()
+		}()
+	}
+	close(start)
+	started.Wait()
+	mgr.Stop()
+
+	mgr.Lock()
+	mgr.orphanPods["task01"] = &v1.Pod{ObjectMeta: apis.ObjectMeta{Name: "pod-01"}}
+	mgr.Unlock()
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, deletes.Load(), int32(0), "an extra cleanup loop remained after Stop")
+}
+
+func TestPlaceholderManagerStopCancelsBlockedCleanup(t *testing.T) {
+	mockedAPIProvider := client.NewMockedAPIProvider(false)
+	deleteStarted := make(chan struct{})
+	mockedAPIProvider.MockDeleteWithContextFn(func(ctx context.Context, _ *v1.Pod) error {
+		close(deleteStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
+	mgr.setCleanupTime(time.Millisecond)
+	mgr.orphanPods["task01"] = &v1.Pod{ObjectMeta: apis.ObjectMeta{Name: "pod-01"}}
+	mgr.Start()
+
+	select {
+	case <-deleteStarted:
+	case <-time.After(time.Second):
+		t.Fatal("orphan cleanup did not start")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		mgr.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel the blocked orphan deletion")
+	}
+	assert.Equal(t, mgr.isRunning(), false, "manager should be stopped after cancellation")
 }
 
 func TestPlaceholderManagerCleanup(t *testing.T) {
@@ -406,16 +502,16 @@ func TestPlaceholderManagerCleanup(t *testing.T) {
 	}
 	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
 	mgr.setCleanupTime(100 * time.Millisecond)
-	defer mgr.setCleanupTime(5 * time.Second)
 	mgr.Start()
 	assert.Equal(t, mgr.isRunning(), true, "manager should be running after start")
+	mgr.Lock()
 	mgr.orphanPods["task01"] = pod1
 	mgr.orphanPods["task02"] = pod2
+	mgr.Unlock()
 	assert.Equal(t, mgr.getOrphanPodsLength(), 2)
 	<-time.After(100 * time.Millisecond)
 	time.Sleep(5 * time.Millisecond)
 	assert.Equal(t, mgr.getOrphanPodsLength(), 0)
 	mgr.Stop()
-	time.Sleep(5 * time.Millisecond)
 	assert.Equal(t, mgr.isRunning(), false, "placeholder manager has stopped")
 }

--- a/pkg/cache/placeholder_manager_test.go
+++ b/pkg/cache/placeholder_manager_test.go
@@ -44,11 +44,36 @@ const (
 	priorityClassName = "test-priority-class"
 )
 
+type concurrentKubeClient struct {
+	client.KubeClient
+	createFn func(pod *v1.Pod) (*v1.Pod, error)
+	deleteFn func(ctx context.Context, pod *v1.Pod) error
+}
+
+func (c *concurrentKubeClient) Create(pod *v1.Pod) (*v1.Pod, error) {
+	return c.createFn(pod)
+}
+
+func (c *concurrentKubeClient) Delete(ctx context.Context, pod *v1.Pod) error {
+	return c.deleteFn(ctx, pod)
+}
+
+func assertPlaceholderManagerStopped(t *testing.T, mgr *PlaceholderManager, stopped bool) {
+	t.Helper()
+	select {
+	case <-mgr.doneChan:
+		assert.Assert(t, stopped, "placeholder manager stopped unexpectedly")
+	default:
+		assert.Assert(t, !stopped, "placeholder manager has not stopped")
+	}
+}
+
 func TestNewPlaceholderManager(t *testing.T) {
 	// the shim does not startup if it cannot get a kubeclient, no need to check for nil
 	mockedAPIProvider := client.NewMockedAPIProvider(false)
 	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
-	assert.Equal(t, mgr.running.Load(), false, "new manager should not run")
+	assert.Equal(t, mgr.started.Load(), false, "new manager should not be started")
+	assertPlaceholderManagerStopped(t, mgr, false)
 	if mgr.orphanPods == nil && len(mgr.orphanPods) != 0 {
 		t.Fatal("orphanPods map should be initialised and empty")
 	}
@@ -313,6 +338,146 @@ func TestCleanUp(t *testing.T) {
 	assert.Equal(t, len(placeholderMgr.orphanPods), 1)
 }
 
+func TestPlaceholderCreationAndCleanupAreSerialized(t *testing.T) {
+	app := createAppWIthTaskGroupAndPodsForTest()
+	mockedAPIProvider := client.NewMockedAPIProvider(false)
+	createStarted := make(chan struct{})
+	continueCreate := make(chan struct{})
+	deleteStarted := make(chan struct{})
+	var createOnce sync.Once
+	var deleteOnce sync.Once
+	kubeClient := &concurrentKubeClient{
+		KubeClient: mockedAPIProvider.GetAPIs().KubeClient,
+		createFn: func(pod *v1.Pod) (*v1.Pod, error) {
+			createOnce.Do(func() {
+				close(createStarted)
+				<-continueCreate
+			})
+			return pod, nil
+		},
+		deleteFn: func(_ context.Context, _ *v1.Pod) error {
+			deleteOnce.Do(func() {
+				close(deleteStarted)
+			})
+			return nil
+		},
+	}
+	mockedAPIProvider.GetAPIs().KubeClient = kubeClient
+	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
+
+	createDone := make(chan struct{})
+	go func() {
+		defer close(createDone)
+		assert.NilError(t, mgr.createAppPlaceholders(app))
+	}()
+	select {
+	case <-createStarted:
+	case <-time.After(time.Second):
+		t.Fatal("placeholder creation did not start")
+	}
+
+	cleanupDone := make(chan struct{})
+	go func() {
+		defer close(cleanupDone)
+		mgr.cleanUp(app)
+	}()
+	select {
+	case <-deleteStarted:
+		close(continueCreate)
+		<-createDone
+		<-cleanupDone
+		t.Fatal("placeholder cleanup started before creation completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(continueCreate)
+	select {
+	case <-createDone:
+	case <-time.After(time.Second):
+		t.Fatal("placeholder creation did not complete")
+	}
+	select {
+	case <-deleteStarted:
+	case <-time.After(time.Second):
+		t.Fatal("placeholder cleanup did not start after creation completed")
+	}
+	select {
+	case <-cleanupDone:
+	case <-time.After(time.Second):
+		t.Fatal("placeholder cleanup did not complete")
+	}
+}
+
+func TestStopCancelsApplicationCleanup(t *testing.T) {
+	app := createAppWIthTaskGroupAndPodsForTest()
+	mockedAPIProvider := client.NewMockedAPIProvider(false)
+	deleteStarted := make(chan struct{})
+	deleteCanceled := make(chan struct{})
+	continueDelete := make(chan struct{})
+	var deleteOnce sync.Once
+	mockedAPIProvider.MockDeleteWithContextFn(func(ctx context.Context, _ *v1.Pod) error {
+		deleteOnce.Do(func() {
+			close(deleteStarted)
+			<-ctx.Done()
+			close(deleteCanceled)
+			<-continueDelete
+		})
+		return ctx.Err()
+	})
+	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
+	mgr.Start()
+
+	app.handleCompleteApplicationEvent()
+	select {
+	case <-deleteStarted:
+	case <-time.After(time.Second):
+		t.Fatal("placeholder cleanup did not start")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		mgr.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-deleteCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("application cleanup was not canceled during manager shutdown")
+	}
+	select {
+	case <-stopDone:
+		close(continueDelete)
+		t.Fatal("manager stopped before application cleanup completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(continueDelete)
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("manager did not stop after application cleanup completed")
+	}
+}
+
+func TestApplicationCleanupRejectedOutsideManagerLifecycle(t *testing.T) {
+	app := createAppWIthTaskGroupAndPodsForTest()
+	mockedAPIProvider := client.NewMockedAPIProvider(false)
+	var deletes atomic.Int32
+	mockedAPIProvider.MockDeleteWithContextFn(func(_ context.Context, _ *v1.Pod) error {
+		deletes.Add(1)
+		return nil
+	})
+	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
+
+	app.handleCompleteApplicationEvent()
+	assert.Equal(t, deletes.Load(), int32(0), "cleanup should not start before the manager starts")
+
+	mgr.Start()
+	mgr.Stop()
+	app.handleCompleteApplicationEvent()
+	assert.Equal(t, deletes.Load(), int32(0), "cleanup should not start after the manager stops")
+}
+
 func TestCleanOrphanPlaceholders(t *testing.T) {
 	mockedAPIProvider := client.NewMockedAPIProvider(false)
 	mockedAPIProvider.MockDeleteFn(func(pod *v1.Pod) error {
@@ -352,35 +517,37 @@ func TestCleanOrphanPlaceholders(t *testing.T) {
 func TestPlaceholderManagerStartStop(t *testing.T) {
 	mockedAPIProvider := client.NewMockedAPIProvider(false)
 	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
-	assert.Equal(t, mgr.running.Load(), false, "new manager should not run")
+	assert.Equal(t, mgr.started.Load(), false, "new manager should not be started")
 	// start clean up goroutine
 	mgr.Start()
-	assert.Equal(t, mgr.isRunning(), true, "manager should be running after start")
+	assert.Equal(t, mgr.started.Load(), true, "manager should be started")
+	assertPlaceholderManagerStopped(t, mgr, false)
 
 	// starting a second time should do nothing
 	mgr.Start()
-	assert.Equal(t, mgr.isRunning(), true, "sending start 2nd time should not do anything")
+	assertPlaceholderManagerStopped(t, mgr, false)
 
 	// Stop waits until the cleanup goroutine has exited.
 	mgr.Stop()
-	assert.Equal(t, mgr.isRunning(), false, "placeholder manager has not stopped")
+	assertPlaceholderManagerStopped(t, mgr, true)
 	// Repeated stops are safe and return immediately.
 	mgr.Stop()
-	assert.Equal(t, mgr.isRunning(), false, "stopping already stopped manager failed")
+	assertPlaceholderManagerStopped(t, mgr, true)
 	// A stopped manager is one-shot and cannot be restarted.
 	mgr.Start()
-	assert.Equal(t, mgr.isRunning(), false, "stopped placeholder manager must not restart")
+	assertPlaceholderManagerStopped(t, mgr, true)
 
-	// make sure stop doesn't do anything on a non running manager
+	// make sure stop doesn't do anything before the manager starts
 	mgr = NewPlaceholderManager(mockedAPIProvider.GetAPIs())
-	assert.Equal(t, mgr.running.Load(), false, "new manager should not run")
+	assert.Equal(t, mgr.started.Load(), false, "new manager should not be started")
 	mgr.Stop()
-	assert.Equal(t, mgr.isRunning(), false, "stopping new manager: nothing should happen")
+	assertPlaceholderManagerStopped(t, mgr, false)
 	mgr.Start()
-	assert.Equal(t, mgr.isRunning(), true, "manager should be running after start (stop start sequence)")
+	assert.Equal(t, mgr.started.Load(), true, "manager should start after a pre-start Stop")
+	assertPlaceholderManagerStopped(t, mgr, false)
 	// lets stop it again now things should stop correctly
 	mgr.Stop()
-	assert.Equal(t, mgr.isRunning(), false, "placeholder manager has not stopped")
+	assertPlaceholderManagerStopped(t, mgr, true)
 }
 
 func TestPlaceholderManagerConcurrentStop(t *testing.T) {
@@ -411,7 +578,7 @@ func TestPlaceholderManagerConcurrentStop(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("concurrent PlaceholderManager.Stop calls blocked")
 	}
-	assert.Equal(t, mgr.isRunning(), false, "manager should be stopped when every Stop call returns")
+	assertPlaceholderManagerStopped(t, mgr, true)
 }
 
 func TestPlaceholderManagerConcurrentStartCreatesOneCleanupLoop(t *testing.T) {
@@ -475,7 +642,7 @@ func TestPlaceholderManagerStopCancelsBlockedCleanup(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Stop did not cancel the blocked orphan deletion")
 	}
-	assert.Equal(t, mgr.isRunning(), false, "manager should be stopped after cancellation")
+	assertPlaceholderManagerStopped(t, mgr, true)
 }
 
 func TestPlaceholderManagerCleanup(t *testing.T) {
@@ -503,7 +670,7 @@ func TestPlaceholderManagerCleanup(t *testing.T) {
 	mgr := NewPlaceholderManager(mockedAPIProvider.GetAPIs())
 	mgr.setCleanupTime(100 * time.Millisecond)
 	mgr.Start()
-	assert.Equal(t, mgr.isRunning(), true, "manager should be running after start")
+	assertPlaceholderManagerStopped(t, mgr, false)
 	mgr.Lock()
 	mgr.orphanPods["task01"] = pod1
 	mgr.orphanPods["task02"] = pod2
@@ -513,5 +680,5 @@ func TestPlaceholderManagerCleanup(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	assert.Equal(t, mgr.getOrphanPodsLength(), 0)
 	mgr.Stop()
-	assert.Equal(t, mgr.isRunning(), false, "placeholder manager has stopped")
+	assertPlaceholderManagerStopped(t, mgr, true)
 }

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -192,7 +192,7 @@ func (task *Task) GetNodeName() string {
 }
 
 func (task *Task) DeleteTaskPod() error {
-	return task.context.apiProvider.GetAPIs().KubeClient.Delete(task.GetTaskPod())
+	return task.context.apiProvider.GetAPIs().KubeClient.Delete(context.Background(), task.GetTaskPod())
 }
 
 func (task *Task) UpdateTaskPodStatus(pod *v1.Pod) (*v1.Pod, error) {

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -19,6 +19,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -142,7 +143,13 @@ func (m *MockedAPIProvider) MockBindFn(bfn func(pod *v1.Pod, hostID string) erro
 
 func (m *MockedAPIProvider) MockDeleteFn(dfn func(pod *v1.Pod) error) {
 	if mock, ok := m.clients.KubeClient.(*KubeClientMock); ok {
-		mock.deleteFn = dfn
+		mock.MockDeleteFn(dfn)
+	}
+}
+
+func (m *MockedAPIProvider) MockDeleteWithContextFn(dfn func(ctx context.Context, pod *v1.Pod) error) {
+	if mock, ok := m.clients.KubeClient.(*KubeClientMock); ok {
+		mock.MockDeleteWithContextFn(dfn)
 	}
 }
 

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -155,7 +155,7 @@ func (m *MockedAPIProvider) MockDeleteWithContextFn(dfn func(ctx context.Context
 
 func (m *MockedAPIProvider) MockCreateFn(cfn func(pod *v1.Pod) (*v1.Pod, error)) {
 	if mock, ok := m.clients.KubeClient.(*KubeClientMock); ok {
-		mock.createFn = cfn
+		mock.MockCreateFn(cfn)
 	}
 }
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -19,6 +19,8 @@
 package client
 
 import (
+	"context"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -32,7 +34,7 @@ type KubeClient interface {
 	Create(pod *v1.Pod) (*v1.Pod, error)
 
 	// Delete a pod from a host
-	Delete(pod *v1.Pod) error
+	Delete(ctx context.Context, pod *v1.Pod) error
 
 	// Update a pod
 	UpdatePod(pod *v1.Pod, podMutator func(pod *v1.Pod)) (*v1.Pod, error)

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -31,7 +31,7 @@ type KubeClient interface {
 	Bind(pod *v1.Pod, hostID string) error
 
 	// Create a pod
-	Create(pod *v1.Pod) (*v1.Pod, error)
+	Create(ctx context.Context, pod *v1.Pod) (*v1.Pod, error)
 
 	// Delete a pod from a host
 	Delete(ctx context.Context, pod *v1.Pod) error

--- a/pkg/client/kubeclient.go
+++ b/pkg/client/kubeclient.go
@@ -137,8 +137,8 @@ func (nc SchedulerKubeClient) Create(pod *v1.Pod) (*v1.Pod, error) {
 	return nc.clientSet.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, apis.CreateOptions{})
 }
 
-func (nc SchedulerKubeClient) Delete(pod *v1.Pod) error {
-	if err := nc.clientSet.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, apis.DeleteOptions{}); err != nil {
+func (nc SchedulerKubeClient) Delete(ctx context.Context, pod *v1.Pod) error {
+	if err := nc.clientSet.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, apis.DeleteOptions{}); err != nil {
 		log.Log(log.ShimClient).Warn("failed to delete pod",
 			zap.String("namespace", pod.Namespace),
 			zap.String("podName", pod.Name),

--- a/pkg/client/kubeclient.go
+++ b/pkg/client/kubeclient.go
@@ -133,8 +133,8 @@ func (nc SchedulerKubeClient) Bind(pod *v1.Pod, hostID string) error {
 	return nil
 }
 
-func (nc SchedulerKubeClient) Create(pod *v1.Pod) (*v1.Pod, error) {
-	return nc.clientSet.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, apis.CreateOptions{})
+func (nc SchedulerKubeClient) Create(ctx context.Context, pod *v1.Pod) (*v1.Pod, error) {
+	return nc.clientSet.CoreV1().Pods(pod.Namespace).Create(ctx, pod, apis.CreateOptions{})
 }
 
 func (nc SchedulerKubeClient) Delete(ctx context.Context, pod *v1.Pod) error {

--- a/pkg/client/kubeclient_mock.go
+++ b/pkg/client/kubeclient_mock.go
@@ -19,6 +19,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -35,7 +36,7 @@ import (
 // KubeClientMock allows us to inject customized bind/delete pod functions
 type KubeClientMock struct {
 	bindFn         func(pod *v1.Pod, hostID string) error
-	deleteFn       func(pod *v1.Pod) error
+	deleteFn       func(ctx context.Context, pod *v1.Pod) error
 	createFn       func(pod *v1.Pod) (*v1.Pod, error)
 	updateFn       func(pod *v1.Pod, podMutator func(pod *v1.Pod)) (*v1.Pod, error)
 	updateStatusFn func(pod *v1.Pod) (*v1.Pod, error)
@@ -64,7 +65,7 @@ type BoundPod struct {
 
 func NewKubeClientMock(err bool) *KubeClientMock {
 	kubeMock := &KubeClientMock{
-		deleteFn: func(pod *v1.Pod) error {
+		deleteFn: func(_ context.Context, pod *v1.Pod) error {
 			if err {
 				return fmt.Errorf("error deleting pod")
 			}
@@ -146,6 +147,12 @@ func (c *KubeClientMock) MockBindFn(bfn func(pod *v1.Pod, hostID string) error) 
 }
 
 func (c *KubeClientMock) MockDeleteFn(dfn func(pod *v1.Pod) error) {
+	c.deleteFn = func(_ context.Context, pod *v1.Pod) error {
+		return dfn(pod)
+	}
+}
+
+func (c *KubeClientMock) MockDeleteWithContextFn(dfn func(ctx context.Context, pod *v1.Pod) error) {
 	c.deleteFn = dfn
 }
 
@@ -191,11 +198,11 @@ func (c *KubeClientMock) Get(podNamespace string, podName string) (*v1.Pod, erro
 	return nil, fmt.Errorf("pod not found: %s/%s", podNamespace, podName)
 }
 
-func (c *KubeClientMock) Delete(pod *v1.Pod) error {
+func (c *KubeClientMock) Delete(ctx context.Context, pod *v1.Pod) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	delete(c.pods, getPodKey(pod))
-	return c.deleteFn(pod)
+	return c.deleteFn(ctx, pod)
 }
 
 func (c *KubeClientMock) GetClientSet() kubernetes.Interface {

--- a/pkg/client/kubeclient_mock.go
+++ b/pkg/client/kubeclient_mock.go
@@ -37,7 +37,7 @@ import (
 type KubeClientMock struct {
 	bindFn         func(pod *v1.Pod, hostID string) error
 	deleteFn       func(ctx context.Context, pod *v1.Pod) error
-	createFn       func(pod *v1.Pod) (*v1.Pod, error)
+	createFn       func(ctx context.Context, pod *v1.Pod) (*v1.Pod, error)
 	updateFn       func(pod *v1.Pod, podMutator func(pod *v1.Pod)) (*v1.Pod, error)
 	updateStatusFn func(pod *v1.Pod) (*v1.Pod, error)
 	getFn          func(podName string) (*v1.Pod, error)
@@ -73,7 +73,7 @@ func NewKubeClientMock(err bool) *KubeClientMock {
 				zap.String("PodName", pod.Name))
 			return nil
 		},
-		createFn: func(pod *v1.Pod) (*v1.Pod, error) {
+		createFn: func(_ context.Context, pod *v1.Pod) (*v1.Pod, error) {
 			if err {
 				return pod, fmt.Errorf("error creating pod")
 			}
@@ -157,7 +157,9 @@ func (c *KubeClientMock) MockDeleteWithContextFn(dfn func(ctx context.Context, p
 }
 
 func (c *KubeClientMock) MockCreateFn(cfn func(pod *v1.Pod) (*v1.Pod, error)) {
-	c.createFn = cfn
+	c.createFn = func(_ context.Context, pod *v1.Pod) (*v1.Pod, error) {
+		return cfn(pod)
+	}
 }
 
 func (c *KubeClientMock) Bind(pod *v1.Pod, hostID string) error {
@@ -166,11 +168,11 @@ func (c *KubeClientMock) Bind(pod *v1.Pod, hostID string) error {
 	return c.bindFn(pod, hostID)
 }
 
-func (c *KubeClientMock) Create(pod *v1.Pod) (*v1.Pod, error) {
+func (c *KubeClientMock) Create(ctx context.Context, pod *v1.Pod) (*v1.Pod, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.pods[getPodKey(pod)] = pod
-	return c.createFn(pod)
+	return c.createFn(ctx, pod)
 }
 
 func (c *KubeClientMock) UpdatePod(pod *v1.Pod, podMutator func(pod *v1.Pod)) (*v1.Pod, error) {

--- a/pkg/client/kubeclient_test.go
+++ b/pkg/client/kubeclient_test.go
@@ -1,0 +1,86 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type placeholderRequestTransport func(*http.Request) (*http.Response, error)
+
+func (f placeholderRequestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestSchedulerKubeClientPlaceholderRequestsCancellation(t *testing.T) {
+	for _, operation := range []string{"create", "delete"} {
+		t.Run(operation, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			requestStarted := make(chan struct{})
+			release := make(chan struct{})
+			defer close(release)
+			clientSet, err := kubernetes.NewForConfig(&rest.Config{
+				Host: "https://kubernetes.invalid",
+				Transport: placeholderRequestTransport(func(req *http.Request) (*http.Response, error) {
+					close(requestStarted)
+					select {
+					case <-req.Context().Done():
+						return nil, req.Context().Err()
+					case <-release:
+						return nil, context.DeadlineExceeded
+					}
+				}),
+			})
+			assert.NilError(t, err)
+			kubeClient := SchedulerKubeClient{clientSet: clientSet}
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "placeholder"}}
+			done := make(chan error, 1)
+			go func() {
+				if operation == "create" {
+					_, err := kubeClient.Create(ctx, pod)
+					done <- err
+				} else {
+					done <- kubeClient.Delete(ctx, pod)
+				}
+			}()
+			select {
+			case <-requestStarted:
+			case <-time.After(time.Second):
+				t.Fatal("Kubernetes request did not start")
+			}
+			cancel()
+			select {
+			case err := <-done:
+				assert.ErrorIs(t, err, context.Canceled)
+			case <-time.After(time.Second):
+				t.Fatal("Kubernetes request did not receive cancellation")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

Make the PlaceholderManager lifecycle atomic, idempotent, and shutdown-safe.

- Ensure concurrent `Start()` calls launch only one cleanup goroutine.
- Close the stop channel once and allow concurrent `Stop()` calls to wait for the same completion signal.
- Guarantee the cleanup goroutine has exited when `Stop()` returns.
- Propagate cancellation to Kubernetes pod deletion requests so shutdown does not wait indefinitely on a blocked API call.
- Avoid holding the orphan-pod lock during Kubernetes API calls.
- Add concurrent lifecycle and blocked-cleanup regression tests.

### Type of change

- [x] Bug Fix

### Jira issue

Jira ID: https://issues.apache.org/jira/browse/YUNIKORN-3404

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### How has this been tested?

- [x] New unit tests were added to cover new or changed code paths.
- [x] `make test` was run, and no failures were reported.
- [x] `go test -race ./pkg/cache -run '^TestPlaceholderManager' -count=1` passed.