### PR TITLE
[YUNIKORN-3440] Use https instead of http in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ docker inspect --format='{{.Config.Labels}}' yunikorn/yunikorn:scheduler-amd64-l
 ```
 
 ## Design documents
-All design documents are located in our [website](http://yunikorn.apache.org/docs/next/design/architecture). 
+All design documents are located in our [website](https://yunikorn.apache.org/docs/next/design/architecture). 
 The core component design documents also contains the design documents for cross component designs.
 
 ## How do I contribute code?
 
-See how to contribute code in [our website](http://yunikorn.apache.org/community/how_to_contribute).
+See how to contribute code in [our website](https://yunikorn.apache.org/community/how_to_contribute).


### PR DESCRIPTION
### Description
Update the links in the README to use https instead of http.

Generated by Claude ( commit message and PR description wording; the file changes were made and verified by me)
### Type of change
- [x] Improvement

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3440

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

Documentation-only change; no code paths affected. All updated links were verified to resolve over https.
### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A