### PR TITLE
[YUNIKORN-3405] Make dispatcher lifecycle thread-safe

### DIFF
--- a/pkg/dispatcher/dispatch_test.go
+++ b/pkg/dispatcher/dispatch_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -156,6 +158,295 @@ func TestDispatcherStartStop(t *testing.T) {
 	} else {
 		t.Logf("seen expected error: %v", err)
 	}
+}
+
+func TestDispatcherConcurrentStartStop(t *testing.T) {
+	createDispatcher(t)
+	defer createDispatcher(t)
+
+	const callers = 100
+	start := make(chan struct{})
+	var started sync.WaitGroup
+	var startTransitions atomic.Int32
+	started.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer started.Done()
+			<-start
+			if dispatcher.start() {
+				startTransitions.Add(1)
+			}
+		}()
+	}
+	close(start)
+	started.Wait()
+	assert.Equal(t, startTransitions.Load(), int32(1))
+	assert.Assert(t, dispatcher.isRunning())
+
+	stop := make(chan struct{})
+	var stopped sync.WaitGroup
+	var panics atomic.Int32
+	stopped.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer stopped.Done()
+			defer func() {
+				if recover() != nil {
+					panics.Add(1)
+				}
+			}()
+			<-stop
+			Stop()
+		}()
+	}
+	close(stop)
+	stopped.Wait()
+	assert.Equal(t, panics.Load(), int32(0))
+	assert.Assert(t, !dispatcher.isRunning())
+}
+
+func TestDispatcherRepeatedStartStop(t *testing.T) {
+	createDispatcher(t)
+	defer createDispatcher(t)
+
+	processed := make(chan string, 1)
+	RegisterEventHandler("TestAppHandler", EventTypeApp, func(obj interface{}) {
+		if event, ok := obj.(TestAppEvent); ok {
+			processed <- event.appID
+		}
+	})
+
+	for i := 0; i < 10; i++ {
+		appID := fmt.Sprintf("test-app-%d", i)
+		Start()
+		assert.Assert(t, dispatcher.isRunning())
+		Dispatch(TestAppEvent{appID: appID, eventType: RunApplication})
+		select {
+		case processedAppID := <-processed:
+			assert.Equal(t, processedAppID, appID)
+		case <-time.After(time.Second):
+			t.Fatalf("dispatcher did not process event during lifecycle %d", i)
+		}
+		Stop()
+		assert.Assert(t, !dispatcher.isRunning())
+	}
+}
+
+func TestDispatcherStopBeforeStart(t *testing.T) {
+	createDispatcher(t)
+	defer createDispatcher(t)
+
+	Stop()
+	assert.Assert(t, !dispatcher.isRunning())
+	Start()
+	assert.Assert(t, dispatcher.isRunning())
+	Stop()
+	assert.Assert(t, !dispatcher.isRunning())
+}
+
+func TestDispatcherStopWaitsForWorker(t *testing.T) {
+	createDispatcher(t)
+	defer createDispatcher(t)
+	dispatcher.stopTimeout = time.Second
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	defer releaseHandler()
+	RegisterEventHandler("TestAppHandler", EventTypeApp, func(obj interface{}) {
+		close(blocked)
+		<-release
+	})
+
+	Start()
+	Dispatch(TestAppEvent{appID: "blocked", eventType: RunApplication})
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not start processing the blocking event")
+	}
+
+	stopComplete := make(chan struct{})
+	go func() {
+		Stop()
+		close(stopComplete)
+	}()
+
+	select {
+	case <-stopComplete:
+		t.Fatal("Stop returned while the dispatcher worker was still active")
+	case <-time.After(50 * time.Millisecond):
+	}
+	releaseHandler()
+
+	select {
+	case <-stopComplete:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after the dispatcher worker exited")
+	}
+	assert.Assert(t, !dispatcher.isRunning())
+}
+
+func TestDispatcherRestartAfterStopTimeout(t *testing.T) {
+	createDispatcher(t)
+	defer createDispatcher(t)
+	dispatcher.stopTimeout = 50 * time.Millisecond
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	defer releaseHandler()
+
+	processed := make(chan string, 2)
+	RegisterEventHandler("TestAppHandler", EventTypeApp, func(obj interface{}) {
+		event, ok := obj.(TestAppEvent)
+		if !ok {
+			return
+		}
+		if event.appID == "blocked" {
+			close(blocked)
+			<-release
+		}
+		processed <- event.appID
+	})
+
+	Start()
+	Dispatch(TestAppEvent{appID: "blocked", eventType: RunApplication})
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not start processing the blocking event")
+	}
+
+	Stop()
+	assert.Assert(t, !dispatcher.isRunning())
+
+	Start()
+	Dispatch(TestAppEvent{appID: "replacement", eventType: RunApplication})
+	select {
+	case appID := <-processed:
+		assert.Equal(t, appID, "replacement")
+	case <-time.After(time.Second):
+		t.Fatal("replacement dispatcher did not process an event after shutdown timed out")
+	}
+
+	releaseHandler()
+	select {
+	case appID := <-processed:
+		assert.Equal(t, appID, "blocked")
+	case <-time.After(time.Second):
+		t.Fatal("stale dispatcher handler did not return")
+	}
+
+	assert.Assert(t, dispatcher.isRunning(), "stale dispatcher changed the replacement lifecycle state")
+}
+
+func TestDispatcherStartWaitsForConcurrentStop(t *testing.T) {
+	createDispatcher(t)
+	defer createDispatcher(t)
+	dispatcher.stopTimeout = 200 * time.Millisecond
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	defer releaseHandler()
+	RegisterEventHandler("TestAppHandler", EventTypeApp, func(obj interface{}) {
+		close(blocked)
+		<-release
+	})
+
+	Start()
+	Dispatch(TestAppEvent{appID: "blocked", eventType: RunApplication})
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not start processing the blocking event")
+	}
+
+	stopReturned := make(chan struct{})
+	go func() {
+		Stop()
+		close(stopReturned)
+	}()
+	err := utils.WaitForCondition(func() bool {
+		return !dispatcher.isRunning()
+	}, time.Millisecond, time.Second)
+	assert.NilError(t, err)
+
+	startReturned := make(chan struct{})
+	go func() {
+		Start()
+		close(startReturned)
+	}()
+	select {
+	case <-startReturned:
+		t.Fatal("Start returned before the concurrent Stop completed")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	select {
+	case <-stopReturned:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after its timeout")
+	}
+	select {
+	case <-startReturned:
+	case <-time.After(time.Second):
+		t.Fatal("Start did not create a replacement after Stop completed")
+	}
+	assert.Assert(t, dispatcher.isRunning())
+	releaseHandler()
+}
+
+func TestAsyncDispatchStopsWithDispatcherRun(t *testing.T) {
+	createDispatcher(t)
+	defer createDispatcher(t)
+	dispatcher.eventChan = make(chan events.SchedulingEvent, 1)
+	dispatcher.asyncDispatchCheckInterval = time.Second
+	dispatcher.dispatchTimeout = 5 * time.Second
+	dispatcher.stopTimeout = 50 * time.Millisecond
+
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	RegisterEventHandler("TestAppHandler", EventTypeApp, func(obj interface{}) {
+		if event, ok := obj.(TestAppEvent); ok && event.appID == "blocked" {
+			close(blocked)
+			<-release
+		}
+	})
+
+	Start()
+	Dispatch(TestAppEvent{appID: "blocked", eventType: RunApplication})
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not start processing the blocking event")
+	}
+	Dispatch(TestAppEvent{appID: "queued", eventType: RunApplication})
+	Dispatch(TestAppEvent{appID: "async", eventType: RunApplication})
+	assert.Equal(t, dispatcher.asyncDispatchCount.Load(), int32(1))
+
+	Stop()
+	err := utils.WaitForCondition(func() bool {
+		return dispatcher.asyncDispatchCount.Load() == 0
+	}, time.Millisecond, time.Second)
+	assert.NilError(t, err)
 }
 
 // Test sending events from multiple senders in parallel,

--- a/pkg/dispatcher/dispatch_test.go
+++ b/pkg/dispatcher/dispatch_test.go
@@ -293,22 +293,35 @@ func TestDispatcherStopWaitsForWorker(t *testing.T) {
 }
 
 func TestDispatcherRestartAfterStopTimeout(t *testing.T) {
+	testDispatcherRestartWaitsForWorker(t, false)
+}
+
+func TestDispatcherStartWaitsForConcurrentStop(t *testing.T) {
+	testDispatcherRestartWaitsForWorker(t, true)
+}
+
+func testDispatcherRestartWaitsForWorker(t *testing.T, startDuringStop bool) {
+	t.Helper()
 	createDispatcher(t)
 	defer createDispatcher(t)
-	dispatcher.stopTimeout = 50 * time.Millisecond
-
+	d := dispatcher
+	d.stopTimeout = 50 * time.Millisecond
 	blocked := make(chan struct{})
 	release := make(chan struct{})
 	var releaseOnce sync.Once
-	releaseHandler := func() {
-		releaseOnce.Do(func() {
-			close(release)
-		})
-	}
+	releaseHandler := func() { releaseOnce.Do(func() { close(release) }) }
 	defer releaseHandler()
 
-	processed := make(chan string, 2)
+	var active, maximum atomic.Int32
+	processed := make(chan string, 3)
 	RegisterEventHandler("TestAppHandler", EventTypeApp, func(obj interface{}) {
+		count := active.Add(1)
+		defer active.Add(-1)
+		for previous := maximum.Load(); count > previous; previous = maximum.Load() {
+			if maximum.CompareAndSwap(previous, count) {
+				break
+			}
+		}
 		event, ok := obj.(TestAppEvent)
 		if !ok {
 			return
@@ -321,96 +334,73 @@ func TestDispatcherRestartAfterStopTimeout(t *testing.T) {
 	})
 
 	Start()
+	run := d.currentRun
 	Dispatch(TestAppEvent{appID: "blocked", eventType: RunApplication})
-	select {
-	case <-blocked:
-	case <-time.After(time.Second):
-		t.Fatal("dispatcher did not start processing the blocking event")
-	}
-
-	Stop()
-	assert.Assert(t, !dispatcher.isRunning())
-
-	Start()
-	Dispatch(TestAppEvent{appID: "replacement", eventType: RunApplication})
-	select {
-	case appID := <-processed:
-		assert.Equal(t, appID, "replacement")
-	case <-time.After(time.Second):
-		t.Fatal("replacement dispatcher did not process an event after shutdown timed out")
-	}
-
-	releaseHandler()
-	select {
-	case appID := <-processed:
-		assert.Equal(t, appID, "blocked")
-	case <-time.After(time.Second):
-		t.Fatal("stale dispatcher handler did not return")
-	}
-
-	assert.Assert(t, dispatcher.isRunning(), "stale dispatcher changed the replacement lifecycle state")
-}
-
-func TestDispatcherStartWaitsForConcurrentStop(t *testing.T) {
-	createDispatcher(t)
-	defer createDispatcher(t)
-	dispatcher.stopTimeout = 200 * time.Millisecond
-
-	blocked := make(chan struct{})
-	release := make(chan struct{})
-	var releaseOnce sync.Once
-	releaseHandler := func() {
-		releaseOnce.Do(func() {
-			close(release)
-		})
-	}
-	defer releaseHandler()
-	RegisterEventHandler("TestAppHandler", EventTypeApp, func(obj interface{}) {
-		close(blocked)
-		<-release
-	})
-
-	Start()
-	Dispatch(TestAppEvent{appID: "blocked", eventType: RunApplication})
-	select {
-	case <-blocked:
-	case <-time.After(time.Second):
-		t.Fatal("dispatcher did not start processing the blocking event")
-	}
-
+	waitDispatcherSignal(t, blocked, "handler did not start")
+	assert.NilError(t, d.dispatch(TestAppEvent{appID: "queued", eventType: RunApplication}))
 	stopReturned := make(chan struct{})
 	go func() {
-		Stop()
+		d.stop()
 		close(stopReturned)
 	}()
-	err := utils.WaitForCondition(func() bool {
-		return !dispatcher.isRunning()
-	}, time.Millisecond, time.Second)
-	assert.NilError(t, err)
+	waitDispatcherSignal(t, run.stopChan, "Stop did not signal shutdown")
+	if !startDuringStop {
+		waitDispatcherSignal(t, stopReturned, "Stop did not return after its timeout")
+	}
 
+	const callers = 8
+	var transitions atomic.Int32
+	var starters sync.WaitGroup
+	starters.Add(callers)
 	startReturned := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer starters.Done()
+			if d.start() {
+				transitions.Add(1)
+			}
+		}()
+	}
 	go func() {
-		Start()
+		starters.Wait()
 		close(startReturned)
 	}()
-	select {
-	case <-startReturned:
-		t.Fatal("Start returned before the concurrent Stop completed")
-	case <-time.After(25 * time.Millisecond):
-	}
+	defer func() {
+		releaseHandler()
+		waitDispatcherSignal(t, run.doneChan, "old worker did not exit")
+		waitDispatcherSignal(t, startReturned, "Start did not finish after old worker exited")
+		waitDispatcherSignal(t, stopReturned, "Stop did not finish")
+	}()
 
-	select {
-	case <-stopReturned:
-	case <-time.After(time.Second):
-		t.Fatal("Stop did not return after its timeout")
-	}
+	waitDispatcherSignal(t, stopReturned, "Stop exceeded its shutdown timeout")
 	select {
 	case <-startReturned:
-	case <-time.After(time.Second):
-		t.Fatal("Start did not create a replacement after Stop completed")
+		t.Fatal("Start returned while the previous worker was still handling an event")
+	case <-time.After(50 * time.Millisecond):
 	}
-	assert.Assert(t, dispatcher.isRunning())
+	assert.Assert(t, !d.isRunning(), "stopping run must reject new events")
 	releaseHandler()
+	waitDispatcherSignal(t, startReturned, "Start did not restart after worker completion")
+	assert.Equal(t, transitions.Load(), int32(1), "only one replacement run should start")
+	assert.NilError(t, d.dispatch(TestAppEvent{appID: "replacement", eventType: RunApplication}))
+	for _, expected := range []string{"blocked", "queued", "replacement"} {
+		select {
+		case appID := <-processed:
+			assert.Equal(t, appID, expected)
+		case <-time.After(time.Second):
+			t.Fatalf("dispatcher did not process %s", expected)
+		}
+	}
+	assert.Equal(t, maximum.Load(), int32(1), "event handlers must not overlap across runs")
+}
+
+func waitDispatcherSignal(t *testing.T, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatal(message)
+	}
 }
 
 func TestAsyncDispatchStopsWithDispatcherRun(t *testing.T) {
@@ -602,8 +592,12 @@ func TestExceedAsyncDispatchLimit(t *testing.T) {
 func createDispatcher(t *testing.T) {
 	if dispatcher != nil {
 		d := dispatcher
-		if d.isRunning() {
-			Stop()
+		d.lifecycleLock.RLock()
+		run := d.currentRun
+		d.lifecycleLock.RUnlock()
+		d.stop()
+		if run != nil {
+			waitDispatcherSignal(t, run.doneChan, "previous dispatcher worker did not exit")
 		}
 		if d.asyncDispatchCount.Load() > 0 {
 			waitTimeout := d.dispatchTimeout + d.asyncDispatchCheckInterval + time.Second
@@ -618,4 +612,127 @@ func createDispatcher(t *testing.T) {
 	}
 	once.Do(func() {}) // run nop, so that functions like RegisterEventHandler() won't run initDispatcher() again
 	initDispatcher()
+}
+
+func TestAsyncDispatchCannotEnqueueAcrossStop(t *testing.T) {
+	run := &dispatcherRun{stopChan: make(chan struct{}), doneChan: make(chan struct{})}
+	d := &Dispatcher{
+		currentRun:                 run,
+		eventChan:                  make(chan events.SchedulingEvent, 1),
+		asyncDispatchLimit:         10,
+		asyncDispatchCheckInterval: time.Second,
+		dispatchTimeout:            time.Second,
+	}
+	d.eventChan <- TestAppEvent{appID: "queued", eventType: RunApplication}
+	func() {
+		// Hold the same lock as Stop while a previously admitted async sender
+		// gets space in the queue. It must recheck its run before enqueueing.
+		d.lifecycleLock.Lock()
+		defer d.lifecycleLock.Unlock()
+		defer func() {
+			run.stopping = true
+			close(run.stopChan)
+		}()
+		d.asyncDispatch(TestAppEvent{appID: "async", eventType: RunApplication}, run)
+		<-d.eventChan
+		select {
+		case <-d.eventChan:
+			t.Error("async sender bypassed the lifecycle lock during shutdown")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}()
+	err := utils.WaitForCondition(func() bool {
+		return d.asyncDispatchCount.Load() == 0
+	}, time.Millisecond, time.Second)
+	assert.NilError(t, err)
+	assert.Equal(t, len(d.eventChan), 0, "stopped run must not enqueue into the shared event channel")
+}
+
+func TestAsyncDispatchResumesWhenQueueHasSpace(t *testing.T) {
+	createDispatcher(t)
+	defer createDispatcher(t)
+	d := dispatcher
+	d.eventChan = make(chan events.SchedulingEvent, 1)
+	// Freeing queue space must wake senders without waiting for this interval.
+	d.asyncDispatchCheckInterval = time.Hour
+	d.dispatchTimeout = 2 * time.Hour
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseHandler()
+	processed := make(chan string, 3)
+	RegisterEventHandler("TestAppHandler", EventTypeApp, func(obj interface{}) {
+		event, ok := obj.(TestAppEvent)
+		if !ok {
+			return
+		}
+		if event.appID == "blocked" {
+			close(blocked)
+			<-release
+		}
+		processed <- event.appID
+	})
+	Start()
+	assert.NilError(t, d.dispatch(TestAppEvent{appID: "blocked", eventType: RunApplication}))
+	waitDispatcherSignal(t, blocked, "handler did not start")
+	assert.NilError(t, d.dispatch(TestAppEvent{appID: "queued", eventType: RunApplication}))
+	assert.NilError(t, d.dispatch(TestAppEvent{appID: "async", eventType: RunApplication}))
+	assert.Equal(t, d.asyncDispatchCount.Load(), int32(1))
+	releaseHandler()
+	for _, expected := range []string{"blocked", "queued", "async"} {
+		select {
+		case appID := <-processed:
+			assert.Equal(t, appID, expected)
+		case <-time.After(time.Second):
+			t.Fatalf("queue space did not promptly release event %s", expected)
+		}
+	}
+}
+
+func TestDispatcherConcurrentStopTimeout(t *testing.T) {
+	createDispatcher(t)
+	defer createDispatcher(t)
+	d := dispatcher
+	d.stopTimeout = 50 * time.Millisecond
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseHandler()
+	RegisterEventHandler("TestAppHandler", EventTypeApp, func(_ interface{}) {
+		close(blocked)
+		<-release
+	})
+	Start()
+	run := d.currentRun
+	assert.NilError(t, d.dispatch(TestAppEvent{appID: "blocked", eventType: RunApplication}))
+	waitDispatcherSignal(t, blocked, "handler did not start")
+
+	const callers = 16
+	start := make(chan struct{})
+	var stopped sync.WaitGroup
+	stopped.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer stopped.Done()
+			<-start
+			d.stop()
+		}()
+	}
+	stopReturned := make(chan struct{})
+	go func() {
+		stopped.Wait()
+		close(stopReturned)
+	}()
+	close(start)
+	waitDispatcherSignal(t, stopReturned, "concurrent Stop callers exceeded their timeout")
+	assert.Assert(t, !d.isRunning())
+	select {
+	case <-run.doneChan:
+		t.Fatal("timeout must not report worker completion")
+	default:
+	}
+	releaseHandler()
+	waitDispatcherSignal(t, run.doneChan, "worker did not finish after handler returned")
 }

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -47,10 +47,11 @@ const (
 )
 
 type dispatcherRun struct {
-	stopChan     chan struct{}
-	doneChan     chan struct{}
-	stopComplete chan struct{}
-	stopping     bool
+	// Buffered notification lets async senders retry promptly when the loop dequeues.
+	spaceAvailable chan struct{}
+	stopChan       chan struct{}
+	doneChan       chan struct{}
+	stopping       bool
 }
 
 // Dispatcher is the central dispatcher that dispatches scheduling events.
@@ -170,14 +171,14 @@ func (p *Dispatcher) dispatch(event events.SchedulingEvent) error {
 	case p.eventChan <- event:
 		return nil
 	default:
-		p.asyncDispatch(event, run.stopChan)
+		p.asyncDispatch(event, run)
 		return nil
 	}
 }
 
-// async-dispatch retries enqueueing the event in every 3 seconds until dispatchTimeout
-// it's only called when the event channel is full.
-func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent, stopChan chan struct{}) {
+// asyncDispatch retries when queue space is available, checking dispatchTimeout
+// at asyncDispatchCheckInterval. It is only called when the event channel is full.
+func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent, run *dispatcherRun) {
 	count := p.asyncDispatchCount.Add(1)
 	log.Log(log.ShimDispatcher).Warn("event channel is full, transition to async-dispatch mode",
 		zap.Int32("asyncDispatchCount", count))
@@ -188,18 +189,19 @@ func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent, stopChan chan s
 	}
 	go func(beginTime time.Time) {
 		defer p.asyncDispatchCount.Add(-1)
+		timer := time.NewTimer(p.asyncDispatchCheckInterval)
+		defer timer.Stop()
 		for {
-			select {
-			case <-stopChan:
+			enqueued, err := p.tryEnqueue(event, run)
+			if err != nil || enqueued {
 				return
-			default:
 			}
 			select {
-			case <-stopChan:
+			case <-run.stopChan:
 				return
-			case p.eventChan <- event:
-				return
-			case <-time.After(p.asyncDispatchCheckInterval):
+			case <-run.spaceAvailable:
+				// The consumer freed space; retry under the lifecycle lock.
+			case <-timer.C:
 				elapseTime := time.Since(beginTime)
 				if elapseTime >= p.dispatchTimeout {
 					log.Log(log.ShimDispatcher).Error("dispatch timeout",
@@ -208,9 +210,26 @@ func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent, stopChan chan s
 				}
 				log.Log(log.ShimDispatcher).Warn("event channel is full, keep waiting...",
 					zap.Float64("elapseSeconds", elapseTime.Seconds()))
+				timer.Reset(p.asyncDispatchCheckInterval)
 			}
 		}
 	}(time.Now())
+}
+
+// tryEnqueue coordinates async admission with Stop. Never wait for channel space
+// while holding the lock, since Stop needs the write lock to signal cancellation.
+func (p *Dispatcher) tryEnqueue(event events.SchedulingEvent, run *dispatcherRun) (bool, error) {
+	p.lifecycleLock.RLock()
+	defer p.lifecycleLock.RUnlock()
+	if p.currentRun != run || run.stopping {
+		return false, fmt.Errorf("dispatcher is not running")
+	}
+	select {
+	case p.eventChan <- event:
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 func (p *Dispatcher) drain() {
@@ -222,6 +241,8 @@ func (p *Dispatcher) drain() {
 	log.Log(log.ShimDispatcher).Info("dispatcher is draining out")
 }
 
+// Start starts the dispatcher. If a previous run is stopping, it waits for that
+// worker to exit, even after a Stop timeout, before starting another run.
 func Start() {
 	log.Log(log.ShimDispatcher).Info("starting the dispatcher")
 	if !getDispatcher().start() {
@@ -229,14 +250,16 @@ func Start() {
 	}
 }
 
+// start waits for a stopping run to actually exit, even if Stop has timed out.
+// This preserves sequential event handling across dispatcher restarts.
 func (p *Dispatcher) start() bool {
 	for {
 		p.lifecycleLock.Lock()
 		if p.currentRun == nil {
 			run := &dispatcherRun{
-				stopChan:     make(chan struct{}),
-				doneChan:     make(chan struct{}),
-				stopComplete: make(chan struct{}),
+				spaceAvailable: make(chan struct{}, 1),
+				stopChan:       make(chan struct{}),
+				doneChan:       make(chan struct{}),
 			}
 			p.currentRun = run
 			go p.run(run)
@@ -247,14 +270,22 @@ func (p *Dispatcher) start() bool {
 			p.lifecycleLock.Unlock()
 			return false
 		}
-		stopComplete := p.currentRun.stopComplete
+		doneChan := p.currentRun.doneChan
 		p.lifecycleLock.Unlock()
-		<-stopComplete
+		<-doneChan
 	}
 }
 
 func (p *Dispatcher) run(run *dispatcherRun) {
-	defer close(run.doneChan)
+	defer func() {
+		p.lifecycleLock.Lock()
+		defer p.lifecycleLock.Unlock()
+		// Only the worker can retire its run. A Stop timeout is not completion.
+		if p.currentRun == run {
+			p.currentRun = nil
+		}
+		close(run.doneChan)
+	}()
 	for {
 		select {
 		case <-run.stopChan:
@@ -268,6 +299,10 @@ func (p *Dispatcher) run(run *dispatcherRun) {
 			log.Log(log.ShimDispatcher).Info("shutting down event channel")
 			return
 		case event := <-p.eventChan:
+			select {
+			case run.spaceAvailable <- struct{}{}:
+			default:
+			}
 			p.handleEvent(event)
 		}
 	}
@@ -302,38 +337,21 @@ func (p *Dispatcher) stop() {
 		return
 	}
 
-	if run.stopping {
-		stopComplete := run.stopComplete
-		p.lifecycleLock.Unlock()
-		<-stopComplete
-		return
+	if !run.stopping {
+		run.stopping = true
+		close(run.stopChan)
 	}
-
-	run.stopping = true
-	close(run.stopChan)
 	stopTimeout := p.stopTimeout
 	p.lifecycleLock.Unlock()
 
-	timedOut := false
+	// Each caller waits outside the lifecycle lock, subject to its own timeout.
+	// Keep currentRun until the worker exits so Start cannot overlap handlers.
 	timer := time.NewTimer(stopTimeout)
 	defer timer.Stop()
 	select {
 	case <-run.doneChan:
-	case <-timer.C:
-		timedOut = true
-		log.Log(log.ShimDispatcher).Info("dispatcher did not stop in time")
-	}
-
-	p.lifecycleLock.Lock()
-	if p.currentRun == run {
-		p.currentRun = nil
-	}
-	close(run.stopComplete)
-	p.lifecycleLock.Unlock()
-
-	if timedOut {
-		log.Log(log.ShimDispatcher).Warn("dispatcher event processing did not stop properly")
-	} else {
 		log.Log(log.ShimDispatcher).Info("dispatcher stopped successfully")
+	case <-timer.C:
+		log.Log(log.ShimDispatcher).Warn("dispatcher event processing did not stop properly")
 	}
 }

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -36,6 +36,7 @@ var dispatcher *Dispatcher
 var once sync.Once
 
 const defaultAsyncDispatchCheckInterval = 3 * time.Second
+const defaultStopTimeout = 5 * time.Second
 
 type EventType int8
 
@@ -45,14 +46,21 @@ const (
 	EventTypeNode
 )
 
-// central dispatcher that dispatches scheduling events.
+type dispatcherRun struct {
+	stopChan     chan struct{}
+	doneChan     chan struct{}
+	stopComplete chan struct{}
+	stopping     bool
+}
+
+// Dispatcher is the central dispatcher that dispatches scheduling events.
 type Dispatcher struct {
-	eventChan chan events.SchedulingEvent
-	stopChan  chan struct{}
-	handlers  map[EventType]map[string]func(interface{})
-	running   atomic.Bool
-	lock      locking.RWMutex
-	stopped   sync.WaitGroup
+	eventChan     chan events.SchedulingEvent
+	handlers      map[EventType]map[string]func(interface{})
+	lock          locking.RWMutex
+	lifecycleLock locking.RWMutex
+	currentRun    *dispatcherRun
+	stopTimeout   time.Duration
 
 	asyncDispatchLimit         int32
 	asyncDispatchCheckInterval time.Duration
@@ -63,17 +71,15 @@ type Dispatcher struct {
 func initDispatcher() {
 	eventChannelCapacity := conf.GetSchedulerConf().EventChannelCapacity
 	dispatcher = &Dispatcher{
-		eventChan: make(chan events.SchedulingEvent, eventChannelCapacity),
-		handlers:  make(map[EventType]map[string]func(interface{})),
-		stopChan:  make(chan struct{}),
-		lock:      locking.RWMutex{},
+		eventChan:   make(chan events.SchedulingEvent, eventChannelCapacity),
+		handlers:    make(map[EventType]map[string]func(interface{})),
+		lock:        locking.RWMutex{},
+		stopTimeout: defaultStopTimeout,
 
 		asyncDispatchCheckInterval: defaultAsyncDispatchCheckInterval,
 		dispatchTimeout:            conf.GetSchedulerConf().DispatchTimeout,
 		asyncDispatchLimit:         max(10000, int32(eventChannelCapacity/10)), //nolint:gosec
 	}
-	dispatcher.setRunning(false)
-
 	log.Log(log.ShimDispatcher).Info("Init dispatcher",
 		zap.Int("EventChannelCapacity", eventChannelCapacity),
 		zap.Int32("AsyncDispatchLimit", dispatcher.asyncDispatchLimit),
@@ -147,29 +153,31 @@ func Dispatch(event events.SchedulingEvent) {
 }
 
 func (p *Dispatcher) isRunning() bool {
-	return p.running.Load()
-}
-
-func (p *Dispatcher) setRunning(flag bool) {
-	p.running.Store(flag)
+	p.lifecycleLock.RLock()
+	defer p.lifecycleLock.RUnlock()
+	return p.currentRun != nil && !p.currentRun.stopping
 }
 
 func (p *Dispatcher) dispatch(event events.SchedulingEvent) error {
-	if !p.isRunning() {
+	p.lifecycleLock.RLock()
+	defer p.lifecycleLock.RUnlock()
+
+	run := p.currentRun
+	if run == nil || run.stopping {
 		return fmt.Errorf("dispatcher is not running")
 	}
 	select {
 	case p.eventChan <- event:
 		return nil
 	default:
-		p.asyncDispatch(event)
+		p.asyncDispatch(event, run.stopChan)
 		return nil
 	}
 }
 
 // async-dispatch retries enqueueing the event in every 3 seconds until dispatchTimeout
 // it's only called when the event channel is full.
-func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent) {
+func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent, stopChan chan struct{}) {
 	count := p.asyncDispatchCount.Add(1)
 	log.Log(log.ShimDispatcher).Warn("event channel is full, transition to async-dispatch mode",
 		zap.Int32("asyncDispatchCount", count))
@@ -178,11 +186,16 @@ func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent) {
 		p.asyncDispatchCount.Add(-1)
 		panic(fmt.Errorf("dispatcher exceeds async-dispatch limit"))
 	}
-	go func(beginTime time.Time, stop chan struct{}) {
+	go func(beginTime time.Time) {
 		defer p.asyncDispatchCount.Add(-1)
-		for p.isRunning() {
+		for {
 			select {
-			case <-stop:
+			case <-stopChan:
+				return
+			default:
+			}
+			select {
+			case <-stopChan:
 				return
 			case p.eventChan <- event:
 				return
@@ -197,7 +210,7 @@ func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent) {
 					zap.Float64("elapseSeconds", elapseTime.Seconds()))
 			}
 		}
-	}(time.Now(), p.stopChan)
+	}(time.Now())
 }
 
 func (p *Dispatcher) drain() {
@@ -211,77 +224,115 @@ func (p *Dispatcher) drain() {
 
 func Start() {
 	log.Log(log.ShimDispatcher).Info("starting the dispatcher")
-	if getDispatcher().isRunning() {
+	if !getDispatcher().start() {
 		log.Log(log.ShimDispatcher).Info("dispatcher is already running")
-		return
 	}
-	getDispatcher().stopChan = make(chan struct{})
-	getDispatcher().stopped.Add(1)
-	go func() {
-		for {
-			select {
-			case event := <-getDispatcher().eventChan:
-				switch v := event.(type) {
-				case events.TaskEvent:
-					getEventHandler(EventTypeTask)(v)
-				case events.ApplicationEvent:
-					getEventHandler(EventTypeApp)(v)
-				case events.SchedulerNodeEvent:
-					getEventHandler(EventTypeNode)(v)
-				default:
-					log.Log(log.ShimDispatcher).Fatal("unsupported event",
-						zap.Any("event", v))
-				}
-			case <-getDispatcher().stopChan:
-				log.Log(log.ShimDispatcher).Info("shutting down event channel")
-				getDispatcher().setRunning(false)
-				getDispatcher().stopped.Done()
-				return
+}
+
+func (p *Dispatcher) start() bool {
+	for {
+		p.lifecycleLock.Lock()
+		if p.currentRun == nil {
+			run := &dispatcherRun{
+				stopChan:     make(chan struct{}),
+				doneChan:     make(chan struct{}),
+				stopComplete: make(chan struct{}),
 			}
+			p.currentRun = run
+			go p.run(run)
+			p.lifecycleLock.Unlock()
+			return true
 		}
-	}()
-	getDispatcher().setRunning(true)
+		if !p.currentRun.stopping {
+			p.lifecycleLock.Unlock()
+			return false
+		}
+		stopComplete := p.currentRun.stopComplete
+		p.lifecycleLock.Unlock()
+		<-stopComplete
+	}
+}
+
+func (p *Dispatcher) run(run *dispatcherRun) {
+	defer close(run.doneChan)
+	for {
+		select {
+		case <-run.stopChan:
+			log.Log(log.ShimDispatcher).Info("shutting down event channel")
+			return
+		default:
+		}
+
+		select {
+		case <-run.stopChan:
+			log.Log(log.ShimDispatcher).Info("shutting down event channel")
+			return
+		case event := <-p.eventChan:
+			p.handleEvent(event)
+		}
+	}
+}
+
+func (p *Dispatcher) handleEvent(event events.SchedulingEvent) {
+	switch v := event.(type) {
+	case events.TaskEvent:
+		getEventHandler(EventTypeTask)(v)
+	case events.ApplicationEvent:
+		getEventHandler(EventTypeApp)(v)
+	case events.SchedulerNodeEvent:
+		getEventHandler(EventTypeNode)(v)
+	default:
+		log.Log(log.ShimDispatcher).Fatal("unsupported event",
+			zap.Any("event", v))
+	}
 }
 
 // stop the dispatcher and wait at most 5 seconds gracefully
 func Stop() {
 	log.Log(log.ShimDispatcher).Info("stopping the dispatcher")
+	getDispatcher().stop()
+}
 
-	var chanClosed bool
-	select {
-	case <-getDispatcher().stopChan:
-		chanClosed = true
-	default:
-	}
-
-	if chanClosed {
-		if getDispatcher().isRunning() {
-			log.Log(log.ShimDispatcher).Info("dispatcher shutdown in progress")
-		} else {
-			log.Log(log.ShimDispatcher).Info("dispatcher is already stopped")
-		}
+func (p *Dispatcher) stop() {
+	p.lifecycleLock.Lock()
+	run := p.currentRun
+	if run == nil {
+		p.lifecycleLock.Unlock()
+		log.Log(log.ShimDispatcher).Info("dispatcher is already stopped")
 		return
 	}
 
-	close(getDispatcher().stopChan)
-	stopWait := make(chan struct{})
-
-	go func() {
-		defer close(stopWait)
-		getDispatcher().stopped.Wait()
-	}()
-
-	// wait until the main event loop stops properly
-	select {
-	case <-stopWait:
-		break
-	case <-time.After(5 * time.Second):
-		log.Log(log.ShimDispatcher).Info("dispatcher did not stop in time")
-		break
+	if run.stopping {
+		stopComplete := run.stopComplete
+		p.lifecycleLock.Unlock()
+		<-stopComplete
+		return
 	}
 
-	if getDispatcher().isRunning() {
-		log.Log(log.ShimDispatcher).Warn("dispatcher even processing did not stop properly")
+	run.stopping = true
+	close(run.stopChan)
+	stopTimeout := p.stopTimeout
+	p.lifecycleLock.Unlock()
+
+	timedOut := false
+	timer := time.NewTimer(stopTimeout)
+	defer timer.Stop()
+	select {
+	case <-run.doneChan:
+	case <-timer.C:
+		timedOut = true
+		log.Log(log.ShimDispatcher).Info("dispatcher did not stop in time")
+	}
+
+	p.lifecycleLock.Lock()
+	if p.currentRun == run {
+		p.currentRun = nil
+	}
+	close(run.stopComplete)
+	p.lifecycleLock.Unlock()
+
+	if timedOut {
+		log.Log(log.ShimDispatcher).Warn("dispatcher event processing did not stop properly")
 	} else {
 		log.Log(log.ShimDispatcher).Info("dispatcher stopped successfully")
 	}


### PR DESCRIPTION
### Description
Make dispatcher lifecycle operations thread-safe by coordinating each worker generation under a lifecycle lock. Each dispatcher run now owns its stop and completion signals, preventing duplicate workers, double-close panics, and stale workers from changing the state of a replacement dispatcher.

Async dispatch retries are bound to the generation that created them, and the dispatcher can start a replacement after a shutdown timeout.

### Type of change

- [x] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3405

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [x] The PR includes the phrase "Generated by Codex".
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.
- [ ] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A