### PR TITLE
[YUNIKORN-3447] Drop managed fields in the informers

### DIFF
--- a/pkg/admission/informers.go
+++ b/pkg/admission/informers.go
@@ -22,9 +22,11 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/informers"
 	informersv1 "k8s.io/client-go/informers/core/v1"
 	schedulinginformersv1 "k8s.io/client-go/informers/scheduling/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/apache/yunikorn-k8shim/pkg/client"
 	"github.com/apache/yunikorn-k8shim/pkg/log"
@@ -40,7 +42,7 @@ type Informers struct {
 func NewInformers(kubeClient client.KubeClient, namespace string) *Informers {
 	stopChan := make(chan struct{})
 
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient.GetClientSet(), 0, informers.WithNamespace(namespace))
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient.GetClientSet(), 0, informers.WithNamespace(namespace), informers.WithTransform(stripManagedFields()))
 	informerFactory.Start(stopChan)
 
 	result := &Informers{
@@ -51,6 +53,17 @@ func NewInformers(kubeClient client.KubeClient, namespace string) *Informers {
 	}
 
 	return result
+}
+
+// stripManagedFields removes the managed fields from objects received by the informers as we do not need them.
+// If any future code relies on the managed fields to be available this might need adjustments.
+func stripManagedFields() cache.TransformFunc {
+	return func(in any) (any, error) {
+		if obj, err := meta.Accessor(in); err == nil && obj.GetManagedFields() != nil {
+			obj.SetManagedFields(nil)
+		}
+		return in, nil
+	}
 }
 
 func (i *Informers) Start() {

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -91,7 +92,7 @@ type APIFactory struct {
 
 func NewAPIFactory(scheduler api.SchedulerAPI, informerFactory informers.SharedInformerFactory, configs *conf.SchedulerConf, testMode bool) (*APIFactory, error) {
 	kubeClient := NewKubeClient(configs.KubeConfig)
-	namespaceInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient.GetClientSet(), 0, informers.WithNamespace(configs.Namespace))
+	namespaceInformerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient.GetClientSet(), 0, informers.WithNamespace(configs.Namespace), informers.WithTransform(stripManagedFields()))
 	// init informers
 	// volume informers are also used to get the Listers for the predicates
 	podInformer := informerFactory.Core().V1().Pods()
@@ -161,6 +162,17 @@ func NewAPIFactory(scheduler api.SchedulerAPI, informerFactory informers.SharedI
 		stopChan: make(chan struct{}),
 		lock:     &locking.RWMutex{},
 	}, nil
+}
+
+// stripManagedFields removes the managed fields from objects received by the informers as we do not need them.
+// If any future code relies on the managed fields to be available this might need adjustments.
+func stripManagedFields() cache.TransformFunc {
+	return func(in any) (any, error) {
+		if obj, err := meta.Accessor(in); err == nil && obj.GetManagedFields() != nil {
+			obj.SetManagedFields(nil)
+		}
+		return in, nil
+	}
 }
 
 func (s *APIFactory) GetAPIs() *Clients {

--- a/test/e2e/framework/helpers/k8s/k8s_utils.go
+++ b/test/e2e/framework/helpers/k8s/k8s_utils.go
@@ -39,6 +39,7 @@ import (
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -760,7 +761,7 @@ func (k *KubeCtl) UpdateConfigMap(cMap *v1.ConfigMap, namespace string) (*v1.Con
 }
 
 func (k *KubeCtl) StartConfigMapInformer(namespace string, stopChan <-chan struct{}, eventHandler cache.ResourceEventHandler) error {
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(k.clientSet, 0, informers.WithNamespace(namespace))
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(k.clientSet, 0, informers.WithNamespace(namespace), informers.WithTransform(stripManagedFields()))
 	informerFactory.Start(stopChan)
 	configMapInformer := informerFactory.Core().V1().ConfigMaps()
 	_, err := configMapInformer.Informer().AddEventHandler(eventHandler)
@@ -776,6 +777,17 @@ func (k *KubeCtl) StartConfigMapInformer(namespace string, stopChan <-chan struc
 	}
 
 	return nil
+}
+
+// stripManagedFields removes the managed fields from objects received by the informers as we do not need them.
+// If any future code relies on the managed fields to be available this might need adjustments.
+func stripManagedFields() cache.TransformFunc {
+	return func(in any) (any, error) {
+		if obj, err := meta.Accessor(in); err == nil && obj.GetManagedFields() != nil {
+			obj.SetManagedFields(nil)
+		}
+		return in, nil
+	}
 }
 
 func (k *KubeCtl) DeleteConfigMap(cName string, namespace string) error {
@@ -810,8 +822,8 @@ func (k *KubeCtl) CreateDeployment(deployment *appsv1.Deployment, namespace stri
 	return k.clientSet.AppsV1().Deployments(namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
 }
 
-func (k *KubeCtl) CreateStatefulSet(stetafulSet *appsv1.StatefulSet, namespace string) (*appsv1.StatefulSet, error) {
-	return k.clientSet.AppsV1().StatefulSets(namespace).Create(context.TODO(), stetafulSet, metav1.CreateOptions{})
+func (k *KubeCtl) CreateStatefulSet(statefulSet *appsv1.StatefulSet, namespace string) (*appsv1.StatefulSet, error) {
+	return k.clientSet.AppsV1().StatefulSets(namespace).Create(context.TODO(), statefulSet, metav1.CreateOptions{})
 }
 
 func (k *KubeCtl) CreateReplicaSet(replicaSet *appsv1.ReplicaSet, namespace string) (*appsv1.ReplicaSet, error) {


### PR DESCRIPTION
### Description
The objects loaded by the informers contain a field called ManagedFields This can be a large part of the object to store. The field is not used in the scheduler and removed in the default scheduler also to limit memory overhead.

Applying the same change to the informers in the K8shim.

### Type of change
- [X] Improvement

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3447

- [X] I have created a Jira issue for this pull request.
- [X] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [X] `make test_all` was run, and no failures reported.
- [X] `make e2e_test` was run, and no failures reported.
- [ ] new e2e tests have been added.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
