### PR TITLE
[YUNIKORN-3371] DRA resource-slice tracker goroutine leaks in tests

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -72,15 +72,16 @@ var (
 
 // context maintains scheduling state, like apps and apps' tasks.
 type Context struct {
-	applications   map[string]*Application        // apps
-	schedulerCache *schedulercache.SchedulerCache // external cache
-	apiProvider    client.APIProvider             // apis to interact with api-server, scheduler-core, etc
-	predManager    predicates.PredicateManager    // K8s predicates
-	namespace      string                         // yunikorn namespace
-	configMaps     []*v1.ConfigMap                // cached yunikorn configmaps
-	lock           *locking.RWMutex               // lock - used not only for context data but also to ensure that multiple event types are not executed concurrently
-	txnID          atomic.Uint64                  // transaction ID counter
-	klogger        klog.Logger
+	applications         map[string]*Application        // apps
+	schedulerCache       *schedulercache.SchedulerCache // external cache
+	apiProvider          client.APIProvider             // apis to interact with api-server, scheduler-core, etc
+	predManager          predicates.PredicateManager    // K8s predicates
+	namespace            string                         // yunikorn namespace
+	configMaps           []*v1.ConfigMap                // cached yunikorn configmaps
+	lock                 *locking.RWMutex               // lock - used not only for context data but also to ensure that multiple event types are not executed concurrently
+	txnID                atomic.Uint64                  // transaction ID counter
+	klogger              klog.Logger
+	resourceSliceTracker *tracker.Tracker
 }
 
 // NewContext create a new context for the scheduler using a default (empty) configuration
@@ -127,6 +128,7 @@ func NewContextWithBootstrapConfigMaps(apis client.APIProvider, bootstrapConfigM
 			log.Log(log.ShimClient).Error("unable to create the resource slice tracker", zap.Error(err))
 			return nil
 		}
+		ctx.resourceSliceTracker = resourceSliceTracker
 		sharedDRAManager = dynamicresources.NewDRAManager(context.TODO(), resourceClaimCache, resourceSliceTracker, informerFactory)
 	}
 
@@ -136,6 +138,18 @@ func NewContextWithBootstrapConfigMaps(apis client.APIProvider, bootstrapConfigM
 	}
 	ctx.predManager = predicates.NewPredicateManager(support.NewFrameworkHandle(sharedLister, informerFactory, clientSet, csiManager, sharedDRAManager), plugins.NewInTreeRegistry(), config)
 	return ctx
+}
+
+// Stop ends all background activity managed by Context.
+func (ctx *Context) Stop() {
+	ctx.lock.Lock()
+	t := ctx.resourceSliceTracker
+	ctx.resourceSliceTracker = nil
+	ctx.lock.Unlock()
+
+	if t != nil {
+		t.Stop()
+	}
 }
 
 func (ctx *Context) AddSchedulingEventHandlers() error {

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -2770,3 +2770,11 @@ func TestTerminatedOrphanedForeignPodNotAdopted(t *testing.T) {
 		})
 	}
 }
+
+func TestContextStop(t *testing.T) {
+	context := NewContext(client.NewMockedAPIProvider(false))
+	assert.Assert(t, context.resourceSliceTracker != nil)
+
+	context.Stop()
+	assert.Assert(t, context.resourceSliceTracker == nil)
+}

--- a/pkg/plugin/support/mock_helpers.go
+++ b/pkg/plugin/support/mock_helpers.go
@@ -50,8 +50,13 @@ func SharedDRAManager() *dynamicresources.DefaultDRAManager {
 	if feature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
 		resourceClaimInformer := InformerFactory(ClientSet()).Resource().V1().ResourceClaims().Informer()
 		resourceClaimCache := assumecache.NewAssumeCache(klog.NewKlogr(), resourceClaimInformer, "ResourceClaim", "", nil)
+		// Disable device taint rules in mock helper to prevent goroutine leaks in tests.
+		// When EnableDeviceTaintRules is true, tracker.StartTracker spawns a background goroutine waiting
+		// for informers to sync, which leaks because unit test informers never sync. Existing unit tests
+		// do not exercise device taints or DRA resources. If future tests specifically require device taint
+		// tracking, this should be re-enabled along with a proper shutdown lifecycle.
 		resourceSliceTracker, err := tracker.StartTracker(context.TODO(), tracker.Options{
-			EnableDeviceTaintRules: feature.DefaultFeatureGate.Enabled(features.DRADeviceTaints),
+			EnableDeviceTaintRules: false,
 			SliceInformer:          InformerFactory(ClientSet()).Resource().V1().ResourceSlices(),
 			ClassInformer:          InformerFactory(ClientSet()).Resource().V1().DeviceClasses(),
 			TaintInformer:          InformerFactory(ClientSet()).Resource().V1beta2().DeviceTaintRules()})

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -252,6 +252,10 @@ func (ss *KubernetesShim) Stop() {
 		ss.phManager.Stop()
 		// stop the dispatcher
 		dispatcher.Stop()
+		// stop the context
+		if ss.context != nil {
+			ss.context.Stop()
+		}
 	})
 	if !stopped {
 		log.Log(log.ShimScheduler).Info("scheduler is already stopped")


### PR DESCRIPTION
### Description
When `EnableDeviceTaintRules` is true (default since K8s 1.36), `tracker.StartTracker` spawns a background sync monitor goroutine that waits for informers to sync. In unit tests, mock informers never sync and the context passed is `context.TODO()` which is never cancelled, so the goroutine leaks permanently for every test that creates a `Context`.

This fix saves the `resourceSliceTracker` reference in the `Context` struct and adds a `Context.Stop()` method that calls `Tracker.Stop()` to cancel the monitor goroutine and wait for it to exit. `KubernetesShim.Stop()` now calls `Context.Stop()` to ensure proper cleanup on scheduler shutdown. For the mock helper path in `support.SharedDRAManager()`, `EnableDeviceTaintRules` is set to `false` to prevent the goroutine from being spawned at all, since existing unit tests do not exercise device taints or DRA resources. A `TestContextStop` unit test is added to verify the shutdown behavior.

### Type of change

- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3371

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [x] The PR includes the phrase "Generated by Antigravity CLI", where Antigravity CLI is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [x] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
NA
